### PR TITLE
Make BatchWriteItem affinity target selection deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ Async clients created by `create_async_client` / `AsyncAlternatorClient` are saf
 - **Request Compression**: Gzip compression requires ScyllaDB 2026.1.0+. Response compression is not yet supported by Alternator.
 - **TLS Session Cache Settings**: The `cache_size` and `timeout_seconds` parameters in `TlsSessionCacheConfig` are not currently used by Python's `ssl` module. Only the `enabled` flag controls session ticket behavior.
 - **Async Key Affinity**: For async clients, partition key auto-discovery happens asynchronously. The first request for an unknown table will use round-robin routing while discovery runs in the background. Subsequent requests will use affinity. Preloading via `table_pk_map` avoids this initial miss.
-- **Batch Operations**: `BatchWriteItem` key affinity is based on the first `PutRequest` or `DeleteRequest` in the batch. Batches with items targeting different partition keys are not split by affinity target.
+- **Batch Operations**: `BatchWriteItem` key affinity is based on a deterministic `PutRequest` or `DeleteRequest` selected from the batch. Batches with items targeting different partition keys are not split by affinity target.
 
 ## Development
 

--- a/alternator/core/key_affinity.py
+++ b/alternator/core/key_affinity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import threading
 from typing import TYPE_CHECKING, Any, NamedTuple
@@ -19,6 +20,7 @@ logger = logging.getLogger("alternator")
 class _BatchWriteRoutingTarget(NamedTuple):
     table_name: str
     attributes: dict[str, Any]
+    sort_key: tuple[str, str, str]
 
 
 class AffinitySelector:
@@ -139,6 +141,7 @@ def _find_batch_write_routing_target(
     if not isinstance(request_items, dict):
         return None
 
+    target: _BatchWriteRoutingTarget | None = None
     for table_name, writes in request_items.items():
         if not isinstance(table_name, str) or not isinstance(writes, list):
             continue
@@ -150,15 +153,70 @@ def _find_batch_write_routing_target(
             if isinstance(put_request, dict):
                 item = put_request.get("Item")
                 if isinstance(item, dict):
-                    return _BatchWriteRoutingTarget(table_name, item)
+                    target = _min_batch_write_target(
+                        target,
+                        _BatchWriteRoutingTarget(
+                            table_name,
+                            item,
+                            _batch_write_sort_key(table_name, "PutRequest", item),
+                        ),
+                    )
 
             delete_request = write.get("DeleteRequest")
             if isinstance(delete_request, dict):
                 key = delete_request.get("Key")
                 if isinstance(key, dict):
-                    return _BatchWriteRoutingTarget(table_name, key)
+                    target = _min_batch_write_target(
+                        target,
+                        _BatchWriteRoutingTarget(
+                            table_name,
+                            key,
+                            _batch_write_sort_key(table_name, "DeleteRequest", key),
+                        ),
+                    )
 
-    return None
+    return target
+
+
+def _min_batch_write_target(
+    current: _BatchWriteRoutingTarget | None,
+    candidate: _BatchWriteRoutingTarget,
+) -> _BatchWriteRoutingTarget:
+    if current is None or candidate.sort_key < current.sort_key:
+        return candidate
+    return current
+
+
+def _batch_write_sort_key(
+    table_name: str,
+    operation: str,
+    attributes: dict[str, Any],
+) -> tuple[str, str, str]:
+    return (table_name, _canonical_json(attributes), operation)
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        _to_jsonable(value),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _to_jsonable(value: object) -> object:
+    if isinstance(value, dict):
+        return {
+            str(key): _to_jsonable(item_value)
+            for key, item_value in sorted(value.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(value, list):
+        return [_to_jsonable(item) for item in value]
+    if isinstance(value, bytes | bytearray):
+        return {"__bytes__": bytes(value).hex()}
+    if isinstance(value, str | int | float | bool) or value is None:
+        return value
+    return repr(value)
 
 
 class PartitionKeyCache:

--- a/tests/unit/test_key_affinity.py
+++ b/tests/unit/test_key_affinity.py
@@ -3,8 +3,10 @@
 import threading
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 from unittest.mock import MagicMock
 
+from alternator.core.hashing import hash_attribute_value
 from alternator.core.key_affinity import (
     AffinitySelector,
     PartitionKeyCache,
@@ -15,6 +17,18 @@ from alternator.core.key_affinity import (
     should_use_affinity,
 )
 from alternator.core.live_nodes import NodeList
+
+
+def _batch_write_routing_target(
+    params: dict[str, Any],
+) -> tuple[str | None, tuple[str, Any] | None, int | None]:
+    table_name = get_table_name(params)
+    pk = extract_partition_key(params, "pk")
+    if pk is None:
+        return (table_name, None, None)
+
+    attr_type, value = pk
+    return (table_name, pk, hash_attribute_value(attr_type, value))
 
 
 class TestIsRmwOperation:
@@ -208,6 +222,161 @@ class TestExtractPartitionKey:
         }
         result = extract_partition_key(params, "session_id")
         assert result == ("S", "session123")
+
+    def test_extract_from_batch_write_is_table_order_independent(self) -> None:
+        """Test batch affinity target is independent of RequestItems order."""
+        orders = [
+            {
+                "PutRequest": {
+                    "Item": {
+                        "pk": {"S": "order123"},
+                    }
+                }
+            }
+        ]
+        sessions = [
+            {
+                "DeleteRequest": {
+                    "Key": {
+                        "pk": {"S": "session123"},
+                    }
+                }
+            }
+        ]
+        params_a = {"RequestItems": {"orders": orders, "sessions": sessions}}
+        params_b = {"RequestItems": {"sessions": sessions, "orders": orders}}
+
+        assert get_table_name(params_a) == "orders"
+        assert get_table_name(params_b) == "orders"
+        assert extract_partition_key(params_a, "pk") == ("S", "order123")
+        assert extract_partition_key(params_b, "pk") == ("S", "order123")
+
+    def test_extract_from_batch_write_is_write_order_independent(self) -> None:
+        """Test batch affinity target is independent of write order."""
+        write_a = {
+            "PutRequest": {
+                "Item": {
+                    "pk": {"S": "order123"},
+                }
+            }
+        }
+        write_b = {
+            "PutRequest": {
+                "Item": {
+                    "pk": {"S": "order456"},
+                }
+            }
+        }
+        params_a = {"RequestItems": {"orders": [write_a, write_b]}}
+        params_b = {"RequestItems": {"orders": [write_b, write_a]}}
+
+        assert extract_partition_key(params_a, "pk") == ("S", "order123")
+        assert extract_partition_key(params_b, "pk") == ("S", "order123")
+
+    def test_batch_write_routing_hash_is_deterministic_for_same_request(self) -> None:
+        """Test equivalent BatchWriteItem requests use the same routing hash."""
+        params_a = {
+            "RequestItems": {
+                "sessions": [
+                    {
+                        "DeleteRequest": {
+                            "Key": {
+                                "pk": {"S": "session123"},
+                            }
+                        }
+                    }
+                ],
+                "orders": [
+                    {
+                        "PutRequest": {
+                            "Item": {
+                                "data": {"S": "value"},
+                                "pk": {"S": "order123"},
+                            }
+                        }
+                    },
+                    {
+                        "PutRequest": {
+                            "Item": {
+                                "pk": {"S": "order456"},
+                                "data": {"S": "value"},
+                            }
+                        }
+                    },
+                ],
+            }
+        }
+        params_b = {
+            "RequestItems": {
+                "orders": [
+                    {
+                        "PutRequest": {
+                            "Item": {
+                                "data": {"S": "value"},
+                                "pk": {"S": "order456"},
+                            }
+                        }
+                    },
+                    {
+                        "PutRequest": {
+                            "Item": {
+                                "pk": {"S": "order123"},
+                                "data": {"S": "value"},
+                            }
+                        }
+                    },
+                ],
+                "sessions": [
+                    {
+                        "DeleteRequest": {
+                            "Key": {
+                                "pk": {"S": "session123"},
+                            }
+                        }
+                    }
+                ],
+            }
+        }
+
+        assert _batch_write_routing_target(params_a) == _batch_write_routing_target(
+            params_b
+        )
+
+    def test_batch_write_routing_hash_is_deterministic_for_repeated_build(
+        self,
+    ) -> None:
+        """Test repeated same-way BatchWriteItem construction routes identically."""
+
+        def build_request() -> dict[str, Any]:
+            return {
+                "RequestItems": {
+                    "orders": [
+                        {
+                            "PutRequest": {
+                                "Item": {
+                                    "pk": {"S": "order123"},
+                                    "data": {"S": "value"},
+                                }
+                            }
+                        }
+                    ],
+                    "sessions": [
+                        {
+                            "DeleteRequest": {
+                                "Key": {
+                                    "pk": {"S": "session123"},
+                                }
+                            }
+                        }
+                    ],
+                }
+            }
+
+        targets = {_batch_write_routing_target(build_request()) for _ in range(10)}
+
+        assert targets == {
+            ("orders", ("S", "order123"), hash_attribute_value("S", "order123"))
+        }
 
     def test_extract_from_empty_batch_write(self) -> None:
         """Test empty BatchWriteItem does not produce a PK."""


### PR DESCRIPTION
## Summary
- Select the `BatchWriteItem` affinity target by a stable canonical sort key instead of request iteration order.
- Make table order, write order, and attribute map order irrelevant for the selected routing target.
- Add tests that verify deterministic routing hashes for equivalent requests and for repeated same-way request construction.
- Update the README batch-affinity note to avoid saying the first write is used.

Fixes #21.

## Testing
- `uv run pytest tests/unit/test_key_affinity.py -v --tb=short --timeout=60`
- `make lint`
- `make test-unit`
- Manual hash-seed probe across `PYTHONHASHSEED=1..10` produced one unique target.