### PR TITLE
Fix BatchWriteItem affinity in ANY_WRITE mode

### DIFF
--- a/.github/workflows/call_jira_sync.yml
+++ b/.github/workflows/call_jira_sync.yml
@@ -12,30 +12,30 @@ permissions:
 jobs:
   jira-sync-pr-opened:
     if: github.event.action == 'opened' || github.event.action == 'edited'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_opened.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_opened.yml@ec43b7d7267d7ecf97a8cf6c18fbc82a02603e34 # main
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
 
   jira-sync-in-review:
     if: github.event.action == 'ready_for_review' || github.event.action == 'review_requested'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_in_review.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_in_review.yml@ec43b7d7267d7ecf97a8cf6c18fbc82a02603e34 # main
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
 
   jira-sync-add-label:
     if: github.event.action == 'labeled'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_add_label.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_add_label.yml@ec43b7d7267d7ecf97a8cf6c18fbc82a02603e34 # main
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
 
   jira-sync-remove-label:
     if: github.event.action == 'unlabeled'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_remove_label.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_remove_label.yml@ec43b7d7267d7ecf97a8cf6c18fbc82a02603e34 # main
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
 
   jira-sync-pr-closed:
     if: github.event.action == 'closed'
-    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_closed.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_closed.yml@ec43b7d7267d7ecf97a8cf6c18fbc82a02603e34 # main
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ config = (
 |------|-------------|
 | `NONE` | Disabled (default round-robin) |
 | `RMW` | Only for operations with `ConditionExpression` or `ReturnValues` |
-| `ANY_WRITE` | For all write operations (`PutItem`, `UpdateItem`, `DeleteItem`) |
+| `ANY_WRITE` | For all write operations (`PutItem`, `UpdateItem`, `DeleteItem`, `BatchWriteItem`) |
 
 ## TLS Configuration
 
@@ -462,7 +462,7 @@ Async clients created by `create_async_client` / `AsyncAlternatorClient` are saf
 - **Request Compression**: Gzip compression requires ScyllaDB 2026.1.0+. Response compression is not yet supported by Alternator.
 - **TLS Session Cache Settings**: The `cache_size` and `timeout_seconds` parameters in `TlsSessionCacheConfig` are not currently used by Python's `ssl` module. Only the `enabled` flag controls session ticket behavior.
 - **Async Key Affinity**: For async clients, partition key auto-discovery happens asynchronously. The first request for an unknown table will use round-robin routing while discovery runs in the background. Subsequent requests will use affinity. Preloading via `table_pk_map` avoids this initial miss.
-- **Batch Operations**: Key affinity routing does not support `BatchWriteItem` operations with items targeting different partition keys.
+- **Batch Operations**: `BatchWriteItem` key affinity is based on the first `PutRequest` or `DeleteRequest` in the batch. Batches with items targeting different partition keys are not split by affinity target.
 
 ## Development
 

--- a/alternator/core/key_affinity.py
+++ b/alternator/core/key_affinity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from alternator._constants import PK_DISCOVERY_TIMEOUT_SECONDS
 
@@ -14,6 +14,11 @@ if TYPE_CHECKING:
     from alternator.core.live_nodes import NodeList
 
 logger = logging.getLogger("alternator")
+
+
+class _BatchWriteRoutingTarget(NamedTuple):
+    table_name: str
+    attributes: dict[str, Any]
 
 
 class AffinitySelector:
@@ -98,6 +103,11 @@ def extract_partition_key(
         pk_value = params["Item"][pk_name]
         return _extract_typed_value(pk_value)
 
+    batch_target = _find_batch_write_routing_target(params)
+    if batch_target and pk_name in batch_target.attributes:
+        pk_value = batch_target.attributes[pk_name]
+        return _extract_typed_value(pk_value)
+
     return None
 
 
@@ -111,7 +121,44 @@ def _extract_typed_value(attr_value: dict[str, Any]) -> tuple[str, Any] | None:
 
 def get_table_name(params: dict[str, Any]) -> str | None:
     """Extract table name from request params."""
-    return params.get("TableName")
+    table_name = params.get("TableName")
+    if isinstance(table_name, str):
+        return table_name
+
+    batch_target = _find_batch_write_routing_target(params)
+    if batch_target:
+        return batch_target.table_name
+
+    return None
+
+
+def _find_batch_write_routing_target(
+    params: dict[str, Any],
+) -> _BatchWriteRoutingTarget | None:
+    request_items = params.get("RequestItems")
+    if not isinstance(request_items, dict):
+        return None
+
+    for table_name, writes in request_items.items():
+        if not isinstance(table_name, str) or not isinstance(writes, list):
+            continue
+        for write in writes:
+            if not isinstance(write, dict):
+                continue
+
+            put_request = write.get("PutRequest")
+            if isinstance(put_request, dict):
+                item = put_request.get("Item")
+                if isinstance(item, dict):
+                    return _BatchWriteRoutingTarget(table_name, item)
+
+            delete_request = write.get("DeleteRequest")
+            if isinstance(delete_request, dict):
+                key = delete_request.get("Key")
+                if isinstance(key, dict):
+                    return _BatchWriteRoutingTarget(table_name, key)
+
+    return None
 
 
 class PartitionKeyCache:

--- a/tests/unit/test_key_affinity.py
+++ b/tests/unit/test_key_affinity.py
@@ -112,12 +112,30 @@ class TestShouldUseAffinity:
         params = {}
         assert should_use_affinity("RMW", "PutItem", params) is False
 
+    def test_rmw_mode_with_batch_write(self) -> None:
+        """Test RMW mode does not use affinity for BatchWriteItem."""
+        params = {
+            "RequestItems": {
+                "users": [
+                    {
+                        "PutRequest": {
+                            "Item": {
+                                "user_id": {"S": "user123"},
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+        assert should_use_affinity("RMW", "BatchWriteItem", params) is False
+
     def test_any_write_mode_with_write(self) -> None:
         """Test ANY_WRITE mode with write operation."""
         params = {}
         assert should_use_affinity("ANY_WRITE", "PutItem", params) is True
         assert should_use_affinity("ANY_WRITE", "UpdateItem", params) is True
         assert should_use_affinity("ANY_WRITE", "DeleteItem", params) is True
+        assert should_use_affinity("ANY_WRITE", "BatchWriteItem", params) is True
 
     def test_any_write_mode_with_read(self) -> None:
         """Test ANY_WRITE mode with read operation."""
@@ -153,6 +171,65 @@ class TestExtractPartitionKey:
         params = {"Item": {"pk": {"S": "partition_key_value"}}}
         result = extract_partition_key(params, "pk")
         assert result == ("S", "partition_key_value")
+
+    def test_extract_from_batch_write_put_request(self) -> None:
+        """Test extracting PK from BatchWriteItem PutRequest."""
+        params = {
+            "RequestItems": {
+                "orders": [
+                    {
+                        "PutRequest": {
+                            "Item": {
+                                "order_id": {"S": "order123"},
+                                "data": {"S": "value"},
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+        result = extract_partition_key(params, "order_id")
+        assert result == ("S", "order123")
+
+    def test_extract_from_batch_write_delete_request(self) -> None:
+        """Test extracting PK from BatchWriteItem DeleteRequest."""
+        params = {
+            "RequestItems": {
+                "sessions": [
+                    {
+                        "DeleteRequest": {
+                            "Key": {
+                                "session_id": {"S": "session123"},
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+        result = extract_partition_key(params, "session_id")
+        assert result == ("S", "session123")
+
+    def test_extract_from_empty_batch_write(self) -> None:
+        """Test empty BatchWriteItem does not produce a PK."""
+        params: dict[str, object] = {"RequestItems": {}}
+        result = extract_partition_key(params, "pk")
+        assert result is None
+
+    def test_extract_from_batch_get_shape(self) -> None:
+        """Test BatchGetItem RequestItems are not treated as batch writes."""
+        params = {
+            "RequestItems": {
+                "users": {
+                    "Keys": [
+                        {
+                            "user_id": {"S": "user123"},
+                        }
+                    ]
+                }
+            }
+        }
+        result = extract_partition_key(params, "user_id")
+        assert result is None
 
     def test_key_not_found(self) -> None:
         """Test when partition key is not in params."""
@@ -212,6 +289,60 @@ class TestGetTableName:
         """Test extracting present table name."""
         params = {"TableName": "users"}
         assert get_table_name(params) == "users"
+
+    def test_table_name_from_batch_write_put_request(self) -> None:
+        """Test extracting table name from BatchWriteItem PutRequest."""
+        params = {
+            "RequestItems": {
+                "orders": [
+                    {
+                        "PutRequest": {
+                            "Item": {
+                                "order_id": {"S": "order123"},
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+        assert get_table_name(params) == "orders"
+
+    def test_table_name_from_batch_write_delete_request(self) -> None:
+        """Test extracting table name from BatchWriteItem DeleteRequest."""
+        params = {
+            "RequestItems": {
+                "sessions": [
+                    {
+                        "DeleteRequest": {
+                            "Key": {
+                                "session_id": {"S": "session123"},
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+        assert get_table_name(params) == "sessions"
+
+    def test_table_name_from_empty_batch_write(self) -> None:
+        """Test empty BatchWriteItem does not produce a table name."""
+        params: dict[str, object] = {"RequestItems": {}}
+        assert get_table_name(params) is None
+
+    def test_table_name_from_batch_get_shape(self) -> None:
+        """Test BatchGetItem RequestItems are not treated as batch writes."""
+        params = {
+            "RequestItems": {
+                "users": {
+                    "Keys": [
+                        {
+                            "user_id": {"S": "user123"},
+                        }
+                    ]
+                }
+            }
+        }
+        assert get_table_name(params) is None
 
     def test_table_name_missing(self) -> None:
         """Test when table name is missing."""


### PR DESCRIPTION
## Summary
- Route `BatchWriteItem` through key affinity in `ANY_WRITE` mode by deriving the target table and partition key from the first concrete `PutRequest` or `DeleteRequest` in `RequestItems`.
- Keep `BatchWriteItem` excluded from `RMW` mode because batch writes are write-only and do not use LWT in `only_rmw_uses_lwt` mode.
- Add unit coverage for batch put/delete extraction, empty batches, and BatchGet-style `RequestItems` that should not be treated as batch writes.
- Update README affinity-mode and batch-operation notes.
- Pin the Jira sync reusable workflow to the same automation commit used by the Java client so the repository's pinned-actions policy is satisfied.

Fixes #19

## Testing
- `uv run pytest tests/unit/test_key_affinity.py -v --tb=short --timeout=60`
- `make install`
- `make lint`
- `make test-unit`