### PR TITLE
Add Vector type and vector search support

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,103 @@ finally:
     close_resource(resource)
 ```
 
+## Vector Search (ScyllaDB Extension)
+
+ScyllaDB Alternator supports vector similarity search, which is not part of the standard AWS DynamoDB API. All clients and resources created by this library have vector search support enabled automatically — no extra setup is needed.
+
+> **Note:** Vector search requires ScyllaDB with Alternator vector search support enabled. These operations are not available on AWS DynamoDB. The feature is fully supported from ScyllaDB 2026.3, and only partially supported in ScyllaDB 2026.2: Version 2026.2 did not yet support the optimized "Vector" type, configurable SimilarityFunction, returning scores (ReturnScores), pre-filtering (KeyConditionExpression) or projected attributes (ProjectionType=INCLUDE).
+
+### Creating a Table with a Vector Index
+
+```python
+client.create_table(
+    TableName="embeddings",
+    KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+    AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+    BillingMode="PAY_PER_REQUEST",
+    VectorIndexes=[{
+        "IndexName": "embedding_index",
+        "VectorAttribute": {"AttributeName": "embedding", "Dimensions": 128},
+        "SimilarityFunction": "COSINE",  # or "DOT_PRODUCT" / "EUCLIDEAN"
+    }],
+)
+```
+
+You can also add a vector index to an existing table via `UpdateTable`:
+
+```python
+client.update_table(
+    TableName="embeddings",
+    VectorIndexUpdates=[{
+        "Create": {
+            "IndexName": "embedding_index",
+            "VectorAttribute": {"AttributeName": "embedding", "Dimensions": 128},
+            "SimilarityFunction": "COSINE",
+        }
+    }],
+)
+```
+
+### Storing and Querying Vectors
+
+#### Low-level client (FLOAT32VECTOR wire format)
+
+```python
+# Store an item with a vector attribute
+client.put_item(
+    TableName="embeddings",
+    Item={
+        "id": {"S": "item1"},
+        "embedding": {"FLOAT32VECTOR": [0.1, 0.2, 0.3, 0.4]},
+    },
+)
+
+# Query by vector similarity (returns the k nearest neighbors)
+result = client.query(
+    TableName="embeddings",
+    VectorSearch={
+        "QueryVector": {"FLOAT32VECTOR": [0.1, 0.2, 0.3, 0.4]},
+        "ReturnScores": "SIMILARITY",  # optional: include similarity scores
+    },
+    Limit=10,
+)
+for item in result["Items"]:
+    print(item)
+# If ReturnScores was set, similarity scores are in result["Scores"]
+```
+
+#### High-level resource interface (Vector type)
+
+The `Vector` class is a `list` subclass that signals to Alternator that the
+value should be stored as an array of 32-bit floats using the `FLOAT32VECTOR`
+wire type. Without `Vector`, a list of numbers is serialized as a DynamoDB `L`
+(list) of high-precision `N` (decimal) values — correct for arbitrary numbers,
+but wasteful for embedding vectors where 32-bit precision is sufficient.
+Using `Vector` for stored attributes reduces storage significantly (4 bytes per
+element instead of a variable-length decimal string). For query vectors it
+makes less difference, but using `Vector` consistently keeps the code uniform.
+
+```python
+from alternator.vector import Vector
+
+table = resource.Table("embeddings")
+
+# Store a vector (sent as FLOAT32VECTOR, stored as compact 32-bit floats)
+table.put_item(Item={"id": "item1", "embedding": Vector([0.1, 0.2, 0.3, 0.4])})
+
+# Query by vector similarity
+result = table.query(
+    VectorSearch={
+        "QueryVector": Vector([0.1, 0.2, 0.3, 0.4]),
+        "ReturnScores": "SIMILARITY",
+    },
+    Limit=10,
+)
+for item in result["Items"]:
+    # embedding is automatically deserialized back as a Vector instance
+    print(item["embedding"])
+```
+
 ## Manual Resource Management
 
 If you prefer not to use context managers:

--- a/alternator/__init__.py
+++ b/alternator/__init__.py
@@ -63,10 +63,15 @@ Exceptions
 - ``NoNodesAvailableError``: Raised when no nodes are available for routing
 - ``ConfigurationError``: Raised for invalid configuration
 
+Vector Search (ScyllaDB Extension)
+-----------------------------------
+- ``Vector``: Optimized vector type stored as ``FLOAT32VECTOR`` on the wire
+
 Notes
 -----
 - Gzip compression requires ScyllaDB 2026.1.0 or later
 - For async support, install with: ``pip install alternator[async]``
+- Vector search is a ScyllaDB Alternator extension not available on AWS DynamoDB
 """
 
 from alternator._version import __version__
@@ -104,6 +109,7 @@ from alternator.exceptions import (
     ConfigurationError,
     NoNodesAvailableError,
 )
+from alternator.vector import Vector
 
 __all__ = [
     # Version
@@ -142,6 +148,8 @@ __all__ = [
     "DatacenterScope",
     "RackScope",
     "RoutingScope",
+    # Vector Search (ScyllaDB extension)
+    "Vector",
 ]
 
 

--- a/alternator/async_client.py
+++ b/alternator/async_client.py
@@ -28,6 +28,7 @@ from alternator.core.key_affinity import (
     should_use_affinity,
 )
 from alternator.core.live_nodes import AsyncLiveNodesManager
+from alternator.vector import enable_vector_support
 
 if TYPE_CHECKING:
     from types_aiobotocore_dynamodb import DynamoDBClient as AsyncDynamoDBClient
@@ -390,6 +391,9 @@ async def create_async_client(
 
         # Attach manager for cleanup reference
         setattr(client, MANAGER_ATTR, manager)
+
+        # Enable Alternator vector search extensions
+        enable_vector_support(client)
     except Exception:
         # Clean up the HTTP fetcher session on failure
         if isinstance(http_fetcher, AsyncNodeFetcher):

--- a/alternator/client.py
+++ b/alternator/client.py
@@ -26,6 +26,7 @@ from alternator.core.key_affinity import (
     should_use_affinity,
 )
 from alternator.core.live_nodes import SyncLiveNodesManager
+from alternator.vector import enable_vector_support
 
 if TYPE_CHECKING:
     from mypy_boto3_dynamodb import DynamoDBClient
@@ -292,6 +293,13 @@ def create_client(
     # Attach manager for cleanup reference
     setattr(client, MANAGER_ATTR, manager)
 
+    # Enable Alternator vector search extensions
+    try:
+        enable_vector_support(client)
+    except Exception:
+        manager.stop()
+        raise
+
     return client
 
 
@@ -350,6 +358,13 @@ def create_resource(
 
     # Attach manager for cleanup reference
     setattr(resource, MANAGER_ATTR, manager)
+
+    # Enable Alternator vector search extensions
+    try:
+        enable_vector_support(resource)
+    except Exception:
+        manager.stop()
+        raise
 
     return resource
 

--- a/alternator/vector.py
+++ b/alternator/vector.py
@@ -1,0 +1,309 @@
+"""Vector search support for ScyllaDB Alternator.
+
+This module provides the :class:`Vector` type and the
+:func:`enable_vector_support` function that add ScyllaDB Alternator's
+vector search extensions to a boto3 DynamoDB client or resource.
+
+Vector search is a ScyllaDB Alternator extension that does not exist in the
+standard AWS DynamoDB API.  Because boto3 / botocore is generated from the
+official DynamoDB service description, it knows nothing about the new
+operations and new wire types introduced by Alternator.  This module patches
+botocore's in-memory service model at runtime to teach it about:
+
+* ``VectorIndexes`` in ``CreateTable`` and ``DescribeTable``
+* ``VectorIndexUpdates`` in ``UpdateTable``
+* ``VectorSearch`` parameter and ``Scores`` response field in ``Query``
+* The ``FLOAT32VECTOR`` attribute type in ``AttributeValue``
+
+It also patches :class:`boto3.dynamodb.types.TypeSerializer` /
+:class:`boto3.dynamodb.types.TypeDeserializer` so that the high-level
+DynamoDB Resource interface automatically converts :class:`Vector` instances
+to the ``FLOAT32VECTOR`` wire format and back.
+
+:func:`enable_vector_support` is called automatically by
+:func:`~alternator.create_client`, :func:`~alternator.create_resource`, and
+:func:`~alternator.async_client.create_async_client`, so users of the
+Alternator client library do not need to call it manually.
+
+Usage::
+
+    import alternator
+
+    config = alternator.AlternatorConfig(seed_hosts=["192.168.1.1"], port=8000)
+    client = alternator.create_client(config)  # vector support enabled automatically
+
+    # Create a table with a vector index
+    client.create_table(
+        TableName="embeddings",
+        KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+        VectorIndexes=[{
+            "IndexName": "embedding_index",
+            "VectorAttribute": {"AttributeName": "embedding", "Dimensions": 4},
+            "SimilarityFunction": "COSINE",
+        }],
+    )
+
+    # Store a vector using the low-level client interface
+    client.put_item(
+        TableName="embeddings",
+        Item={"id": {"S": "item1"}, "embedding": {"FLOAT32VECTOR": [0.1, 0.2, 0.3, 0.4]}},
+    )
+
+    # Query by vector similarity
+    result = client.query(
+        TableName="embeddings",
+        VectorSearch={"QueryVector": {"FLOAT32VECTOR": [0.1, 0.2, 0.3, 0.4]}},
+    )
+
+With the high-level Resource interface, use :class:`Vector` directly::
+
+    import alternator
+    from alternator.vector import Vector
+
+    config = alternator.AlternatorConfig(seed_hosts=["192.168.1.1"], port=8000)
+    resource = alternator.create_resource(config)  # vector support enabled automatically
+
+    table = resource.Table("embeddings")
+    table.put_item(Item={"id": "item1", "embedding": Vector([0.1, 0.2, 0.3, 0.4])})
+    response = table.query(
+        VectorSearch={"QueryVector": Vector([0.1, 0.2, 0.3, 0.4])},
+    )
+    # response["Items"][0]["embedding"] will be a Vector instance
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import boto3.dynamodb.types
+
+# ---------------------------------------------------------------------------
+# New botocore shapes that describe Alternator's vector search extensions.
+# These are injected into the DynamoDB service model at runtime.
+# ---------------------------------------------------------------------------
+
+_VECTOR_SHAPES: dict[str, Any] = {
+    # --- CreateTable / DescribeTable -----------------------------------------
+    "VectorIndexes": {
+        "type": "list",
+        "member": {"shape": "VectorIndex"},
+    },
+    "VectorIndex": {
+        "type": "structure",
+        "members": {
+            "IndexName": {"shape": "String"},
+            "VectorAttribute": {"shape": "VectorAttribute"},
+            "Projection": {"shape": "Projection"},
+            "SimilarityFunction": {"shape": "String"},
+            # Read-only fields returned by DescribeTable / CreateTable output
+            "IndexStatus": {"shape": "String"},
+            "Backfilling": {"shape": "BooleanObject"},
+        },
+        "required": ["IndexName", "VectorAttribute"],
+    },
+    "VectorAttribute": {
+        "type": "structure",
+        "members": {
+            "AttributeName": {"shape": "String"},
+            "Dimensions": {"shape": "Integer"},
+        },
+        "required": ["AttributeName", "Dimensions"],
+    },
+    # --- UpdateTable ---------------------------------------------------------
+    "VectorIndexUpdates": {
+        "type": "list",
+        "member": {"shape": "VectorIndexUpdate"},
+    },
+    "VectorIndexUpdate": {
+        "type": "structure",
+        "members": {
+            "Create": {"shape": "CreateVectorIndexAction"},
+            "Delete": {"shape": "DeleteVectorIndexAction"},
+        },
+    },
+    "CreateVectorIndexAction": {
+        "type": "structure",
+        "members": {
+            "IndexName": {"shape": "String"},
+            "VectorAttribute": {"shape": "VectorAttribute"},
+            "Projection": {"shape": "Projection"},
+            "SimilarityFunction": {"shape": "String"},
+        },
+        "required": ["IndexName", "VectorAttribute"],
+    },
+    "DeleteVectorIndexAction": {
+        "type": "structure",
+        "members": {
+            "IndexName": {"shape": "String"},
+        },
+        "required": ["IndexName"],
+    },
+    # --- Query ---------------------------------------------------------------
+    "VectorSearch": {
+        "type": "structure",
+        "members": {
+            "QueryVector": {"shape": "AttributeValue"},
+            "ReturnScores": {"shape": "String"},
+        },
+        "required": ["QueryVector"],
+    },
+    "Score": {"type": "double"},
+    "ScoresList": {
+        "type": "list",
+        "member": {"shape": "Score"},
+    },
+    # --- FLOAT32VECTOR attribute type ----------------------------------------
+    "Float32VectorElement": {"type": "double"},
+    "Float32VectorAttributeValue": {
+        "type": "list",
+        "member": {"shape": "Float32VectorElement"},
+    },
+}
+
+
+class Vector(list[float]):
+    """An optimized vector type for ScyllaDB Alternator vector search.
+
+    Subclasses :class:`list` so it can be used everywhere a regular Python
+    list is expected.  When :func:`enable_vector_support` has been called,
+    the patched :class:`~boto3.dynamodb.types.TypeSerializer` will encode a
+    ``Vector`` value as ``{"FLOAT32VECTOR": [...]}`` on the wire instead of
+    the standard DynamoDB list encoding ``{"L": [{"N": "..."}, ...]}``.
+    Conversely, ``FLOAT32VECTOR`` values received from the server are
+    deserialized back into ``Vector`` instances.
+
+    Example::
+
+        from alternator.vector import Vector
+
+        embedding = Vector([0.1, 0.2, 0.3, 0.4])
+        table.put_item(Item={"id": "item1", "embedding": embedding})
+
+        response = table.get_item(Key={"id": "item1"})
+        assert isinstance(response["Item"]["embedding"], Vector)
+    """
+
+
+class _VectorTypeSerializer(boto3.dynamodb.types.TypeSerializer):
+    """TypeSerializer subclass that handles :class:`Vector` values."""
+
+    def serialize(self, value: Any) -> dict[str, Any]:  # type: ignore[override]  # noqa: ANN401 -- boto3 TypeSerializer.serialize accepts any Python value
+        if isinstance(value, Vector):
+            for i, element in enumerate(value):
+                if isinstance(element, bool) or not isinstance(element, (int, float)):
+                    raise TypeError(
+                        f"Vector element at index {i} must be int or float, "
+                        f"got {type(element).__name__!r}"
+                    )
+            return {"FLOAT32VECTOR": list(value)}
+        return super().serialize(value)  # type: ignore[return-value]
+
+
+class _VectorTypeDeserializer(boto3.dynamodb.types.TypeDeserializer):
+    """TypeDeserializer subclass that handles FLOAT32VECTOR values."""
+
+    def _deserialize_float32vector(self, value: Any) -> Vector:  # noqa: ANN401 -- value is the raw JSON list from the DynamoDB wire format
+        return Vector(value)
+
+
+def enable_vector_support(client_or_resource: Any) -> None:  # noqa: ANN401 -- accepts either a boto3 DynamoDB client or resource instance
+    """Enable ScyllaDB Alternator vector search on a boto3 DynamoDB client or resource.
+
+    Patches botocore's in-memory DynamoDB service model to accept and return
+    the new parameters introduced by Alternator's vector search feature.
+    Also patches :class:`boto3.dynamodb.types.TypeSerializer` and
+    :class:`boto3.dynamodb.types.TypeDeserializer` globally so that the
+    high-level DynamoDB Resource interface handles :class:`Vector` values
+    transparently.
+
+    This function is **idempotent**: calling it multiple times (on the same or
+    different clients) is safe and has no additional effect.
+
+    Because botocore's underlying shape data (``_shape_map``) is shared across
+    all clients created from the same boto3 session, the modifications made
+    here are visible to any client that resolves the affected shapes for the
+    first time after this call.  However, clients that have already cached a
+    resolved shape object will retain their cached version.  In practice this
+    is not a concern because this function is called on each freshly-created
+    client before any requests are made.
+
+    Args:
+        client_or_resource: A boto3 DynamoDB *client* (e.g. returned by
+            :func:`~alternator.create_client` or ``boto3.client("dynamodb")``)
+            or a DynamoDB *resource* (e.g. returned by
+            :func:`~alternator.create_resource` or
+            ``boto3.resource("dynamodb")``).
+    """
+    # Resolve to the underlying boto3 low-level client
+    if hasattr(client_or_resource, "meta") and hasattr(
+        client_or_resource.meta, "client"
+    ):
+        # DynamoDB Resource: resource.meta.client is the low-level client
+        boto_client = client_or_resource.meta.client
+    else:
+        boto_client = client_or_resource
+
+    service_model = boto_client.meta.service_model
+    shape_resolver = service_model._shape_resolver
+
+    # Register new shapes (skip shapes that are already present)
+    for shape_name, shape_def in _VECTOR_SHAPES.items():
+        if shape_name not in shape_resolver._shape_map:
+            shape_resolver._shape_map[shape_name] = shape_def
+        shape_resolver._shape_cache.pop(shape_name, None)
+
+    # Add VectorIndexes to CreateTable input
+    create_table_input = service_model.operation_model("CreateTable").input_shape
+    if "VectorIndexes" not in create_table_input._shape_model["members"]:
+        create_table_input._shape_model["members"]["VectorIndexes"] = {
+            "shape": "VectorIndexes"
+        }
+    create_table_input._cache.pop("members", None)
+
+    # Add VectorIndexUpdates to UpdateTable input
+    update_table_input = service_model.operation_model("UpdateTable").input_shape
+    if "VectorIndexUpdates" not in update_table_input._shape_model["members"]:
+        update_table_input._shape_model["members"]["VectorIndexUpdates"] = {
+            "shape": "VectorIndexUpdates"
+        }
+    update_table_input._cache.pop("members", None)
+
+    # Add VectorSearch to Query input and Scores to Query output
+    query_op = service_model.operation_model("Query")
+    query_input = query_op.input_shape
+    if "VectorSearch" not in query_input._shape_model["members"]:
+        query_input._shape_model["members"]["VectorSearch"] = {"shape": "VectorSearch"}
+    query_input._cache.pop("members", None)
+
+    query_output = query_op.output_shape
+    if "Scores" not in query_output._shape_model["members"]:
+        query_output._shape_model["members"]["Scores"] = {"shape": "ScoresList"}
+    query_output._cache.pop("members", None)
+
+    # Add VectorIndexes to TableDescription (DescribeTable / CreateTable output)
+    table_desc = shape_resolver.get_shape_by_name("TableDescription")
+    if "VectorIndexes" not in table_desc._shape_model["members"]:
+        table_desc._shape_model["members"]["VectorIndexes"] = {"shape": "VectorIndexes"}
+    table_desc._cache.pop("members", None)
+    shape_resolver._shape_cache.pop("TableDescription", None)
+
+    # Add FLOAT32VECTOR to AttributeValue
+    attr_value = shape_resolver.get_shape_by_name("AttributeValue")
+    if "FLOAT32VECTOR" not in attr_value._shape_model["members"]:
+        attr_value._shape_model["members"]["FLOAT32VECTOR"] = {
+            "shape": "Float32VectorAttributeValue"
+        }
+    attr_value._cache.pop("members", None)
+    shape_resolver._shape_cache.pop("AttributeValue", None)
+
+    # Patch TypeSerializer / TypeDeserializer on the resource's injector
+    # (per-resource, not process-wide).  The _injector is only present on the
+    # high-level DynamoDB Resource; low-level clients don't use TypeSerializer.
+    if hasattr(client_or_resource, "_injector"):
+        injector = client_or_resource._injector
+        if not isinstance(injector._serializer, _VectorTypeSerializer):
+            injector._serializer = _VectorTypeSerializer()
+        if not isinstance(injector._deserializer, _VectorTypeDeserializer):
+            injector._deserializer = _VectorTypeDeserializer()

--- a/tests/integration/test_vector.py
+++ b/tests/integration/test_vector.py
@@ -1,0 +1,200 @@
+"""Integration tests for vector search support.
+
+These tests require a running ScyllaDB cluster with Alternator and vector
+search support enabled.  Start a local cluster with: make scylla-start
+
+Vector search is a ScyllaDB Alternator extension; all tests in this file are
+skipped when running against a Scylla version that predates the feature.
+"""
+
+import uuid
+from collections.abc import Callable
+from decimal import Decimal
+
+import pytest
+
+from alternator import (
+    AlternatorClient,
+    AlternatorConfig,
+    AlternatorResource,
+)
+from alternator.vector import Vector
+from tests.integration import (
+    SCYLLA_HOST,
+    SCYLLA_PORT,
+    SKIP_INTEGRATION,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(SKIP_INTEGRATION, reason="Integration tests disabled"),
+]
+
+
+config = AlternatorConfig(seed_hosts=[SCYLLA_HOST], port=SCYLLA_PORT, scheme="http")
+
+
+def table_name() -> str:
+    return f"test_vec_{uuid.uuid4().hex[:8]}"
+
+
+def test_create_table_with_vector_index(
+    skip_if_scylla_version_below: Callable[..., None],
+) -> None:
+    """CreateTable with VectorIndexes should succeed and DescribeTable should
+    return the index."""
+    from tests.integration.scylla_version import ScyllaVersion
+
+    skip_if_scylla_version_below(ScyllaVersion(2026, 2, 0), "vector search")
+
+    name = table_name()
+    with AlternatorClient(config) as client:
+        client.create_table(
+            TableName=name,
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+            VectorIndexes=[
+                {
+                    "IndexName": "embedding_index",
+                    "VectorAttribute": {"AttributeName": "embedding", "Dimensions": 4},
+                    "SimilarityFunction": "COSINE",
+                }
+            ],
+        )
+        waiter = client.get_waiter("table_exists")
+        waiter.wait(TableName=name)
+
+        try:
+            desc = client.describe_table(TableName=name)
+            indexes = desc["Table"].get("VectorIndexes", [])
+            assert any(idx["IndexName"] == "embedding_index" for idx in indexes), (
+                f"Expected 'embedding_index' in VectorIndexes, got: {indexes}"
+            )
+        finally:
+            client.delete_table(TableName=name)
+
+
+def test_create_table_with_vector_index_via_resource(
+    skip_if_scylla_version_below: Callable[..., None],
+) -> None:
+    """Vector index creation should work through the high-level Resource
+    interface as well as the low-level client."""
+    from tests.integration.scylla_version import ScyllaVersion
+
+    skip_if_scylla_version_below(ScyllaVersion(2026, 2, 0), "vector search")
+
+    name = table_name()
+    with AlternatorResource(config) as resource:
+        resource.create_table(
+            TableName=name,
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+            VectorIndexes=[
+                {
+                    "IndexName": "embedding_index",
+                    "VectorAttribute": {"AttributeName": "embedding", "Dimensions": 4},
+                }
+            ],
+        )
+        table = resource.Table(name)
+        table.wait_until_exists()
+
+        try:
+            desc = resource.meta.client.describe_table(TableName=name)
+            indexes = desc["Table"].get("VectorIndexes", [])
+            assert any(idx["IndexName"] == "embedding_index" for idx in indexes)
+        finally:
+            table.delete()
+
+
+def test_vector_roundtrip_via_resource(
+    skip_if_scylla_version_below: Callable[..., None],
+) -> None:
+    """A Vector stored via put_item should be returned as a Vector by
+    get_item, and its values should be close to the original floats
+    (within 32-bit float precision)."""
+    from tests.integration.scylla_version import ScyllaVersion
+
+    skip_if_scylla_version_below(ScyllaVersion(2026, 2, 0), "vector search")
+
+    name = table_name()
+    with AlternatorResource(config) as resource:
+        resource.create_table(
+            TableName=name,
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        table = resource.Table(name)
+        table.wait_until_exists()
+
+        try:
+            original = Vector([0.1, 0.2, 0.3, 0.4])
+            table.put_item(Item={"pk": "item1", "embedding": original})
+
+            returned = table.get_item(Key={"pk": "item1"}, ConsistentRead=True)["Item"][
+                "embedding"
+            ]
+
+            # Should come back as a Vector instance
+            assert isinstance(returned, Vector), (
+                f"Expected Vector, got {type(returned)}"
+            )
+            # Values should be close to the originals (32-bit float precision)
+            assert len(returned) == len(original)
+            for got, expected in zip(returned, original, strict=True):
+                assert abs(float(got) - expected) < 1e-6, (
+                    f"Value mismatch: got {got}, expected {expected}"
+                )
+        finally:
+            table.delete()
+
+
+def test_vector_differs_from_decimal_list(
+    skip_if_scylla_version_below: Callable[..., None],
+) -> None:
+    """A plain list of Decimals and a Vector containing the same values
+    should both round-trip, but the Vector comes back as a Vector instance
+    while the plain list comes back as a list of Decimals — confirming that
+    the two wire types are distinct."""
+    from tests.integration.scylla_version import ScyllaVersion
+
+    skip_if_scylla_version_below(ScyllaVersion(2026, 2, 0), "vector search")
+
+    name = table_name()
+    with AlternatorResource(config) as resource:
+        resource.create_table(
+            TableName=name,
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        table = resource.Table(name)
+        table.wait_until_exists()
+
+        try:
+            table.put_item(
+                Item={
+                    "pk": "dec",
+                    "v": [Decimal("0.1"), Decimal("0.2"), Decimal("0.3")],
+                }
+            )
+            table.put_item(Item={"pk": "vec", "v": Vector([0.1, 0.2, 0.3])})
+
+            dec_returned = table.get_item(Key={"pk": "dec"}, ConsistentRead=True)[
+                "Item"
+            ]["v"]
+            vec_returned = table.get_item(Key={"pk": "vec"}, ConsistentRead=True)[
+                "Item"
+            ]["v"]
+
+            # Decimal list comes back as a plain list of Decimals
+            assert not isinstance(dec_returned, Vector)
+            assert all(isinstance(x, Decimal) for x in dec_returned)
+
+            # Vector comes back as a Vector
+            assert isinstance(vec_returned, Vector)
+        finally:
+            table.delete()


### PR DESCRIPTION
ScyllaDB Alternator extends the DynamoDB API with vector search: tables can declare VectorIndexes at CreateTable time, items can store float vectors in FLOAT32VECTOR attributes, and nearest-neighbor queries can be issued via a VectorSearch parameter on Query.

This commit adds first-class support for these extensions:

* alternator/vector.py: new module with:
  - Vector(list): a thin list subclass that signals the FLOAT32VECTOR wire type, giving 4 bytes per element instead of a decimal string.
  - enable_vector_support(): patches botocore's in-memory DynamoDB service model to accept the new shapes (VectorIndexes, VectorIndex, VectorAttribute, VectorSearch, …) and patches TypeSerializer / TypeDeserializer so that Vector values round-trip correctly.

* alternator/client.py, alternator/async_client.py: call enable_vector_support() automatically inside create_client(), create_resource(), and create_async_client(), so users get vector support out of the box with no extra setup.

* alternator/__init__.py: export Vector as part of the public API.

* README.md: add a "Vector Search" section with examples for CreateTable with VectorIndexes, storing and retrieving Vector attributes, and low-level FLOAT32VECTOR usage.

* tests/integration/test_vector.py: integration tests covering CreateTable with a vector index (via client and resource), Vector put/get roundtrip, and the distinction between Vector and a plain Decimal list on the wire. Tests are skipped automatically on Scylla versions older than 2026.2.0.