### PR TITLE
Add Config and TLS aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ pip install alternator-client[async]
 ### Synchronous Client
 
 ```python
-from alternator import AlternatorConfig, AlternatorClient
+from alternator import Config, AlternatorClient
 
 # Configure the client
-config = AlternatorConfig(
+config = Config(
     seed_hosts=["192.168.1.1", "192.168.1.2"],
     port=8000,
 )
@@ -58,11 +58,11 @@ with AlternatorClient(config) as client:
 
 ```python
 import asyncio
-from alternator import AlternatorConfig
+from alternator import Config
 from alternator.async_client import AsyncAlternatorClient
 
 async def main():
-    config = AlternatorConfig(
+    config = Config(
         seed_hosts=["192.168.1.1"],
         port=8000,
     )
@@ -80,14 +80,17 @@ asyncio.run(main())
 ### Basic Configuration
 
 ```python
-from alternator import AlternatorConfig
+from alternator import Config
 
-config = AlternatorConfig(
+config = Config(
     seed_hosts=["node1.example.com", "node2.example.com"],
     port=8000,
     scheme="http",  # or "https" for TLS
 )
 ```
+
+> **Compatibility:** `AlternatorConfig` and `TlsConfig` remain available for
+> existing callers, but are deprecated. Prefer `Config` and `TLS` for new code.
 
 ### Using the Builder Pattern
 
@@ -96,14 +99,14 @@ from alternator import (
     AlternatorConfigBuilder,
     CompressionAlgorithm,
     KeyRouteAffinityMode,
-    TlsConfig,
+    TLS,
 )
 
 config = (
     AlternatorConfigBuilder()
     .with_seeds("node1.example.com", "node2.example.com")
     .with_port(8000)
-    .with_https(TlsConfig.system_default())
+    .with_https(TLS.system_default())
     .with_datacenter("us-east-1")
     .with_compression(CompressionAlgorithm.GZIP, min_size=1024)
     .with_key_affinity(KeyRouteAffinityMode.RMW)
@@ -125,7 +128,7 @@ config = (
 | `optimize_headers` | `bool` | `False` | Enable header filtering |
 | `headers_whitelist` | `frozenset[str]` | `None` | Additional headers to keep |
 | `authentication_enabled` | `bool` | `True` | Include auth headers |
-| `tls` | `TlsConfig` | system default | TLS configuration |
+| `tls` | `TLS` | system default | TLS configuration |
 | `key_affinity` | `KeyRouteAffinityConfig` | `NONE` | Key-based routing |
 | `max_pool_connections` | `int` | `200` | Max connections per host |
 | `active_refresh_interval_ms` | `int` | `1000` | Node refresh interval when active |
@@ -136,24 +139,24 @@ config = (
 Control which nodes receive your requests based on topology:
 
 ```python
-from alternator import ClusterScope, DatacenterScope, RackScope
+from alternator import Config, ClusterScope, DatacenterScope, RackScope
 
 # Route to any node in the cluster (default)
-config = AlternatorConfig(
+config = Config(
     seed_hosts=["node1"],
     port=8000,
     routing_scope=ClusterScope(),
 )
 
 # Route to nodes in a specific datacenter
-config = AlternatorConfig(
+config = Config(
     seed_hosts=["node1"],
     port=8000,
     routing_scope=DatacenterScope(datacenter="us-east-1"),
 )
 
 # Route to nodes in a specific rack (with fallback)
-config = AlternatorConfig(
+config = Config(
     seed_hosts=["node1"],
     port=8000,
     routing_scope=RackScope(datacenter="us-east-1", rack="rack1"),
@@ -196,20 +199,20 @@ config = (
 ## TLS Configuration
 
 ```python
-from alternator import TlsConfig, TlsSessionCacheConfig
+from alternator import TLS, TlsSessionCacheConfig
 from pathlib import Path
 
 # Use system CA certificates (default)
-tls = TlsConfig.system_default()
+tls = TLS.system_default()
 
 # Use custom CA certificate
-tls = TlsConfig.with_custom_ca(Path("/path/to/ca.pem"))
+tls = TLS.with_custom_ca(Path("/path/to/ca.pem"))
 
 # Trust all certificates (INSECURE - dev only)
-tls = TlsConfig.trust_all()
+tls = TLS.trust_all()
 
 # Full configuration
-tls = TlsConfig(
+tls = TLS(
     custom_ca_cert_paths=[Path("/path/to/ca.pem")],
     trust_system_ca_certs=True,
     verify_hostname=True,
@@ -247,14 +250,14 @@ config = (
 ```python
 from alternator import (
     AlternatorClient,
-    AlternatorConfig,
+    Config,
     AlternatorError,
     NoNodesAvailableError,
     ConfigurationError,
 )
 
 try:
-    config = AlternatorConfig(seed_hosts=[], port=8000)
+    config = Config(seed_hosts=[], port=8000)
 except ConfigurationError as e:
     print(f"Invalid configuration: {e}")
 
@@ -290,9 +293,9 @@ Log levels:
 For table-oriented operations, use `AlternatorResource` which wraps boto3's DynamoDB resource:
 
 ```python
-from alternator import AlternatorConfig, AlternatorResource
+from alternator import Config, AlternatorResource
 
-config = AlternatorConfig(seed_hosts=["192.168.1.1"], port=8000)
+config = Config(seed_hosts=["192.168.1.1"], port=8000)
 
 with AlternatorResource(config) as resource:
     table = resource.Table("my_table")
@@ -303,9 +306,9 @@ with AlternatorResource(config) as resource:
 You can also use the factory function:
 
 ```python
-from alternator import create_resource, close_resource, AlternatorConfig
+from alternator import create_resource, close_resource, Config
 
-config = AlternatorConfig(seed_hosts=["node1"], port=8000)
+config = Config(seed_hosts=["node1"], port=8000)
 resource = create_resource(config)
 
 try:
@@ -417,9 +420,9 @@ for item in result["Items"]:
 If you prefer not to use context managers:
 
 ```python
-from alternator import create_client, close_client, AlternatorConfig
+from alternator import create_client, close_client, Config
 
-config = AlternatorConfig(seed_hosts=["node1"], port=8000)
+config = Config(seed_hosts=["node1"], port=8000)
 client = create_client(config)
 
 try:
@@ -431,10 +434,10 @@ finally:
 Async equivalent:
 
 ```python
-from alternator import AlternatorConfig
+from alternator import Config
 from alternator.async_client import create_async_client, close_async_client
 
-config = AlternatorConfig(seed_hosts=["node1"], port=8000)
+config = Config(seed_hosts=["node1"], port=8000)
 client = await create_async_client(config)
 
 try:

--- a/alternator/__init__.py
+++ b/alternator/__init__.py
@@ -8,9 +8,9 @@ Quick Start
 -----------
 Synchronous usage::
 
-    from alternator import AlternatorConfig, AlternatorClient
+    from alternator import Config, AlternatorClient
 
-    config = AlternatorConfig(
+    config = Config(
         seed_hosts=["192.168.1.1", "192.168.1.2"],
         port=8000,
     )
@@ -24,17 +24,17 @@ Synchronous usage::
 
 Asynchronous usage::
 
-    from alternator import AlternatorConfig
+    from alternator import Config
     from alternator.async_client import AsyncAlternatorClient
 
-    config = AlternatorConfig(seed_hosts=["192.168.1.1"], port=8000)
+    config = Config(seed_hosts=["192.168.1.1"], port=8000)
 
     async with AsyncAlternatorClient(config) as client:
         response = await client.list_tables()
 
 Configuration
 -------------
-Use ``AlternatorConfig`` for direct configuration or ``AlternatorConfigBuilder``
+Use ``Config`` for direct configuration or ``AlternatorConfigBuilder``
 for a fluent builder pattern::
 
     from alternator import AlternatorConfigBuilder, CompressionAlgorithm
@@ -52,9 +52,9 @@ Key Classes
 -----------
 - ``AlternatorClient``: Sync context manager for load-balanced connections
 - ``AsyncAlternatorClient``: Async context manager for load-balanced connections
-- ``AlternatorConfig``: Main configuration dataclass
+- ``Config``: Main configuration dataclass
 - ``AlternatorConfigBuilder``: Fluent builder for configuration
-- ``TlsConfig``: TLS/SSL configuration
+- ``TLS``: TLS/SSL configuration
 - ``ClusterScope``, ``DatacenterScope``, ``RackScope``: Routing scope controls
 
 Exceptions
@@ -84,9 +84,11 @@ from alternator.client import (
     create_resource,
 )
 from alternator.config import (
+    TLS,
     AlternatorConfig,
     AlternatorConfigBuilder,
     CompressionAlgorithm,
+    Config,
     HeaderOptimizationConfig,
     KeyRouteAffinityConfig,
     KeyRouteAffinityMode,
@@ -126,6 +128,8 @@ __all__ = [
     "close_async_client",
     "create_async_client",
     # Config
+    "Config",
+    "TLS",
     "AlternatorConfig",
     "AlternatorConfigBuilder",
     "CompressionAlgorithm",

--- a/alternator/_http.py
+++ b/alternator/_http.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 if TYPE_CHECKING:
     import aiohttp
 
-    from alternator.config import TlsConfig
+    from alternator.config import TLS
 
 logger = logging.getLogger("alternator")
 
@@ -93,7 +93,7 @@ def create_sync_http_fetcher(
     return fetch_nodes
 
 
-def create_ssl_context(tls_config: TlsConfig) -> ssl.SSLContext:
+def create_ssl_context(tls_config: TLS) -> ssl.SSLContext:
     """
     Create an SSL context from TLS configuration.
 

--- a/alternator/async_client.py
+++ b/alternator/async_client.py
@@ -33,7 +33,7 @@ from alternator.vector import enable_vector_support
 if TYPE_CHECKING:
     from types_aiobotocore_dynamodb import DynamoDBClient as AsyncDynamoDBClient
 
-    from alternator.config import AlternatorConfig
+    from alternator.config import Config
 
 logger = logging.getLogger("alternator")
 
@@ -200,7 +200,7 @@ class AsyncPartitionKeyCache:
 
 
 def _create_async_affinity_hash_computer(
-    config: AlternatorConfig,
+    config: Config,
     pk_cache: AsyncPartitionKeyCache | None,
 ) -> Callable[[str, dict[str, Any]], int | None] | None:
     """
@@ -269,7 +269,7 @@ def _create_async_affinity_hash_computer(
 
 
 async def create_async_client(
-    config: AlternatorConfig,
+    config: Config,
     **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
 ) -> AsyncDynamoDBClient:
     """
@@ -293,10 +293,10 @@ async def create_async_client(
         An async DynamoDB client with load balancing enabled
 
     Example:
-        from alternator import AlternatorConfig
+        from alternator import Config
         from alternator.async_client import create_async_client
 
-        config = AlternatorConfig(
+        config = Config(
             seed_hosts=["node1.example.com"],
             port=8000,
         )
@@ -343,7 +343,7 @@ async def create_async_client(
     # BotoConfig is managed internally — don't let callers override it
     boto_kwargs.pop("config", None)
 
-    # Create boto config from AlternatorConfig settings
+    # Create boto config from Config settings
     from botocore import UNSIGNED
 
     auth_enabled = "aws_access_key_id" in boto_kwargs
@@ -453,7 +453,7 @@ class AsyncAlternatorClient:
             await client.put_item(...)
     """
 
-    def __init__(self, config: AlternatorConfig, **boto_kwargs: Any) -> None:  # noqa: ANN401 -- boto3 kwargs are untyped
+    def __init__(self, config: Config, **boto_kwargs: Any) -> None:  # noqa: ANN401 -- boto3 kwargs are untyped
         self._config = config
         self._boto_kwargs = boto_kwargs
         self._client: AsyncDynamoDBClient | None = None

--- a/alternator/client.py
+++ b/alternator/client.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from mypy_boto3_dynamodb import DynamoDBClient
     from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource
 
-    from alternator.config import AlternatorConfig
+    from alternator.config import Config
 
 logger = logging.getLogger("alternator")
 
@@ -84,7 +84,7 @@ def _cleanup_all_managers() -> None:
             manager.stop()
 
 
-def _create_and_start_manager(config: AlternatorConfig) -> SyncLiveNodesManager:
+def _create_and_start_manager(config: Config) -> SyncLiveNodesManager:
     """
     Create and initialize a SyncLiveNodesManager.
 
@@ -126,8 +126,8 @@ def _create_and_start_manager(config: AlternatorConfig) -> SyncLiveNodesManager:
     return manager
 
 
-def _create_boto_config(config: AlternatorConfig, *, auth_enabled: bool) -> BotoConfig:
-    """Create BotoConfig from AlternatorConfig settings.
+def _create_boto_config(config: Config, *, auth_enabled: bool) -> BotoConfig:
+    """Create BotoConfig from Config settings.
 
     When no credentials are provided (auth_enabled=False), uses UNSIGNED
     signature to skip request signing entirely.
@@ -147,7 +147,7 @@ def _create_boto_config(config: AlternatorConfig, *, auth_enabled: bool) -> Boto
 
 
 def _create_affinity_hash_computer(
-    config: AlternatorConfig,
+    config: Config,
     client: DynamoDBClient,
 ) -> Callable[[str, dict[str, Any]], int | None] | None:
     """
@@ -220,7 +220,7 @@ def _create_affinity_hash_computer(
 
 
 def create_client(
-    config: AlternatorConfig,
+    config: Config,
     **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
 ) -> DynamoDBClient:
     """
@@ -245,9 +245,9 @@ def create_client(
         A DynamoDB client with load balancing enabled
 
     Example:
-        from alternator import AlternatorConfig, create_client
+        from alternator import Config, create_client
 
-        config = AlternatorConfig(
+        config = Config(
             seed_hosts=["node1.example.com"],
             port=8000,
         )
@@ -304,7 +304,7 @@ def create_client(
 
 
 def create_resource(
-    config: AlternatorConfig,
+    config: Config,
     **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
 ) -> DynamoDBServiceResource:
     """
@@ -405,7 +405,7 @@ class AlternatorClient:
             client.put_item(...)
     """
 
-    def __init__(self, config: AlternatorConfig, **boto_kwargs: Any) -> None:  # noqa: ANN401 -- boto3 kwargs are untyped
+    def __init__(self, config: Config, **boto_kwargs: Any) -> None:  # noqa: ANN401 -- boto3 kwargs are untyped
         self._config = config
         self._boto_kwargs = boto_kwargs
         self._client: DynamoDBClient | None = None
@@ -448,7 +448,7 @@ class AlternatorResource:
             table.put_item(Item={"pk": "123", "data": "hello"})
     """
 
-    def __init__(self, config: AlternatorConfig, **boto_kwargs: Any) -> None:  # noqa: ANN401 -- boto3 kwargs are untyped
+    def __init__(self, config: Config, **boto_kwargs: Any) -> None:  # noqa: ANN401 -- boto3 kwargs are untyped
         self._config = config
         self._boto_kwargs = boto_kwargs
         self._resource: DynamoDBServiceResource | None = None

--- a/alternator/config.py
+++ b/alternator/config.py
@@ -51,7 +51,7 @@ class TlsSessionCacheConfig:
 
 
 @dataclass(frozen=True)
-class TlsConfig:
+class TLS:
     """TLS/SSL configuration for HTTPS connections."""
 
     # Certificate trust settings
@@ -66,7 +66,7 @@ class TlsConfig:
     session_cache: TlsSessionCacheConfig = field(default_factory=TlsSessionCacheConfig)
 
     @classmethod
-    def trust_all(cls) -> TlsConfig:
+    def trust_all(cls) -> TLS:
         """
         Create insecure config that trusts all certificates.
 
@@ -83,7 +83,7 @@ class TlsConfig:
             ``ALTERNATOR_ALLOW_INSECURE_TLS=1``.
         """
         msg = (
-            "TlsConfig.trust_all() disables TLS certificate verification. "
+            "TLS.trust_all() disables TLS certificate verification. "
             "This is INSECURE and should only be used for development. "
             "Set ALTERNATOR_ALLOW_INSECURE_TLS=1 to suppress this warning."
         )
@@ -97,14 +97,26 @@ class TlsConfig:
         )
 
     @classmethod
-    def system_default(cls) -> TlsConfig:
+    def system_default(cls) -> TLS:
         """Create config using system CA certificates."""
         return cls(trust_system_ca_certs=True)
 
     @classmethod
-    def with_custom_ca(cls, *cert_paths: Path) -> TlsConfig:
+    def with_custom_ca(cls, *cert_paths: Path) -> TLS:
         """Create config with custom CA certificates."""
         return cls(custom_ca_cert_paths=tuple(cert_paths))
+
+
+@dataclass(frozen=True)
+class TlsConfig(TLS):
+    """Deprecated compatibility name for :class:`TLS`."""
+
+    def __post_init__(self) -> None:
+        warnings.warn(
+            "TlsConfig is deprecated; use TLS instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
 
 @dataclass(frozen=True)
@@ -211,12 +223,12 @@ class KeyRouteAffinityConfig:
 
 
 @dataclass(frozen=True)
-class AlternatorConfig:
+class Config:
     """
     Main configuration for Alternator load balancing client.
 
     Example:
-        config = AlternatorConfig(
+        config = Config(
             seed_hosts=["192.168.1.1", "192.168.1.2"],
             port=8000,
         )
@@ -243,7 +255,7 @@ class AlternatorConfig:
     )
 
     # TLS configuration (used when scheme="https")
-    tls: TlsConfig = field(default_factory=TlsConfig.system_default)
+    tls: TLS = field(default_factory=TLS.system_default)
 
     # Key route affinity for LWT optimization
     key_affinity: KeyRouteAffinityConfig = field(default_factory=KeyRouteAffinityConfig)
@@ -278,9 +290,22 @@ class AlternatorConfig:
             )
 
 
+@dataclass(frozen=True)
+class AlternatorConfig(Config):
+    """Deprecated compatibility name for :class:`Config`."""
+
+    def __post_init__(self) -> None:
+        warnings.warn(
+            "AlternatorConfig is deprecated; use Config instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__post_init__()
+
+
 class AlternatorConfigBuilder:
     """
-    Fluent builder for AlternatorConfig.
+    Fluent builder for Config.
 
     Example:
         config = (
@@ -301,7 +326,7 @@ class AlternatorConfigBuilder:
         self._routing_scope: RoutingScope | None = None
         self._request_compression = RequestCompressionConfig()
         self._header_optimization = HeaderOptimizationConfig()
-        self._tls = TlsConfig.system_default()
+        self._tls = TLS.system_default()
         self._key_affinity = KeyRouteAffinityConfig()
         self._retries = RetryConfig()
         self._max_pool_connections = 200
@@ -323,9 +348,7 @@ class AlternatorConfigBuilder:
         self._scheme = "http"
         return self
 
-    def with_https(
-        self, tls_config: TlsConfig | None = None
-    ) -> AlternatorConfigBuilder:
+    def with_https(self, tls_config: TLS | None = None) -> AlternatorConfigBuilder:
         """Use HTTPS scheme with optional TLS configuration."""
         self._scheme = "https"
         if tls_config:
@@ -431,11 +454,11 @@ class AlternatorConfigBuilder:
         )
         return self
 
-    def build(self) -> AlternatorConfig:
+    def build(self) -> Config:
         """Build the configuration object."""
         from alternator.core.routing_scope import ClusterScope
 
-        return AlternatorConfig(
+        return Config(
             seed_hosts=tuple(self._seed_hosts),
             port=self._port,
             scheme=self._scheme,

--- a/alternator/core/handlers.py
+++ b/alternator/core/handlers.py
@@ -21,7 +21,7 @@ from alternator.core.request import extract_operation_name, extract_request_para
 from alternator.exceptions import NoNodesAvailableError
 
 if TYPE_CHECKING:
-    from alternator.config import AlternatorConfig
+    from alternator.config import Config
     from alternator.core.live_nodes import NodeList
 
 # Type alias for DynamoDB request parameters (inherently flexible key-value structure)
@@ -42,7 +42,7 @@ class _HasNodes(Protocol):
 def _register_alternator_handlers(
     events: BaseEventHooks,
     manager: _HasNodes,
-    config: AlternatorConfig,
+    config: Config,
     compute_affinity_hash: Callable[[str, DynamoDBParams], int | None] | None = None,
     *,
     auth_enabled: bool = False,

--- a/alternator/core/live_nodes.py
+++ b/alternator/core/live_nodes.py
@@ -15,7 +15,7 @@ from alternator._http import AsyncHttpFetcher, SyncHttpFetcher
 from alternator.exceptions import NoNodesAvailableError
 
 if TYPE_CHECKING:
-    from alternator.config import AlternatorConfig
+    from alternator.config import Config
     from alternator.core.routing_scope import RoutingScope
 
 logger = logging.getLogger("alternator")
@@ -82,7 +82,7 @@ class LiveNodesManagerCore:
     - URL building for /localnodes endpoint
     """
 
-    def __init__(self, config: AlternatorConfig) -> None:
+    def __init__(self, config: Config) -> None:
         self._config = config
         self._nodes: NodeList = NodeList(nodes=(), scope_name="")
         self._nodes_lock = threading.Lock()
@@ -219,7 +219,7 @@ class SyncLiveNodesManager:
 
     def __init__(
         self,
-        config: AlternatorConfig,
+        config: Config,
         http_fetch: SyncHttpFetcher,
     ) -> None:
         """
@@ -340,7 +340,7 @@ class AsyncLiveNodesManager:
 
     def __init__(
         self,
-        config: AlternatorConfig,
+        config: Config,
         http_fetch: AsyncHttpFetcher,
     ) -> None:
         """

--- a/alternator/core/tls.py
+++ b/alternator/core/tls.py
@@ -6,10 +6,10 @@ import ssl
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from alternator.config import TlsConfig
+    from alternator.config import TLS
 
 
-def create_ssl_context(tls_config: TlsConfig) -> ssl.SSLContext:
+def create_ssl_context(tls_config: TLS) -> ssl.SSLContext:
     """
     Create an SSL context from TLS configuration.
 

--- a/alternator/vector.py
+++ b/alternator/vector.py
@@ -29,7 +29,7 @@ Usage::
 
     import alternator
 
-    config = alternator.AlternatorConfig(seed_hosts=["192.168.1.1"], port=8000)
+    config = alternator.Config(seed_hosts=["192.168.1.1"], port=8000)
     client = alternator.create_client(config)  # vector support enabled automatically
 
     # Create a table with a vector index
@@ -62,7 +62,7 @@ With the high-level Resource interface, use :class:`Vector` directly::
     import alternator
     from alternator.vector import Vector
 
-    config = alternator.AlternatorConfig(seed_hosts=["192.168.1.1"], port=8000)
+    config = alternator.Config(seed_hosts=["192.168.1.1"], port=8000)
     resource = alternator.create_resource(config)  # vector support enabled automatically
 
     table = resource.Table("embeddings")

--- a/examples/async_demo.py
+++ b/examples/async_demo.py
@@ -14,7 +14,7 @@ import sys
 
 from botocore.exceptions import ClientError
 
-from alternator import AlternatorConfig, NoNodesAvailableError
+from alternator import Config, NoNodesAvailableError
 from alternator.async_client import AsyncAlternatorClient
 
 # Enable logging to see load balancing in action
@@ -27,7 +27,7 @@ logging.basicConfig(
 async def main() -> None:
     """Run the async demo."""
     # Configure the client
-    config = AlternatorConfig(
+    config = Config(
         seed_hosts=["localhost"],  # Replace with your Scylla nodes
         port=8000,
         scheme="http",  # Use "https" for TLS

--- a/examples/sync_demo.py
+++ b/examples/sync_demo.py
@@ -13,7 +13,7 @@ import sys
 
 from botocore.exceptions import ClientError
 
-from alternator import AlternatorClient, AlternatorConfig, NoNodesAvailableError
+from alternator import AlternatorClient, Config, NoNodesAvailableError
 
 # Enable logging to see load balancing in action
 logging.basicConfig(
@@ -25,7 +25,7 @@ logging.basicConfig(
 def main() -> None:
     """Run the sync demo."""
     # Configure the client
-    config = AlternatorConfig(
+    config = Config(
         seed_hosts=["localhost"],  # Replace with your Scylla nodes
         port=8000,
         scheme="http",  # Use "https" for TLS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,10 +63,10 @@ def scylla_version() -> ScyllaVersion | None:
         return None
 
     try:
-        from alternator import AlternatorConfig, close_client, create_client
+        from alternator import Config, close_client, create_client
         from tests.integration.scylla_version import detect_version_from_cluster
 
-        config = AlternatorConfig(
+        config = Config(
             seed_hosts=[SCYLLA_HOST],
             port=SCYLLA_PORT,
             scheme="http",

--- a/tests/integration/test_async_client.py
+++ b/tests/integration/test_async_client.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 
 import pytest
 
-from alternator import AlternatorConfig
+from alternator import Config
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
 
 pytestmark = [
@@ -22,9 +22,9 @@ pytestmark = [
 
 
 @pytest.fixture
-def config() -> AlternatorConfig:
+def config() -> Config:
     """Create test configuration."""
-    return AlternatorConfig(
+    return Config(
         seed_hosts=[SCYLLA_HOST],
         port=SCYLLA_PORT,
         scheme="http",
@@ -40,7 +40,7 @@ def table_name() -> str:
 class TestAsyncBasicOperations:
     """Test basic async DynamoDB operations."""
 
-    async def test_list_tables(self, config: AlternatorConfig) -> None:
+    async def test_list_tables(self, config: Config) -> None:
         """Test listing tables asynchronously."""
         from alternator.async_client import AsyncAlternatorClient
 
@@ -49,9 +49,7 @@ class TestAsyncBasicOperations:
             assert "TableNames" in response
             assert isinstance(response["TableNames"], list)
 
-    async def test_put_and_get_item(
-        self, config: AlternatorConfig, table_name: str
-    ) -> None:
+    async def test_put_and_get_item(self, config: Config, table_name: str) -> None:
         """Test putting and getting an item asynchronously."""
         from alternator.async_client import AsyncAlternatorClient
 
@@ -96,9 +94,7 @@ class TestAsyncBasicOperations:
 class TestAsyncConcurrency:
     """Test concurrent async operations."""
 
-    async def test_concurrent_writes(
-        self, config: AlternatorConfig, table_name: str
-    ) -> None:
+    async def test_concurrent_writes(self, config: Config, table_name: str) -> None:
         """Test concurrent write operations."""
         from alternator.async_client import AsyncAlternatorClient
 
@@ -148,7 +144,7 @@ class TestAsyncConcurrency:
             finally:
                 await client.delete_table(TableName=table_name)
 
-    async def test_high_concurrency(self, config: AlternatorConfig) -> None:
+    async def test_high_concurrency(self, config: Config) -> None:
         """Test high concurrency list_tables operations."""
         from alternator.async_client import AsyncAlternatorClient
 

--- a/tests/integration/test_batch_transactions.py
+++ b/tests/integration/test_batch_transactions.py
@@ -9,7 +9,7 @@ import uuid
 
 import pytest
 
-from alternator import AlternatorClient, AlternatorConfig
+from alternator import AlternatorClient, Config
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
 
 pytestmark = [
@@ -19,9 +19,9 @@ pytestmark = [
 
 
 @pytest.fixture
-def config() -> AlternatorConfig:
+def config() -> Config:
     """Create test configuration."""
-    return AlternatorConfig(
+    return Config(
         seed_hosts=[SCYLLA_HOST],
         port=SCYLLA_PORT,
         scheme="http",
@@ -37,9 +37,7 @@ def table_name() -> str:
 class TestBatchWriteItem:
     """Test BatchWriteItem operations through the load-balanced client."""
 
-    def test_batch_write_multiple_items(
-        self, config: AlternatorConfig, table_name: str
-    ) -> None:
+    def test_batch_write_multiple_items(self, config: Config, table_name: str) -> None:
         """Test writing multiple items in a single batch."""
         with AlternatorClient(config) as client:
             client.create_table(
@@ -76,9 +74,7 @@ class TestBatchWriteItem:
             finally:
                 client.delete_table(TableName=table_name)
 
-    def test_batch_write_with_deletes(
-        self, config: AlternatorConfig, table_name: str
-    ) -> None:
+    def test_batch_write_with_deletes(self, config: Config, table_name: str) -> None:
         """Test batch write mixing puts and deletes."""
         with AlternatorClient(config) as client:
             client.create_table(
@@ -134,9 +130,7 @@ class TestBatchWriteItem:
 class TestBatchGetItem:
     """Test BatchGetItem operations through the load-balanced client."""
 
-    def test_batch_get_multiple_items(
-        self, config: AlternatorConfig, table_name: str
-    ) -> None:
+    def test_batch_get_multiple_items(self, config: Config, table_name: str) -> None:
         """Test getting multiple items in a single batch."""
         with AlternatorClient(config) as client:
             client.create_table(
@@ -175,9 +169,7 @@ class TestBatchGetItem:
             finally:
                 client.delete_table(TableName=table_name)
 
-    def test_batch_get_nonexistent_keys(
-        self, config: AlternatorConfig, table_name: str
-    ) -> None:
+    def test_batch_get_nonexistent_keys(self, config: Config, table_name: str) -> None:
         """Test batch get with keys that don't exist."""
         with AlternatorClient(config) as client:
             client.create_table(

--- a/tests/integration/test_composite_keys.py
+++ b/tests/integration/test_composite_keys.py
@@ -11,8 +11,8 @@ import pytest
 
 from alternator import (
     AlternatorClient,
-    AlternatorConfig,
     AlternatorConfigBuilder,
+    Config,
     KeyRouteAffinityMode,
 )
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
@@ -24,9 +24,9 @@ pytestmark = [
 
 
 @pytest.fixture
-def config() -> AlternatorConfig:
+def config() -> Config:
     """Create test configuration."""
-    return AlternatorConfig(
+    return Config(
         seed_hosts=[SCYLLA_HOST],
         port=SCYLLA_PORT,
         scheme="http",
@@ -60,7 +60,7 @@ def _create_composite_table(client: AlternatorClient, table_name: str) -> None:
 class TestCompositeKeyBasicOperations:
     """Test basic CRUD with composite (HASH + RANGE) keys."""
 
-    def test_put_and_get_item(self, config: AlternatorConfig, table_name: str) -> None:
+    def test_put_and_get_item(self, config: Config, table_name: str) -> None:
         """Test put and get with composite key."""
         with AlternatorClient(config) as client:
             _create_composite_table(client, table_name)
@@ -90,7 +90,7 @@ class TestCompositeKeyBasicOperations:
                 client.delete_table(TableName=table_name)
 
     def test_multiple_range_keys_same_partition(
-        self, config: AlternatorConfig, table_name: str
+        self, config: Config, table_name: str
     ) -> None:
         """Test multiple items with same HASH key but different RANGE keys."""
         with AlternatorClient(config) as client:
@@ -119,9 +119,7 @@ class TestCompositeKeyBasicOperations:
             finally:
                 client.delete_table(TableName=table_name)
 
-    def test_update_item_composite_key(
-        self, config: AlternatorConfig, table_name: str
-    ) -> None:
+    def test_update_item_composite_key(self, config: Config, table_name: str) -> None:
         """Test updating an item with composite key."""
         with AlternatorClient(config) as client:
             _create_composite_table(client, table_name)
@@ -157,9 +155,7 @@ class TestCompositeKeyBasicOperations:
             finally:
                 client.delete_table(TableName=table_name)
 
-    def test_delete_item_composite_key(
-        self, config: AlternatorConfig, table_name: str
-    ) -> None:
+    def test_delete_item_composite_key(self, config: Config, table_name: str) -> None:
         """Test deleting an item with composite key."""
         with AlternatorClient(config) as client:
             _create_composite_table(client, table_name)
@@ -196,9 +192,7 @@ class TestCompositeKeyBasicOperations:
 class TestCompositeKeyQuery:
     """Test query operations with composite keys."""
 
-    def test_query_by_partition_key(
-        self, config: AlternatorConfig, table_name: str
-    ) -> None:
+    def test_query_by_partition_key(self, config: Config, table_name: str) -> None:
         """Test querying all range keys for a given partition key."""
         with AlternatorClient(config) as client:
             _create_composite_table(client, table_name)
@@ -229,7 +223,7 @@ class TestCompositeKeyQuery:
                 client.delete_table(TableName=table_name)
 
     def test_query_with_range_key_condition(
-        self, config: AlternatorConfig, table_name: str
+        self, config: Config, table_name: str
     ) -> None:
         """Test querying with both partition and range key conditions."""
         with AlternatorClient(config) as client:

--- a/tests/integration/test_connection_reuse.py
+++ b/tests/integration/test_connection_reuse.py
@@ -15,10 +15,10 @@ from pathlib import Path
 import pytest
 
 from alternator import (
+    TLS,
     AlternatorClient,
-    AlternatorConfig,
     AlternatorConfigBuilder,
-    TlsConfig,
+    Config,
 )
 from tests.integration import (
     SCYLLA_HOST,
@@ -34,9 +34,9 @@ pytestmark = [
 
 
 @pytest.fixture
-def http_config() -> AlternatorConfig:
+def http_config() -> Config:
     """Create HTTP test configuration."""
-    return AlternatorConfig(
+    return Config(
         seed_hosts=[SCYLLA_HOST],
         port=SCYLLA_PORT,
         scheme="http",
@@ -44,7 +44,7 @@ def http_config() -> AlternatorConfig:
 
 
 @pytest.fixture
-def https_config() -> AlternatorConfig | None:
+def https_config() -> Config | None:
     """Create HTTPS test configuration with trust-all for self-signed certs."""
     ca_path = Path(__file__).resolve().parents[1] / "scylla" / "db.crt"
     if not ca_path.exists():
@@ -53,7 +53,7 @@ def https_config() -> AlternatorConfig | None:
         AlternatorConfigBuilder()
         .with_seeds(SCYLLA_HOST)
         .with_port(SCYLLA_HTTPS_PORT)
-        .with_https(TlsConfig.with_custom_ca(ca_path))
+        .with_https(TLS.with_custom_ca(ca_path))
         .build()
     )
 
@@ -70,14 +70,14 @@ def ca_path() -> Path:
 class TestHttpConnectionReuseSerial:
     """Test HTTP connection reuse with serial requests."""
 
-    def test_serial_requests_succeed(self, http_config: AlternatorConfig) -> None:
+    def test_serial_requests_succeed(self, http_config: Config) -> None:
         """Test that multiple serial requests over HTTP succeed without errors."""
         with AlternatorClient(http_config) as client:
             for _ in range(20):
                 response = client.list_tables()
                 assert "TableNames" in response
 
-    def test_serial_crud_operations(self, http_config: AlternatorConfig) -> None:
+    def test_serial_crud_operations(self, http_config: Config) -> None:
         """Test serial CRUD operations reuse connections."""
         table_name = f"test_conn_{uuid.uuid4().hex[:8]}"
         with AlternatorClient(http_config) as client:
@@ -109,18 +109,14 @@ class TestHttpConnectionReuseSerial:
 class TestHttpsConnectionReuseSerial:
     """Test HTTPS connection reuse with serial requests."""
 
-    def test_serial_requests_succeed(
-        self, https_config: AlternatorConfig, ca_path: Path
-    ) -> None:
+    def test_serial_requests_succeed(self, https_config: Config, ca_path: Path) -> None:
         """Test that multiple serial HTTPS requests succeed."""
         with AlternatorClient(https_config, verify=str(ca_path)) as client:
             for _ in range(20):
                 response = client.list_tables()
                 assert "TableNames" in response
 
-    def test_serial_crud_over_https(
-        self, https_config: AlternatorConfig, ca_path: Path
-    ) -> None:
+    def test_serial_crud_over_https(self, https_config: Config, ca_path: Path) -> None:
         """Test serial CRUD over HTTPS reuses connections."""
         table_name = f"test_https_{uuid.uuid4().hex[:8]}"
         with AlternatorClient(https_config, verify=str(ca_path)) as client:
@@ -151,7 +147,7 @@ class TestHttpsConnectionReuseSerial:
 class TestHttpConnectionReuseParallel:
     """Test HTTP connection reuse with parallel requests."""
 
-    def test_parallel_list_tables(self, http_config: AlternatorConfig) -> None:
+    def test_parallel_list_tables(self, http_config: Config) -> None:
         """Test parallel requests over HTTP all succeed."""
         with AlternatorClient(http_config) as client:
             errors: list[Exception] = []
@@ -176,7 +172,7 @@ class TestHttpConnectionReuseParallel:
             assert len(results) == 50
             assert all("TableNames" in r for r in results)
 
-    def test_parallel_writes(self, http_config: AlternatorConfig) -> None:
+    def test_parallel_writes(self, http_config: Config) -> None:
         """Test parallel write operations over HTTP."""
         table_name = f"test_par_{uuid.uuid4().hex[:8]}"
         with AlternatorClient(http_config) as client:
@@ -228,7 +224,7 @@ class TestHttpsConnectionReuseParallel:
     """Test HTTPS connection reuse with parallel requests."""
 
     def test_parallel_list_tables_https(
-        self, https_config: AlternatorConfig, ca_path: Path
+        self, https_config: Config, ca_path: Path
     ) -> None:
         """Test parallel HTTPS requests all succeed."""
         with AlternatorClient(https_config, verify=str(ca_path)) as client:
@@ -253,9 +249,7 @@ class TestHttpsConnectionReuseParallel:
             assert len(errors) == 0, f"Parallel HTTPS requests had errors: {errors}"
             assert len(results) == 50
 
-    def test_parallel_writes_https(
-        self, https_config: AlternatorConfig, ca_path: Path
-    ) -> None:
+    def test_parallel_writes_https(self, https_config: Config, ca_path: Path) -> None:
         """Test parallel write operations over HTTPS."""
         table_name = f"test_https_par_{uuid.uuid4().hex[:8]}"
         with AlternatorClient(https_config, verify=str(ca_path)) as client:
@@ -299,7 +293,7 @@ class TestConnectionPoolingValidation:
     """Test connection pooling behavior."""
 
     def test_many_serial_requests_dont_exhaust_resources(
-        self, http_config: AlternatorConfig
+        self, http_config: Config
     ) -> None:
         """Test that many serial requests don't exhaust file descriptors or connections."""
         with AlternatorClient(http_config) as client:
@@ -308,9 +302,7 @@ class TestConnectionPoolingValidation:
                 response = client.list_tables()
                 assert "TableNames" in response
 
-    def test_high_concurrency_doesnt_exhaust_pool(
-        self, http_config: AlternatorConfig
-    ) -> None:
+    def test_high_concurrency_doesnt_exhaust_pool(self, http_config: Config) -> None:
         """Test high concurrency doesn't exhaust the connection pool."""
         with AlternatorClient(http_config) as client:
             errors: list[Exception] = []
@@ -332,7 +324,7 @@ class TestConnectionPoolingValidation:
 
             assert len(errors) == 0, f"Connection pool exhaustion: {errors}"
 
-    def test_connection_reuse_rate(self, http_config: AlternatorConfig) -> None:
+    def test_connection_reuse_rate(self, http_config: Config) -> None:
         """Test that connections are being reused by verifying consistent throughput.
 
         If connections were not being reused, we'd see degraded performance

--- a/tests/integration/test_key_affinity_operations.py
+++ b/tests/integration/test_key_affinity_operations.py
@@ -13,8 +13,8 @@ import pytest
 
 from alternator import (
     AlternatorClient,
-    AlternatorConfig,
     AlternatorConfigBuilder,
+    Config,
     KeyRouteAffinityMode,
 )
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
@@ -43,7 +43,7 @@ def _create_table(client: AlternatorClient, table_name: str) -> None:
     waiter.wait(TableName=table_name)
 
 
-def _make_rmw_config(table_name: str) -> AlternatorConfig:
+def _make_rmw_config(table_name: str) -> Config:
     """Create config with RMW affinity mode."""
     return (
         AlternatorConfigBuilder()
@@ -57,7 +57,7 @@ def _make_rmw_config(table_name: str) -> AlternatorConfig:
     )
 
 
-def _make_any_write_config(table_name: str) -> AlternatorConfig:
+def _make_any_write_config(table_name: str) -> Config:
     """Create config with ANY_WRITE affinity mode."""
     return (
         AlternatorConfigBuilder()

--- a/tests/integration/test_node_health.py
+++ b/tests/integration/test_node_health.py
@@ -14,8 +14,8 @@ import pytest
 
 from alternator import (
     AlternatorClient,
-    AlternatorConfig,
     AlternatorConfigBuilder,
+    Config,
 )
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
 
@@ -26,9 +26,9 @@ pytestmark = [
 
 
 @pytest.fixture
-def config() -> AlternatorConfig:
+def config() -> Config:
     """Create test configuration."""
-    return AlternatorConfig(
+    return Config(
         seed_hosts=[SCYLLA_HOST],
         port=SCYLLA_PORT,
         scheme="http",
@@ -38,7 +38,7 @@ def config() -> AlternatorConfig:
 class TestNodeDiscovery:
     """Test that the client discovers nodes from the cluster."""
 
-    def test_discovers_multiple_nodes(self, config: AlternatorConfig) -> None:
+    def test_discovers_multiple_nodes(self, config: Config) -> None:
         """Test that the client discovers nodes via /localnodes endpoint."""
         with AlternatorClient(config) as client:
             # Perform a request to trigger node discovery
@@ -52,7 +52,7 @@ class TestNodeDiscovery:
 
     def test_seed_host_used_for_initial_discovery(self) -> None:
         """Test that the seed host is used when initial discovery hasn't completed."""
-        config = AlternatorConfig(
+        config = Config(
             seed_hosts=[SCYLLA_HOST],
             port=SCYLLA_PORT,
             scheme="http",
@@ -67,9 +67,7 @@ class TestNodeDiscovery:
 class TestNodeRecoveryDetection:
     """Test that the client detects when nodes recover via periodic refresh."""
 
-    def test_continuous_operations_after_recovery(
-        self, config: AlternatorConfig
-    ) -> None:
+    def test_continuous_operations_after_recovery(self, config: Config) -> None:
         """Test that operations continue to work after the node list refreshes.
 
         This simulates the background refresh cycle by making requests
@@ -91,7 +89,7 @@ class TestActiveVsQuarantinedNodeTracking:
     current behavior of node list management.
     """
 
-    def test_all_nodes_active_after_startup(self, config: AlternatorConfig) -> None:
+    def test_all_nodes_active_after_startup(self, config: Config) -> None:
         """Test that all discovered nodes are active after client startup."""
         with AlternatorClient(config) as client:
             # Multiple requests should succeed, indicating active nodes
@@ -107,7 +105,7 @@ class TestActiveVsQuarantinedNodeTracking:
             # All requests should succeed when all nodes are healthy
             assert success_count == 50
 
-    def test_node_list_refreshed_periodically(self, config: AlternatorConfig) -> None:
+    def test_node_list_refreshed_periodically(self, config: Config) -> None:
         """Test that the node list is refreshed by the background thread."""
         with AlternatorClient(config) as client:
             # Initial request
@@ -155,7 +153,7 @@ class TestQuarantineAndRelease:
         When multiple seed hosts are provided, the client should try
         them in order for node discovery.
         """
-        config = AlternatorConfig(
+        config = Config(
             seed_hosts=[SCYLLA_HOST, SCYLLA_HOST],  # Same host twice for testing
             port=SCYLLA_PORT,
             scheme="http",
@@ -173,7 +171,7 @@ class TestQuarantineReleaseConcurrency:
     the current round-robin + retry mechanism.
     """
 
-    def test_concurrent_requests_with_refresh(self, config: AlternatorConfig) -> None:
+    def test_concurrent_requests_with_refresh(self, config: Config) -> None:
         """Test that concurrent requests work during node list refresh."""
         import threading
 

--- a/tests/integration/test_sync_client.py
+++ b/tests/integration/test_sync_client.py
@@ -12,9 +12,9 @@ import pytest
 
 from alternator import (
     AlternatorClient,
-    AlternatorConfig,
     AlternatorConfigBuilder,
     CompressionAlgorithm,
+    Config,
     KeyRouteAffinityMode,
     close_client,
     create_client,
@@ -33,9 +33,9 @@ pytestmark = [
 
 
 @pytest.fixture
-def config() -> AlternatorConfig:
+def config() -> Config:
     """Create test configuration."""
-    return AlternatorConfig(
+    return Config(
         seed_hosts=[SCYLLA_HOST],
         port=SCYLLA_PORT,
         scheme="http",
@@ -51,16 +51,14 @@ def table_name() -> str:
 class TestBasicOperations:
     """Test basic DynamoDB operations through the load-balanced client."""
 
-    def test_list_tables(self, config: AlternatorConfig) -> None:
+    def test_list_tables(self, config: Config) -> None:
         """Test listing tables."""
         with AlternatorClient(config) as client:
             response = client.list_tables()
             assert "TableNames" in response
             assert isinstance(response["TableNames"], list)
 
-    def test_create_and_delete_table(
-        self, config: AlternatorConfig, table_name: str
-    ) -> None:
+    def test_create_and_delete_table(self, config: Config, table_name: str) -> None:
         """Test creating and deleting a table."""
         with AlternatorClient(config) as client:
             # Create table
@@ -86,7 +84,7 @@ class TestBasicOperations:
             waiter = client.get_waiter("table_not_exists")
             waiter.wait(TableName=table_name)
 
-    def test_put_and_get_item(self, config: AlternatorConfig, table_name: str) -> None:
+    def test_put_and_get_item(self, config: Config, table_name: str) -> None:
         """Test putting and getting an item."""
         with AlternatorClient(config) as client:
             # Create table
@@ -126,7 +124,7 @@ class TestBasicOperations:
 class TestLoadBalancing:
     """Test load balancing functionality."""
 
-    def test_requests_distributed(self, config: AlternatorConfig) -> None:
+    def test_requests_distributed(self, config: Config) -> None:
         """Test that requests are distributed across nodes."""
         with AlternatorClient(config) as client:
             # Make multiple requests
@@ -248,7 +246,7 @@ class TestKeyAffinity:
 class TestManualResourceManagement:
     """Test manual client lifecycle management."""
 
-    def test_create_and_close(self, config: AlternatorConfig) -> None:
+    def test_create_and_close(self, config: Config) -> None:
         """Test manual create/close without context manager."""
         client = create_client(config)
         try:
@@ -257,7 +255,7 @@ class TestManualResourceManagement:
         finally:
             close_client(client)
 
-    def test_double_close_safe(self, config: AlternatorConfig) -> None:
+    def test_double_close_safe(self, config: Config) -> None:
         """Test that closing twice is safe."""
         client = create_client(config)
         close_client(client)
@@ -267,7 +265,7 @@ class TestManualResourceManagement:
 class TestErrorHandling:
     """Test error handling scenarios."""
 
-    def test_invalid_table_raises(self, config: AlternatorConfig) -> None:
+    def test_invalid_table_raises(self, config: Config) -> None:
         """Test that accessing invalid table raises appropriate error."""
         with (
             AlternatorClient(config) as client,
@@ -547,13 +545,13 @@ class TestTLSConfiguration:
     def test_tls_custom_ca(self) -> None:
         """Test TLS with custom CA certificate (self-signed cert acts as CA).
 
-        Note: TlsConfig affects node discovery (/localnodes). For boto3
+        Note: TLS affects node discovery (/localnodes). For boto3
         connections, we also pass ``verify=<ca_path>`` so botocore uses
         the same CA bundle.
         """
         from pathlib import Path
 
-        from alternator import TlsConfig
+        from alternator import TLS
 
         ca_path = Path(__file__).resolve().parents[1] / "scylla" / "db.crt"
         if not ca_path.exists():
@@ -563,7 +561,7 @@ class TestTLSConfiguration:
             AlternatorConfigBuilder()
             .with_seeds(SCYLLA_HOST)
             .with_port(SCYLLA_HTTPS_PORT)
-            .with_https(TlsConfig.with_custom_ca(ca_path))
+            .with_https(TLS.with_custom_ca(ca_path))
             .build()
         )
 
@@ -574,17 +572,17 @@ class TestTLSConfiguration:
     def test_tls_trust_all(self) -> None:
         """Test TLS with trust-all mode (insecure, for testing only).
 
-        Note: TlsConfig.trust_all() affects node discovery. For boto3
+        Note: TLS.trust_all() affects node discovery. For boto3
         connections, we also pass ``verify=False`` so botocore skips
         certificate verification.
         """
-        from alternator import TlsConfig
+        from alternator import TLS
 
         config = (
             AlternatorConfigBuilder()
             .with_seeds(SCYLLA_HOST)
             .with_port(SCYLLA_HTTPS_PORT)
-            .with_https(TlsConfig.trust_all())
+            .with_https(TLS.trust_all())
             .build()
         )
 
@@ -599,13 +597,13 @@ class TestTLSConfiguration:
         """
         from botocore.exceptions import SSLError
 
-        from alternator import TlsConfig
+        from alternator import TLS
 
         config = (
             AlternatorConfigBuilder()
             .with_seeds(SCYLLA_HOST)
             .with_port(SCYLLA_HTTPS_PORT)
-            .with_https(TlsConfig.system_default())
+            .with_https(TLS.system_default())
             .build()
         )
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -16,9 +16,9 @@ from pathlib import Path
 import pytest
 
 from alternator import (
+    TLS,
     AlternatorClient,
     AlternatorConfigBuilder,
-    TlsConfig,
 )
 from alternator.config import TlsSessionCacheConfig
 from tests.integration import SCYLLA_HOST, SCYLLA_HTTPS_PORT, SKIP_INTEGRATION
@@ -54,7 +54,7 @@ class TestTlsSessionCacheAln:
             .with_seeds(SCYLLA_HOST)
             .with_port(SCYLLA_HTTPS_PORT)
             .with_https(
-                TlsConfig(
+                TLS(
                     custom_ca_cert_paths=(ca_path,),
                     session_cache=TlsSessionCacheConfig(enabled=True),
                 )
@@ -75,7 +75,7 @@ class TestTlsSessionCacheAln:
             .with_seeds(SCYLLA_HOST)
             .with_port(SCYLLA_HTTPS_PORT)
             .with_https(
-                TlsConfig(
+                TLS(
                     custom_ca_cert_paths=(ca_path,),
                     session_cache=TlsSessionCacheConfig(enabled=False),
                 )
@@ -101,7 +101,7 @@ class TestTlsSessionCacheDynamoDbApi:
             .with_seeds(SCYLLA_HOST)
             .with_port(SCYLLA_HTTPS_PORT)
             .with_https(
-                TlsConfig(
+                TLS(
                     custom_ca_cert_paths=(ca_path,),
                     session_cache=TlsSessionCacheConfig(enabled=True),
                 )
@@ -145,7 +145,7 @@ class TestTlsSessionCacheDynamoDbApi:
             .with_seeds(SCYLLA_HOST)
             .with_port(SCYLLA_HTTPS_PORT)
             .with_https(
-                TlsConfig(
+                TLS(
                     custom_ca_cert_paths=(ca_path,),
                     session_cache=TlsSessionCacheConfig(enabled=False),
                 )
@@ -204,7 +204,7 @@ class TestSslKeyLogFile:
                     AlternatorConfigBuilder()
                     .with_seeds(SCYLLA_HOST)
                     .with_port(SCYLLA_HTTPS_PORT)
-                    .with_https(TlsConfig.with_custom_ca(ca_path))
+                    .with_https(TLS.with_custom_ca(ca_path))
                     .build()
                 )
 
@@ -243,7 +243,7 @@ class TestSslKeyLogFile:
                     AlternatorConfigBuilder()
                     .with_seeds(SCYLLA_HOST)
                     .with_port(SCYLLA_HTTPS_PORT)
-                    .with_https(TlsConfig.with_custom_ca(ca_path))
+                    .with_https(TLS.with_custom_ca(ca_path))
                     .build()
                 )
 
@@ -271,7 +271,7 @@ class TestTlsSessionCacheConfig:
         from alternator.core.tls import create_ssl_context
 
         # Enabled
-        tls_enabled = TlsConfig(
+        tls_enabled = TLS(
             custom_ca_cert_paths=(ca_path,),
             session_cache=TlsSessionCacheConfig(enabled=True),
         )
@@ -279,7 +279,7 @@ class TestTlsSessionCacheConfig:
         assert not (ctx_enabled.options & ssl.OP_NO_TICKET)
 
         # Disabled
-        tls_disabled = TlsConfig(
+        tls_disabled = TLS(
             custom_ca_cert_paths=(ca_path,),
             session_cache=TlsSessionCacheConfig(enabled=False),
         )

--- a/tests/integration/test_vector.py
+++ b/tests/integration/test_vector.py
@@ -15,8 +15,8 @@ import pytest
 
 from alternator import (
     AlternatorClient,
-    AlternatorConfig,
     AlternatorResource,
+    Config,
 )
 from alternator.vector import Vector
 from tests.integration import (
@@ -31,7 +31,7 @@ pytestmark = [
 ]
 
 
-config = AlternatorConfig(seed_hosts=[SCYLLA_HOST], port=SCYLLA_PORT, scheme="http")
+config = Config(seed_hosts=[SCYLLA_HOST], port=SCYLLA_PORT, scheme="http")
 
 
 def table_name() -> str:

--- a/tests/unit/test_async_manager.py
+++ b/tests/unit/test_async_manager.py
@@ -6,15 +6,15 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from alternator.async_client import AsyncPartitionKeyCache
-from alternator.config import AlternatorConfig
+from alternator.config import Config
 from alternator.core.live_nodes import AsyncLiveNodesManager, NoNodesAvailableError
 from alternator.core.routing_scope import ClusterScope, DatacenterScope
 
 
 @pytest.fixture
-def config() -> AlternatorConfig:
+def config() -> Config:
     """Create test config."""
-    return AlternatorConfig(
+    return Config(
         seed_hosts=["192.168.1.1"],
         port=8000,
         scheme="http",
@@ -25,7 +25,7 @@ class TestAsyncLiveNodesManager:
     """Tests for AsyncLiveNodesManager."""
 
     @pytest.mark.asyncio
-    async def test_start_stop_lifecycle(self, config: AlternatorConfig) -> None:
+    async def test_start_stop_lifecycle(self, config: Config) -> None:
         """Test manager start/stop lifecycle."""
 
         async def mock_fetch(url: str) -> list[str]:
@@ -45,7 +45,7 @@ class TestAsyncLiveNodesManager:
         assert manager._refresh_task is None
 
     @pytest.mark.asyncio
-    async def test_next_node_uri_format(self, config: AlternatorConfig) -> None:
+    async def test_next_node_uri_format(self, config: Config) -> None:
         """Test next_node_uri returns correctly formatted URI."""
 
         async def mock_fetch(url: str) -> list[str]:
@@ -59,9 +59,7 @@ class TestAsyncLiveNodesManager:
         assert ":8000" in uri
 
     @pytest.mark.asyncio
-    async def test_next_node_uri_raises_when_empty(
-        self, config: AlternatorConfig
-    ) -> None:
+    async def test_next_node_uri_raises_when_empty(self, config: Config) -> None:
         """Test next_node_uri raises when no nodes available."""
 
         async def mock_fetch(url: str) -> list[str]:
@@ -84,7 +82,7 @@ class TestAsyncLiveNodesManager:
                 return []
             return ["192.168.1.1"]
 
-        config = AlternatorConfig(
+        config = Config(
             seed_hosts=["192.168.1.1"],
             port=8000,
             routing_scope=DatacenterScope(datacenter="dc1"),
@@ -100,7 +98,7 @@ class TestAsyncLiveNodesManager:
         assert "dc=" not in call_urls[1]
 
     @pytest.mark.asyncio
-    async def test_url_construction(self, config: AlternatorConfig) -> None:
+    async def test_url_construction(self, config: Config) -> None:
         """Test build_localnodes_url constructs correct URL."""
         manager = AsyncLiveNodesManager(config, lambda _: [])
 
@@ -108,9 +106,7 @@ class TestAsyncLiveNodesManager:
         assert url == "http://192.168.1.1:8000/localnodes"
 
     @pytest.mark.asyncio
-    async def test_url_construction_with_dc_scope(
-        self, config: AlternatorConfig
-    ) -> None:
+    async def test_url_construction_with_dc_scope(self, config: Config) -> None:
         """Test URL construction with datacenter scope."""
         manager = AsyncLiveNodesManager(config, lambda _: [])
 
@@ -120,7 +116,7 @@ class TestAsyncLiveNodesManager:
         assert url == "http://192.168.1.1:8000/localnodes?dc=dc1"
 
     @pytest.mark.asyncio
-    async def test_round_robin_selection(self, config: AlternatorConfig) -> None:
+    async def test_round_robin_selection(self, config: Config) -> None:
         """Test round-robin selection works."""
 
         async def mock_fetch(url: str) -> list[str]:
@@ -134,9 +130,7 @@ class TestAsyncLiveNodesManager:
         assert nodes == ["a", "b", "c", "a", "b", "c"]
 
     @pytest.mark.asyncio
-    async def test_background_refresh_updates_nodes(
-        self, config: AlternatorConfig
-    ) -> None:
+    async def test_background_refresh_updates_nodes(self, config: Config) -> None:
         """Test that background refresh updates node list."""
         call_count = 0
 
@@ -148,7 +142,7 @@ class TestAsyncLiveNodesManager:
         # Config with fast refresh
         from alternator.config import NodeListPollingConfig
 
-        fast_config = AlternatorConfig(
+        fast_config = Config(
             seed_hosts=["192.168.1.1"],
             port=8000,
             node_list_polling=NodeListPollingConfig(active_interval_ms=50),
@@ -174,9 +168,7 @@ class TestAsyncLiveNodesManager:
         assert manager.nodes.nodes != initial_nodes
 
     @pytest.mark.asyncio
-    async def test_refresh_failure_keeps_existing_nodes(
-        self, config: AlternatorConfig
-    ) -> None:
+    async def test_refresh_failure_keeps_existing_nodes(self, config: Config) -> None:
         """Test that refresh failure preserves existing node list."""
         first_call = True
 

--- a/tests/unit/test_boto_config.py
+++ b/tests/unit/test_boto_config.py
@@ -5,19 +5,19 @@ import contextlib
 from botocore import UNSIGNED
 
 from alternator.client import _create_boto_config
-from alternator.config import AlternatorConfig, RetryConfig, RetryMode
+from alternator.config import Config, RetryConfig, RetryMode
 
 
 class TestCreateBotoConfig:
     """Tests for _create_boto_config."""
 
-    def _make_config(self, **overrides: object) -> AlternatorConfig:
+    def _make_config(self, **overrides: object) -> Config:
         defaults = {
             "seed_hosts": ["localhost"],
             "port": 9998,
         }
         defaults.update(overrides)
-        return AlternatorConfig(**defaults)  # type: ignore[arg-type]  -- test helper
+        return Config(**defaults)  # type: ignore[arg-type]  -- test helper
 
     def test_unsigned_when_no_credentials(self) -> None:
         """Without credentials the signature must be UNSIGNED."""
@@ -35,7 +35,7 @@ class TestCreateBotoConfig:
         assert "signature_version" not in boto_config._user_provided_options
 
     def test_retry_settings_propagated(self) -> None:
-        """Retry config from AlternatorConfig flows into BotoConfig."""
+        """Retry config from Config flows into BotoConfig."""
         config = self._make_config(
             retries=RetryConfig(max_attempts=5, mode=RetryMode.ADAPTIVE),
         )
@@ -46,7 +46,7 @@ class TestCreateBotoConfig:
         assert retries["mode"] == "adaptive"
 
     def test_pool_connections_propagated(self) -> None:
-        """max_pool_connections from AlternatorConfig flows into BotoConfig."""
+        """max_pool_connections from Config flows into BotoConfig."""
         config = self._make_config(max_pool_connections=42)
         boto_config = _create_boto_config(config, auth_enabled=False)
 
@@ -88,10 +88,10 @@ class TestUnsignedRequestNoAuthHeader:
         assert "Authorization" not in captured[0].headers
 
     @staticmethod
-    def _make_config(**overrides: object) -> AlternatorConfig:
+    def _make_config(**overrides: object) -> Config:
         defaults = {
             "seed_hosts": ["localhost"],
             "port": 9998,
         }
         defaults.update(overrides)
-        return AlternatorConfig(**defaults)  # type: ignore[arg-type]  -- test helper
+        return Config(**defaults)  # type: ignore[arg-type]  -- test helper

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,9 +5,11 @@ from pathlib import Path
 import pytest
 
 from alternator.config import (
+    TLS,
     AlternatorConfig,
     AlternatorConfigBuilder,
     CompressionAlgorithm,
+    Config,
     KeyRouteAffinityConfig,
     KeyRouteAffinityMode,
     TlsConfig,
@@ -18,11 +20,11 @@ from alternator.exceptions import ConfigurationError
 
 
 class TestAlternatorConfig:
-    """Tests for AlternatorConfig validation."""
+    """Tests for Config validation."""
 
     def test_valid_config(self) -> None:
         """Test creating a valid configuration."""
-        config = AlternatorConfig(
+        config = Config(
             seed_hosts=["192.168.1.1", "192.168.1.2"],
             port=8000,
         )
@@ -35,19 +37,19 @@ class TestAlternatorConfig:
         with pytest.raises(
             ConfigurationError, match="At least one seed host is required"
         ):
-            AlternatorConfig(seed_hosts=[], port=8000)
+            Config(seed_hosts=[], port=8000)
 
     def test_missing_seeds_also_raises_value_error(self) -> None:
         """Test backward compat: ConfigurationError is also a ValueError."""
         with pytest.raises(ValueError, match="At least one seed host is required"):
-            AlternatorConfig(seed_hosts=[], port=8000)
+            Config(seed_hosts=[], port=8000)
 
     def test_invalid_scheme_raises(self) -> None:
         """Test that invalid scheme raises ConfigurationError."""
         with pytest.raises(
             ConfigurationError, match="scheme must be 'http' or 'https'"
         ):
-            AlternatorConfig(
+            Config(
                 seed_hosts=["localhost"],
                 port=8000,
                 scheme="ftp",
@@ -56,21 +58,21 @@ class TestAlternatorConfig:
     def test_invalid_port_zero_raises(self) -> None:
         """Test that port 0 raises ConfigurationError."""
         with pytest.raises(ConfigurationError, match="port must be 1-65535"):
-            AlternatorConfig(seed_hosts=["localhost"], port=0)
+            Config(seed_hosts=["localhost"], port=0)
 
     def test_invalid_port_negative_raises(self) -> None:
         """Test that negative port raises ConfigurationError."""
         with pytest.raises(ConfigurationError, match="port must be 1-65535"):
-            AlternatorConfig(seed_hosts=["localhost"], port=-1)
+            Config(seed_hosts=["localhost"], port=-1)
 
     def test_invalid_port_too_large_raises(self) -> None:
         """Test that port > 65535 raises ConfigurationError."""
         with pytest.raises(ConfigurationError, match="port must be 1-65535"):
-            AlternatorConfig(seed_hosts=["localhost"], port=65536)
+            Config(seed_hosts=["localhost"], port=65536)
 
     def test_default_values(self) -> None:
         """Test default configuration values."""
-        config = AlternatorConfig(seed_hosts=["localhost"], port=8000)
+        config = Config(seed_hosts=["localhost"], port=8000)
         assert config.scheme == "http"
         assert config.request_compression.algorithm == CompressionAlgorithm.NONE
         assert config.request_compression.min_size_bytes == 1024
@@ -79,6 +81,40 @@ class TestAlternatorConfig:
         assert config.node_list_polling.active_interval_ms == 1000
         assert config.node_list_polling.idle_interval_ms == 60000
         assert isinstance(config.routing_scope, ClusterScope)
+
+
+class TestDeprecatedConfigNames:
+    """Tests for deprecated compatibility names."""
+
+    def test_alternator_config_warns_and_builds_config(self) -> None:
+        """Test deprecated AlternatorConfig compatibility name."""
+        with pytest.warns(DeprecationWarning, match="AlternatorConfig"):
+            config = AlternatorConfig(seed_hosts=["localhost"], port=8000)
+
+        assert isinstance(config, Config)
+        assert config.seed_hosts == ["localhost"]
+
+    def test_tls_config_warns_and_builds_tls(self) -> None:
+        """Test deprecated TlsConfig compatibility name."""
+        with pytest.warns(DeprecationWarning, match="TlsConfig"):
+            tls = TlsConfig()
+
+        assert isinstance(tls, TLS)
+        assert tls.trust_system_ca_certs is True
+
+    def test_deprecated_tls_factory_warns(self) -> None:
+        """Test deprecated TlsConfig factory methods remain usable."""
+        with pytest.warns(DeprecationWarning, match="TlsConfig"):
+            tls = TlsConfig.system_default()
+
+        assert isinstance(tls, TLS)
+
+    def test_top_level_preferred_exports(self) -> None:
+        """Test top-level package exports preferred names."""
+        import alternator
+
+        assert alternator.Config is Config
+        assert alternator.TLS is TLS
 
 
 class TestAlternatorConfigBuilder:
@@ -117,7 +153,7 @@ class TestAlternatorConfigBuilder:
 
     def test_build_with_https_and_tls_config(self) -> None:
         """Test building config with HTTPS and custom TLS."""
-        tls = TlsConfig.trust_all()
+        tls = TLS.trust_all()
         config = (
             AlternatorConfigBuilder()
             .with_seeds("localhost")
@@ -243,24 +279,24 @@ class TestAlternatorConfigBuilder:
 
 
 class TestTlsConfig:
-    """Tests for TlsConfig factory methods."""
+    """Tests for TLS factory methods."""
 
     def test_trust_all(self) -> None:
-        """Test TlsConfig.trust_all() factory."""
-        tls = TlsConfig.trust_all()
+        """Test TLS.trust_all() factory."""
+        tls = TLS.trust_all()
         assert tls.trust_all_certificates is True
         assert tls.verify_hostname is False
 
     def test_system_default(self) -> None:
-        """Test TlsConfig.system_default() factory."""
-        tls = TlsConfig.system_default()
+        """Test TLS.system_default() factory."""
+        tls = TLS.system_default()
         assert tls.trust_system_ca_certs is True
         assert tls.trust_all_certificates is False
         assert tls.verify_hostname is True
 
     def test_with_custom_ca(self) -> None:
-        """Test TlsConfig.with_custom_ca() factory."""
-        tls = TlsConfig.with_custom_ca(
+        """Test TLS.with_custom_ca() factory."""
+        tls = TLS.with_custom_ca(
             Path("/etc/ssl/ca1.pem"),
             Path("/etc/ssl/ca2.pem"),
         )
@@ -269,7 +305,7 @@ class TestTlsConfig:
 
     def test_default_session_cache(self) -> None:
         """Test default session cache configuration."""
-        tls = TlsConfig()
+        tls = TLS()
         assert tls.session_cache.enabled is True
         assert tls.session_cache.cache_size == 1024
         assert tls.session_cache.timeout_seconds == 86400

--- a/tests/unit/test_headers.py
+++ b/tests/unit/test_headers.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock
 
-from alternator.config import AlternatorConfig
+from alternator.config import Config
 from alternator.core.handlers import _register_alternator_handlers
 from alternator.core.headers import (
     AUTH_HEADERS,
@@ -196,11 +196,11 @@ class TestCompressionHeaders:
         assert "Content-Encoding" in COMPRESSION_HEADERS
 
 
-def _make_config(*, optimize_headers: bool = True) -> AlternatorConfig:
+def _make_config(*, optimize_headers: bool = True) -> Config:
     """Create a minimal config for handler registration tests."""
     from alternator.config import HeaderOptimizationConfig
 
-    return AlternatorConfig(
+    return Config(
         seed_hosts=("localhost",),
         port=8000,
         header_optimization=HeaderOptimizationConfig(enabled=optimize_headers),

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 import pytest
 
 from alternator._http import create_ssl_context, create_sync_http_fetcher
-from alternator.config import TlsConfig, TlsSessionCacheConfig
+from alternator.config import TLS, TlsSessionCacheConfig
 
 
 class MockHTTPHandler(BaseHTTPRequestHandler):
@@ -162,7 +162,7 @@ class TestCreateSslContext:
 
     def test_trust_all_disables_verification(self) -> None:
         """Test trust_all mode disables certificate verification."""
-        tls_config = TlsConfig.trust_all()
+        tls_config = TLS.trust_all()
         context = create_ssl_context(tls_config)
 
         assert context.verify_mode == ssl.CERT_NONE
@@ -170,7 +170,7 @@ class TestCreateSslContext:
 
     def test_system_default_enables_verification(self) -> None:
         """Test system_default enables certificate verification."""
-        tls_config = TlsConfig.system_default()
+        tls_config = TLS.system_default()
         context = create_ssl_context(tls_config)
 
         assert context.verify_mode == ssl.CERT_REQUIRED
@@ -186,13 +186,13 @@ class TestCreateSslContext:
         # This is a valid PEM structure but not a real CA
         # We'll test the path is called correctly using mock
         with patch("ssl.SSLContext.load_verify_locations") as mock_load:
-            tls_config = TlsConfig.with_custom_ca(cert_file)
+            tls_config = TLS.with_custom_ca(cert_file)
             create_ssl_context(tls_config)
             mock_load.assert_called_once_with(str(cert_file))
 
     def test_verify_hostname_can_be_disabled(self) -> None:
         """Test hostname verification can be disabled."""
-        tls_config = TlsConfig(
+        tls_config = TLS(
             trust_system_ca_certs=True,
             verify_hostname=False,
         )
@@ -202,7 +202,7 @@ class TestCreateSslContext:
 
     def test_session_cache_enabled_by_default(self) -> None:
         """Test session caching is enabled by default."""
-        tls_config = TlsConfig.system_default()
+        tls_config = TLS.system_default()
         context = create_ssl_context(tls_config)
 
         # OP_NO_TICKET should NOT be set when session cache is enabled
@@ -215,7 +215,7 @@ class TestCreateSslContext:
             cache_size=512,
             timeout_seconds=3600,
         )
-        tls_config = TlsConfig(session_cache=cache_config)
+        tls_config = TLS(session_cache=cache_config)
         context = create_ssl_context(tls_config)
 
         # Should not raise and should have reasonable settings
@@ -224,7 +224,7 @@ class TestCreateSslContext:
     def test_session_cache_disabled(self) -> None:
         """Test session caching can be disabled."""
         cache_config = TlsSessionCacheConfig(enabled=False)
-        tls_config = TlsConfig(session_cache=cache_config)
+        tls_config = TLS(session_cache=cache_config)
         context = create_ssl_context(tls_config)
 
         # OP_NO_TICKET should be set when session cache is disabled

--- a/tests/unit/test_live_nodes.py
+++ b/tests/unit/test_live_nodes.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
-from alternator.config import AlternatorConfig, NodeListPollingConfig
+from alternator.config import Config, NodeListPollingConfig
 from alternator.core.live_nodes import (
     LiveNodesManagerCore,
     NodeList,
@@ -117,9 +117,9 @@ class TestLiveNodesManagerCore:
     """Tests for LiveNodesManagerCore."""
 
     @pytest.fixture
-    def config(self) -> AlternatorConfig:
+    def config(self) -> Config:
         """Create test configuration."""
-        return AlternatorConfig(
+        return Config(
             seed_hosts=["localhost"],
             port=8000,
             node_list_polling=NodeListPollingConfig(
@@ -127,13 +127,13 @@ class TestLiveNodesManagerCore:
             ),
         )
 
-    def test_initial_state_empty(self, config: AlternatorConfig) -> None:
+    def test_initial_state_empty(self, config: Config) -> None:
         """Test initial state has empty node list."""
         manager = LiveNodesManagerCore(config)
         assert len(manager.nodes) == 0
         assert manager.nodes.scope_name == ""
 
-    def test_update_nodes(self, config: AlternatorConfig) -> None:
+    def test_update_nodes(self, config: Config) -> None:
         """Test updating node list."""
         manager = LiveNodesManagerCore(config)
         scope = ClusterScope()
@@ -145,7 +145,7 @@ class TestLiveNodesManagerCore:
         assert "host1" in manager.nodes.nodes
         assert "host2" in manager.nodes.nodes
 
-    def test_next_node_round_robin(self, config: AlternatorConfig) -> None:
+    def test_next_node_round_robin(self, config: Config) -> None:
         """Test next_node uses round-robin selection."""
         manager = LiveNodesManagerCore(config)
         manager.update_nodes(["a", "b", "c"], ClusterScope())
@@ -153,12 +153,12 @@ class TestLiveNodesManagerCore:
         selections = [manager.next_node() for _ in range(6)]
         assert selections == ["a", "b", "c", "a", "b", "c"]
 
-    def test_next_node_returns_none_when_empty(self, config: AlternatorConfig) -> None:
+    def test_next_node_returns_none_when_empty(self, config: Config) -> None:
         """Test next_node returns None when no nodes available."""
         manager = LiveNodesManagerCore(config)
         assert manager.next_node() is None
 
-    def test_active_refresh_interval(self, config: AlternatorConfig) -> None:
+    def test_active_refresh_interval(self, config: Config) -> None:
         """Test active refresh interval when recently active."""
         manager = LiveNodesManagerCore(config)
         manager.update_nodes(["host1"], ClusterScope())
@@ -170,9 +170,9 @@ class TestLiveNodesManagerCore:
         interval = manager.get_refresh_interval_seconds()
         assert interval == 0.1  # 100ms
 
-    def test_idle_refresh_interval(self, config: AlternatorConfig) -> None:
+    def test_idle_refresh_interval(self, config: Config) -> None:
         """Test idle refresh interval after inactivity."""
-        config_short = AlternatorConfig(
+        config_short = Config(
             seed_hosts=["localhost"],
             port=8000,
             node_list_polling=NodeListPollingConfig(
@@ -188,7 +188,7 @@ class TestLiveNodesManagerCore:
         interval = manager.get_refresh_interval_seconds()
         assert interval == 0.2  # 200ms (idle)
 
-    def test_nodes_property_thread_safe(self, config: AlternatorConfig) -> None:
+    def test_nodes_property_thread_safe(self, config: Config) -> None:
         """Test nodes property is thread-safe."""
         manager = LiveNodesManagerCore(config)
         results: list[NodeList] = []
@@ -247,7 +247,7 @@ class TestRoundRobinConcurrency:
 
     def test_concurrent_update_and_select(self) -> None:
         """Test concurrent node updates and selections."""
-        config = AlternatorConfig(
+        config = Config(
             seed_hosts=["localhost"],
             port=8000,
         )

--- a/tests/unit/test_network_failures.py
+++ b/tests/unit/test_network_failures.py
@@ -12,7 +12,7 @@ from threading import Thread
 import pytest
 
 from alternator._http import create_sync_http_fetcher
-from alternator.config import AlternatorConfig
+from alternator.config import Config
 from alternator.core.live_nodes import SyncLiveNodesManager
 
 # ---------------------------------------------------------------------------
@@ -141,10 +141,10 @@ class TestSyncManagerNetworkFailures:
     """Network failure scenarios for the SyncLiveNodesManager."""
 
     @pytest.fixture
-    def config(self) -> AlternatorConfig:
+    def config(self) -> Config:
         from alternator.config import NodeListPollingConfig
 
-        return AlternatorConfig(
+        return Config(
             seed_hosts=["192.168.1.1"],
             port=8000,
             node_list_polling=NodeListPollingConfig(
@@ -152,7 +152,7 @@ class TestSyncManagerNetworkFailures:
             ),
         )
 
-    def test_manager_survives_fetch_exception(self, config: AlternatorConfig) -> None:
+    def test_manager_survives_fetch_exception(self, config: Config) -> None:
         """Manager keeps existing nodes when fetcher raises."""
         call_count = 0
 
@@ -171,7 +171,7 @@ class TestSyncManagerNetworkFailures:
         assert manager.refresh_nodes() is False
         assert len(manager.nodes) == 2
 
-    def test_manager_survives_timeout_exception(self, config: AlternatorConfig) -> None:
+    def test_manager_survives_timeout_exception(self, config: Config) -> None:
         """Manager keeps existing nodes when fetcher times out."""
         call_count = 0
 
@@ -190,7 +190,7 @@ class TestSyncManagerNetworkFailures:
 
     def test_manager_all_seeds_fail(self) -> None:
         """Manager returns False when all seed hosts fail."""
-        config = AlternatorConfig(
+        config = Config(
             seed_hosts=["host1", "host2", "host3"],
             port=8000,
         )
@@ -204,7 +204,7 @@ class TestSyncManagerNetworkFailures:
 
     def test_manager_partial_seed_failure(self) -> None:
         """Manager succeeds if at least one seed host responds."""
-        config = AlternatorConfig(
+        config = Config(
             seed_hosts=["bad-host", "good-host"],
             port=8000,
         )

--- a/tests/unit/test_sync_manager.py
+++ b/tests/unit/test_sync_manager.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 
 import pytest
 
-from alternator.config import AlternatorConfig
+from alternator.config import Config
 from alternator.core.live_nodes import NoNodesAvailableError, SyncLiveNodesManager
 from alternator.core.routing_scope import DatacenterScope
 
@@ -14,11 +14,11 @@ class TestSyncLiveNodesManager:
     """Tests for SyncLiveNodesManager."""
 
     @pytest.fixture
-    def config(self) -> AlternatorConfig:
+    def config(self) -> Config:
         """Create test configuration."""
         from alternator.config import NodeListPollingConfig
 
-        return AlternatorConfig(
+        return Config(
             seed_hosts=["192.168.1.1"],
             port=8000,
             node_list_polling=NodeListPollingConfig(
@@ -26,7 +26,7 @@ class TestSyncLiveNodesManager:
             ),
         )
 
-    def test_start_stop_lifecycle(self, config: AlternatorConfig) -> None:
+    def test_start_stop_lifecycle(self, config: Config) -> None:
         """Test manager starts and stops cleanly."""
         nodes_returned: list[str] = ["node1", "node2"]
 
@@ -45,7 +45,7 @@ class TestSyncLiveNodesManager:
         # Stop should complete without hanging
         manager.stop()
 
-    def test_next_node_uri_format(self, config: AlternatorConfig) -> None:
+    def test_next_node_uri_format(self, config: Config) -> None:
         """Test next_node_uri returns correct format."""
 
         def mock_fetch(url: str) -> Sequence[str]:
@@ -60,7 +60,7 @@ class TestSyncLiveNodesManager:
         assert ":8000" in uri
         assert "192.168.1" in uri
 
-    def test_next_node_uri_raises_when_empty(self, config: AlternatorConfig) -> None:
+    def test_next_node_uri_raises_when_empty(self, config: Config) -> None:
         """Test next_node_uri raises when no nodes available."""
 
         def mock_fetch(url: str) -> Sequence[str]:
@@ -71,9 +71,9 @@ class TestSyncLiveNodesManager:
         with pytest.raises(NoNodesAvailableError):
             manager.next_node_uri()
 
-    def test_fallback_chain_on_empty(self, config: AlternatorConfig) -> None:
+    def test_fallback_chain_on_empty(self, config: Config) -> None:
         """Test fallback chain is used when scope returns empty."""
-        dc_config = AlternatorConfig(
+        dc_config = Config(
             seed_hosts=["192.168.1.1"],
             port=8000,
             routing_scope=DatacenterScope(datacenter="dc1"),
@@ -96,7 +96,7 @@ class TestSyncLiveNodesManager:
         assert "dc=dc1" in calls[0]
         assert "dc=" not in calls[1]
 
-    def test_url_construction(self, config: AlternatorConfig) -> None:
+    def test_url_construction(self, config: Config) -> None:
         """Test URL is constructed correctly."""
         captured_url: list[str] = []
 
@@ -111,7 +111,7 @@ class TestSyncLiveNodesManager:
 
     def test_url_construction_with_dc_scope(self) -> None:
         """Test URL includes query string for datacenter scope."""
-        config = AlternatorConfig(
+        config = Config(
             seed_hosts=["host1"],
             port=9000,
             routing_scope=DatacenterScope(datacenter="us-east"),
@@ -127,7 +127,7 @@ class TestSyncLiveNodesManager:
 
         assert "?dc=us-east" in captured_url[0]
 
-    def test_background_refresh_updates_nodes(self, config: AlternatorConfig) -> None:
+    def test_background_refresh_updates_nodes(self, config: Config) -> None:
         """Test background thread updates nodes."""
         call_count = 0
         nodes_list = [["initial"], ["updated1", "updated2"]]
@@ -152,7 +152,7 @@ class TestSyncLiveNodesManager:
 
     def test_https_url_construction(self) -> None:
         """Test HTTPS URL is constructed correctly."""
-        config = AlternatorConfig(
+        config = Config(
             seed_hosts=["secure-host"],
             port=8443,
             scheme="https",
@@ -169,7 +169,7 @@ class TestSyncLiveNodesManager:
         assert captured_url[0].startswith("https://")
         assert ":8443" in captured_url[0]
 
-    def test_round_robin_selection(self, config: AlternatorConfig) -> None:
+    def test_round_robin_selection(self, config: Config) -> None:
         """Test nodes are selected in round-robin order."""
 
         def mock_fetch(url: str) -> Sequence[str]:
@@ -183,9 +183,7 @@ class TestSyncLiveNodesManager:
 
         assert hosts == ["node1", "node2", "node3", "node1", "node2", "node3"]
 
-    def test_refresh_failure_keeps_existing_nodes(
-        self, config: AlternatorConfig
-    ) -> None:
+    def test_refresh_failure_keeps_existing_nodes(self, config: Config) -> None:
         """Test failed refresh keeps existing nodes."""
         call_count = 0
 

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from alternator.config import TlsConfig, TlsSessionCacheConfig
+from alternator.config import TLS, TlsSessionCacheConfig
 from alternator.core.tls import create_ssl_context
 
 
@@ -14,7 +14,7 @@ class TestCreateSslContext:
 
     def test_system_default(self) -> None:
         """Test creating SSL context with system defaults."""
-        tls_config = TlsConfig.system_default()
+        tls_config = TLS.system_default()
         ctx = create_ssl_context(tls_config)
 
         assert isinstance(ctx, ssl.SSLContext)
@@ -23,7 +23,7 @@ class TestCreateSslContext:
 
     def test_trust_all_insecure(self) -> None:
         """Test creating insecure SSL context that trusts all certificates."""
-        tls_config = TlsConfig.trust_all()
+        tls_config = TLS.trust_all()
         ctx = create_ssl_context(tls_config)
 
         assert isinstance(ctx, ssl.SSLContext)
@@ -32,21 +32,21 @@ class TestCreateSslContext:
 
     def test_hostname_verification_disabled(self) -> None:
         """Test disabling hostname verification."""
-        tls_config = TlsConfig(verify_hostname=False)
+        tls_config = TLS(verify_hostname=False)
         ctx = create_ssl_context(tls_config)
 
         assert ctx.check_hostname is False
 
     def test_hostname_verification_enabled(self) -> None:
         """Test enabling hostname verification (default)."""
-        tls_config = TlsConfig(verify_hostname=True)
+        tls_config = TLS(verify_hostname=True)
         ctx = create_ssl_context(tls_config)
 
         assert ctx.check_hostname is True
 
     def test_session_cache_enabled(self) -> None:
         """Test session tickets enabled when session cache is enabled."""
-        tls_config = TlsConfig(session_cache=TlsSessionCacheConfig(enabled=True))
+        tls_config = TLS(session_cache=TlsSessionCacheConfig(enabled=True))
         ctx = create_ssl_context(tls_config)
 
         # OP_NO_TICKET should NOT be set (tickets enabled)
@@ -54,7 +54,7 @@ class TestCreateSslContext:
 
     def test_session_cache_disabled(self) -> None:
         """Test session tickets disabled when session cache is disabled."""
-        tls_config = TlsConfig(session_cache=TlsSessionCacheConfig(enabled=False))
+        tls_config = TLS(session_cache=TlsSessionCacheConfig(enabled=False))
         ctx = create_ssl_context(tls_config)
 
         # OP_NO_TICKET should be set (tickets disabled)
@@ -69,7 +69,7 @@ class TestCreateSslContext:
         # Test with system CA files if available
         ca_file = ssl_module.get_default_verify_paths().cafile
         if ca_file and Path(ca_file).exists():
-            tls_config = TlsConfig.with_custom_ca(Path(ca_file))
+            tls_config = TLS.with_custom_ca(Path(ca_file))
             ctx = create_ssl_context(tls_config)
             assert isinstance(ctx, ssl.SSLContext)
         else:
@@ -78,7 +78,7 @@ class TestCreateSslContext:
 
     def test_custom_ca_with_nonexistent_path(self) -> None:
         """Test error when custom CA cert path doesn't exist."""
-        tls_config = TlsConfig(custom_ca_cert_paths=[Path("/nonexistent/ca.pem")])
+        tls_config = TLS(custom_ca_cert_paths=[Path("/nonexistent/ca.pem")])
 
         with pytest.raises(FileNotFoundError):
             create_ssl_context(tls_config)
@@ -91,7 +91,7 @@ class TestCreateSslContext:
         ca_file = ssl_module.get_default_verify_paths().cafile
         if ca_file and Path(ca_file).exists():
             # Test with the same cert twice (valid scenario)
-            tls_config = TlsConfig(custom_ca_cert_paths=(Path(ca_file), Path(ca_file)))
+            tls_config = TLS(custom_ca_cert_paths=(Path(ca_file), Path(ca_file)))
             ctx = create_ssl_context(tls_config)
             assert isinstance(ctx, ssl.SSLContext)
         else:
@@ -103,7 +103,7 @@ class TestCreateSslContext:
 
         ca_file = ssl_module.get_default_verify_paths().cafile
         if ca_file and Path(ca_file).exists():
-            tls_config = TlsConfig(
+            tls_config = TLS(
                 custom_ca_cert_paths=[Path(ca_file)],
                 trust_system_ca_certs=False,
             )
@@ -114,11 +114,11 @@ class TestCreateSslContext:
 
 
 class TestTlsConfig:
-    """Tests for TlsConfig class."""
+    """Tests for TLS class."""
 
     def test_default_values(self) -> None:
-        """Test TlsConfig default values."""
-        config = TlsConfig()
+        """Test TLS default values."""
+        config = TLS()
 
         assert config.custom_ca_cert_paths == ()
         assert config.trust_system_ca_certs is True
@@ -127,25 +127,25 @@ class TestTlsConfig:
         assert config.session_cache.enabled is True
 
     def test_trust_all_factory(self) -> None:
-        """Test TlsConfig.trust_all() factory method."""
-        config = TlsConfig.trust_all()
+        """Test TLS.trust_all() factory method."""
+        config = TLS.trust_all()
 
         assert config.trust_all_certificates is True
         assert config.verify_hostname is False
 
     def test_system_default_factory(self) -> None:
-        """Test TlsConfig.system_default() factory method."""
-        config = TlsConfig.system_default()
+        """Test TLS.system_default() factory method."""
+        config = TLS.system_default()
 
         assert config.trust_system_ca_certs is True
         assert config.trust_all_certificates is False
 
     def test_with_custom_ca_factory(self) -> None:
-        """Test TlsConfig.with_custom_ca() factory method."""
+        """Test TLS.with_custom_ca() factory method."""
         path1 = Path("/path/to/ca1.pem")
         path2 = Path("/path/to/ca2.pem")
 
-        config = TlsConfig.with_custom_ca(path1, path2)
+        config = TLS.with_custom_ca(path1, path2)
 
         assert config.custom_ca_cert_paths == (path1, path2)
 


### PR DESCRIPTION
Closes #26

## Summary
- expose preferred `Config` and `TLS` names
- keep `AlternatorConfig` and `TlsConfig` working with `DeprecationWarning`
- update docs/examples/tests to prefer the new names

## Tests
- `make lint`
- `make test-unit`