### PR TITLE
Add explicit Alternator auth API

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,12 +127,37 @@ config = (
 | `min_compression_size_bytes` | `int` | `1024` | Minimum body size to compress |
 | `optimize_headers` | `bool` | `False` | Enable header filtering |
 | `headers_whitelist` | `frozenset[str]` | `None` | Additional headers to keep |
-| `authentication_enabled` | `bool` | `True` | Include auth headers |
 | `tls` | `TLS` | system default | TLS configuration |
 | `key_affinity` | `KeyRouteAffinityConfig` | `NONE` | Key-based routing |
 | `max_pool_connections` | `int` | `200` | Max connections per host |
 | `active_refresh_interval_ms` | `int` | `1000` | Node refresh interval when active |
 | `idle_refresh_interval_ms` | `int` | `60000` | Node refresh interval when idle |
+
+## Authentication
+
+Authentication is disabled by default. Alternator authentication in this client
+supports static credentials only; AWS SDK environment, profile, and provider-chain
+credentials are not used for Alternator auth.
+
+```python
+from alternator import Auth, AlternatorClient, Config
+
+config = Config(seed_hosts=["node1"], port=8000)
+
+# Default: unsigned requests
+with AlternatorClient(config, auth=Auth.disabled()) as client:
+    client.list_tables()
+
+# Signed requests with static Alternator credentials
+with AlternatorClient(
+    config,
+    auth=Auth.static_credentials("alternator", "secret"),
+) as client:
+    client.list_tables()
+```
+
+Passing raw boto credential kwargs such as `aws_access_key_id` still works for
+compatibility, but is deprecated. Prefer `auth=Auth.static_credentials(...)`.
 
 ## Routing Scopes
 

--- a/alternator/__init__.py
+++ b/alternator/__init__.py
@@ -53,6 +53,7 @@ Key Classes
 - ``AlternatorClient``: Sync context manager for load-balanced connections
 - ``AsyncAlternatorClient``: Async context manager for load-balanced connections
 - ``Config``: Main configuration dataclass
+- ``Auth``: Explicit disabled/static-credentials auth settings
 - ``AlternatorConfigBuilder``: Fluent builder for configuration
 - ``TLS``: TLS/SSL configuration
 - ``ClusterScope``, ``DatacenterScope``, ``RackScope``: Routing scope controls
@@ -87,6 +88,7 @@ from alternator.config import (
     TLS,
     AlternatorConfig,
     AlternatorConfigBuilder,
+    Auth,
     CompressionAlgorithm,
     Config,
     HeaderOptimizationConfig,
@@ -128,6 +130,7 @@ __all__ = [
     "close_async_client",
     "create_async_client",
     # Config
+    "Auth",
     "Config",
     "TLS",
     "AlternatorConfig",

--- a/alternator/async_client.py
+++ b/alternator/async_client.py
@@ -20,6 +20,7 @@ from alternator._http import (
     create_ssl_context,
 )
 from alternator.config import KeyRouteAffinityMode
+from alternator.core.auth import apply_auth
 from alternator.core.handlers import _register_alternator_handlers
 from alternator.core.hashing import hash_attribute_value
 from alternator.core.key_affinity import (
@@ -33,7 +34,7 @@ from alternator.vector import enable_vector_support
 if TYPE_CHECKING:
     from types_aiobotocore_dynamodb import DynamoDBClient as AsyncDynamoDBClient
 
-    from alternator.config import Config
+    from alternator.config import Auth, Config
 
 logger = logging.getLogger("alternator")
 
@@ -270,6 +271,8 @@ def _create_async_affinity_hash_computer(
 
 async def create_async_client(
     config: Config,
+    *,
+    auth: Auth | None = None,
     **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
 ) -> AsyncDynamoDBClient:
     """
@@ -279,14 +282,13 @@ async def create_async_client(
     transparently distributes requests across cluster nodes.
 
     Note:
-        When ``optimize_headers`` is enabled, authentication headers are
-        only preserved if credentials are passed explicitly via
-        ``aws_access_key_id`` in *boto_kwargs*. Unlike a regular boto3
-        DynamoDB client, credentials from environment variables or
-        ``~/.aws/credentials`` are not detected for this purpose.
+        Authentication is disabled by default. Alternator authentication
+        currently supports only static credentials; pass
+        ``auth=Auth.static_credentials(...)`` to enable request signing.
 
     Args:
         config: Alternator configuration
+        auth: Explicit Alternator auth settings. Defaults to disabled auth.
         **boto_kwargs: Additional arguments passed to aioboto3.client()
 
     Returns:
@@ -346,7 +348,7 @@ async def create_async_client(
     # Create boto config from Config settings
     from botocore import UNSIGNED
 
-    auth_enabled = "aws_access_key_id" in boto_kwargs
+    auth_enabled = apply_auth(auth, boto_kwargs)
     aio_kwargs: dict[str, Any] = {
         "retries": {
             "max_attempts": config.retries.max_attempts,
@@ -453,13 +455,22 @@ class AsyncAlternatorClient:
             await client.put_item(...)
     """
 
-    def __init__(self, config: Config, **boto_kwargs: Any) -> None:  # noqa: ANN401 -- boto3 kwargs are untyped
+    def __init__(
+        self,
+        config: Config,
+        *,
+        auth: Auth | None = None,
+        **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
+    ) -> None:
         self._config = config
+        self._auth = auth
         self._boto_kwargs = boto_kwargs
         self._client: AsyncDynamoDBClient | None = None
 
     async def __aenter__(self) -> AsyncDynamoDBClient:
-        self._client = await create_async_client(self._config, **self._boto_kwargs)
+        self._client = await create_async_client(
+            self._config, auth=self._auth, **self._boto_kwargs
+        )
         return self._client
 
     async def __aexit__(

--- a/alternator/client.py
+++ b/alternator/client.py
@@ -17,6 +17,7 @@ from botocore.config import Config as BotoConfig
 from alternator._constants import MANAGER_ATTR, PK_CACHE_ATTR
 from alternator._http import create_ssl_context, create_sync_http_fetcher
 from alternator.config import KeyRouteAffinityMode
+from alternator.core.auth import apply_auth
 from alternator.core.handlers import _register_alternator_handlers
 from alternator.core.hashing import hash_attribute_value
 from alternator.core.key_affinity import (
@@ -32,7 +33,7 @@ if TYPE_CHECKING:
     from mypy_boto3_dynamodb import DynamoDBClient
     from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource
 
-    from alternator.config import Config
+    from alternator.config import Auth, Config
 
 logger = logging.getLogger("alternator")
 
@@ -221,6 +222,8 @@ def _create_affinity_hash_computer(
 
 def create_client(
     config: Config,
+    *,
+    auth: Auth | None = None,
     **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
 ) -> DynamoDBClient:
     """
@@ -230,14 +233,13 @@ def create_client(
     transparently distributes requests across cluster nodes.
 
     Note:
-        When ``optimize_headers`` is enabled, authentication headers are
-        only preserved if credentials are passed explicitly via
-        ``aws_access_key_id`` in *boto_kwargs*. Unlike a regular boto3
-        DynamoDB client, credentials from environment variables or
-        ``~/.aws/credentials`` are not detected for this purpose.
+        Authentication is disabled by default. Alternator authentication
+        currently supports only static credentials; pass
+        ``auth=Auth.static_credentials(...)`` to enable request signing.
 
     Args:
         config: Alternator configuration
+        auth: Explicit Alternator auth settings. Defaults to disabled auth.
         **boto_kwargs: Additional arguments passed to boto3.client()
             (excluding ``config`` — BotoConfig is managed internally)
 
@@ -264,7 +266,7 @@ def create_client(
 
     # Get initial endpoint and merged boto config
     initial_endpoint = manager.next_node_uri()
-    auth_enabled = "aws_access_key_id" in boto_kwargs
+    auth_enabled = apply_auth(auth, boto_kwargs)
     boto_config = _create_boto_config(config, auth_enabled=auth_enabled)
 
     # Create boto3 client
@@ -305,17 +307,17 @@ def create_client(
 
 def create_resource(
     config: Config,
+    *,
+    auth: Auth | None = None,
     **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
 ) -> DynamoDBServiceResource:
     """
     Create a load-balanced DynamoDB resource for Alternator.
 
     Note:
-        When ``optimize_headers`` is enabled, authentication headers are
-        only preserved if credentials are passed explicitly via
-        ``aws_access_key_id`` in *boto_kwargs*. Unlike a regular boto3
-        DynamoDB client, credentials from environment variables or
-        ``~/.aws/credentials`` are not detected for this purpose.
+        Authentication is disabled by default. Alternator authentication
+        currently supports only static credentials; pass
+        ``auth=Auth.static_credentials(...)`` to enable request signing.
 
     Example:
         resource = create_resource(config)
@@ -330,7 +332,7 @@ def create_resource(
 
     # Get initial endpoint and merged boto config
     initial_endpoint = manager.next_node_uri()
-    auth_enabled = "aws_access_key_id" in boto_kwargs
+    auth_enabled = apply_auth(auth, boto_kwargs)
     boto_config = _create_boto_config(config, auth_enabled=auth_enabled)
 
     # Create boto3 resource
@@ -405,13 +407,20 @@ class AlternatorClient:
             client.put_item(...)
     """
 
-    def __init__(self, config: Config, **boto_kwargs: Any) -> None:  # noqa: ANN401 -- boto3 kwargs are untyped
+    def __init__(
+        self,
+        config: Config,
+        *,
+        auth: Auth | None = None,
+        **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
+    ) -> None:
         self._config = config
+        self._auth = auth
         self._boto_kwargs = boto_kwargs
         self._client: DynamoDBClient | None = None
 
     def __enter__(self) -> DynamoDBClient:
-        self._client = create_client(self._config, **self._boto_kwargs)
+        self._client = create_client(self._config, auth=self._auth, **self._boto_kwargs)
         return self._client
 
     def __exit__(
@@ -448,13 +457,22 @@ class AlternatorResource:
             table.put_item(Item={"pk": "123", "data": "hello"})
     """
 
-    def __init__(self, config: Config, **boto_kwargs: Any) -> None:  # noqa: ANN401 -- boto3 kwargs are untyped
+    def __init__(
+        self,
+        config: Config,
+        *,
+        auth: Auth | None = None,
+        **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
+    ) -> None:
         self._config = config
+        self._auth = auth
         self._boto_kwargs = boto_kwargs
         self._resource: DynamoDBServiceResource | None = None
 
     def __enter__(self) -> DynamoDBServiceResource:
-        self._resource = create_resource(self._config, **self._boto_kwargs)
+        self._resource = create_resource(
+            self._config, auth=self._auth, **self._boto_kwargs
+        )
         return self._resource
 
     def __exit__(

--- a/alternator/config.py
+++ b/alternator/config.py
@@ -144,16 +144,83 @@ class HeaderOptimizationConfig:
 
     When enabled, non-essential HTTP headers are stripped from requests
     to reduce bandwidth. Authentication headers (Authorization,
-    X-Amz-Date, X-Amz-Security-Token) are only preserved when
-    credentials are passed explicitly to create_client /
-    create_async_client via ``aws_access_key_id``. Unlike a regular
-    boto3 DynamoDB client, credentials from environment variables
-    or ~/.aws/credentials are not detected for this purpose — pass
-    them explicitly when using header optimization.
+    X-Amz-Date, X-Amz-Security-Token) are preserved when explicit
+    static credentials are passed with ``auth=Auth.static_credentials(...)``.
     """
 
     enabled: bool = False
     whitelist: frozenset[str] | None = None
+
+
+@dataclass(frozen=True)
+class Auth:
+    """
+    Explicit Alternator authentication settings.
+
+    Alternator client authentication currently supports only static
+    credentials. Environment, profile, and provider-chain credentials are not
+    supported by this API.
+    """
+
+    access_key_id: str | None = None
+    secret_access_key: str | None = None
+    session_token: str | None = None
+
+    def __post_init__(self) -> None:
+        has_key = self.access_key_id is not None
+        has_secret = self.secret_access_key is not None
+        if has_key != has_secret:
+            raise ConfigurationError(
+                "Static auth requires both access_key_id and secret_access_key"
+            )
+        if self.session_token is not None and not has_key:
+            raise ConfigurationError(
+                "session_token requires static access_key_id and secret_access_key"
+            )
+        if self.access_key_id == "" or self.secret_access_key == "":
+            raise ConfigurationError("Static auth credentials must not be empty")
+
+    @classmethod
+    def disabled(cls) -> Auth:
+        """Create auth settings with request signing disabled."""
+        return cls()
+
+    @classmethod
+    def static_credentials(
+        cls,
+        access_key_id: str,
+        secret_access_key: str,
+        session_token: str | None = None,
+    ) -> Auth:
+        """Create auth settings using static Alternator credentials."""
+        return cls(
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            session_token=session_token,
+        )
+
+    @property
+    def enabled(self) -> bool:
+        """Whether request signing is enabled."""
+        return self.access_key_id is not None
+
+    def as_boto_kwargs(self) -> dict[str, str]:
+        """Return boto credential kwargs for static auth."""
+        if not self.enabled:
+            return {}
+
+        if self.access_key_id is None or self.secret_access_key is None:
+            raise ConfigurationError(
+                "Static auth requires both access_key_id and secret_access_key"
+            )
+
+        kwargs = {
+            "aws_access_key_id": self.access_key_id,
+            "aws_secret_access_key": self.secret_access_key,
+        }
+        if self.session_token is not None:
+            kwargs["aws_session_token"] = self.session_token
+        return kwargs
 
 
 class RetryMode(Enum):
@@ -392,12 +459,8 @@ class AlternatorConfigBuilder:
 
         When enabled, non-essential HTTP headers are stripped from requests
         to reduce bandwidth. Authentication headers (Authorization,
-        X-Amz-Date, X-Amz-Security-Token) are only preserved when
-        credentials are passed explicitly to create_client /
-        create_async_client via ``aws_access_key_id``. Unlike a regular
-        boto3 DynamoDB client, credentials from environment variables
-        or ~/.aws/credentials are not detected for this purpose — pass
-        them explicitly when using header optimization.
+        X-Amz-Date, X-Amz-Security-Token) are preserved when explicit
+        static credentials are passed with ``auth=Auth.static_credentials(...)``.
         """
         self._header_optimization = HeaderOptimizationConfig(
             enabled=True,

--- a/alternator/core/auth.py
+++ b/alternator/core/auth.py
@@ -1,0 +1,47 @@
+"""Authentication helpers for Alternator boto clients."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+from alternator.config import Auth
+from alternator.exceptions import ConfigurationError
+
+_CREDENTIAL_KWARGS = frozenset(
+    {
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_session_token",
+    }
+)
+
+
+def apply_auth(auth: Auth | None, boto_kwargs: dict[str, Any]) -> bool:
+    """
+    Apply explicit Alternator auth to boto kwargs.
+
+    Returns:
+        Whether request signing should be enabled.
+    """
+    legacy_credential_keys = _CREDENTIAL_KWARGS.intersection(boto_kwargs)
+    if legacy_credential_keys:
+        if auth is not None:
+            raise ConfigurationError(
+                "Do not combine auth=... with raw boto credential kwargs; "
+                "use Auth.static_credentials(...) instead"
+            )
+        warnings.warn(
+            "Passing raw boto credential kwargs is deprecated; "
+            "use auth=Auth.static_credentials(...) instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return "aws_access_key_id" in boto_kwargs
+
+    resolved_auth = auth or Auth.disabled()
+    if not resolved_auth.enabled:
+        return False
+
+    boto_kwargs.update(resolved_auth.as_boto_kwargs())
+    return True

--- a/tests/integration/test_sync_client.py
+++ b/tests/integration/test_sync_client.py
@@ -13,6 +13,7 @@ import pytest
 from alternator import (
     AlternatorClient,
     AlternatorConfigBuilder,
+    Auth,
     CompressionAlgorithm,
     Config,
     KeyRouteAffinityMode,
@@ -475,8 +476,7 @@ class TestHeaderOptimization:
 
         with AlternatorClient(
             config,
-            aws_access_key_id="alternator",
-            aws_secret_access_key="secret",
+            auth=Auth.static_credentials("alternator", "secret"),
             region_name="us-east-1",
         ) as client:
             response = client.list_tables()

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,97 @@
+"""Tests for explicit Alternator auth configuration."""
+
+import pytest
+
+from alternator.config import Auth
+from alternator.core.auth import apply_auth
+from alternator.exceptions import ConfigurationError
+
+
+class TestAuth:
+    """Tests for Auth factory methods and validation."""
+
+    def test_disabled_auth(self) -> None:
+        """Disabled auth has no boto credential kwargs."""
+        auth = Auth.disabled()
+
+        assert auth.enabled is False
+        assert auth.as_boto_kwargs() == {}
+
+    def test_static_credentials(self) -> None:
+        """Static credentials map to boto credential kwargs."""
+        auth = Auth.static_credentials("alternator", "secret")
+
+        assert auth.enabled is True
+        assert auth.as_boto_kwargs() == {
+            "aws_access_key_id": "alternator",
+            "aws_secret_access_key": "secret",
+        }
+
+    def test_static_credentials_with_session_token(self) -> None:
+        """Static credentials can include a session token."""
+        auth = Auth.static_credentials("alternator", "secret", "token")
+
+        assert auth.as_boto_kwargs()["aws_session_token"] == "token"
+
+    def test_rejects_partial_static_credentials(self) -> None:
+        """Static auth requires both key id and secret."""
+        with pytest.raises(ConfigurationError, match="requires both"):
+            Auth(access_key_id="alternator")
+
+    def test_rejects_empty_static_credentials(self) -> None:
+        """Static auth credentials cannot be empty strings."""
+        with pytest.raises(ConfigurationError, match="must not be empty"):
+            Auth.static_credentials("", "secret")
+
+
+class TestApplyAuth:
+    """Tests for applying auth to boto kwargs."""
+
+    def test_default_auth_is_disabled(self) -> None:
+        """No auth argument leaves signing disabled."""
+        boto_kwargs: dict[str, object] = {}
+
+        assert apply_auth(None, boto_kwargs) is False
+        assert boto_kwargs == {}
+
+    def test_disabled_auth_is_unsigned(self) -> None:
+        """Explicit disabled auth leaves signing disabled."""
+        boto_kwargs: dict[str, object] = {}
+
+        assert apply_auth(Auth.disabled(), boto_kwargs) is False
+        assert boto_kwargs == {}
+
+    def test_static_auth_updates_boto_kwargs(self) -> None:
+        """Static auth enables signing and injects credentials."""
+        boto_kwargs: dict[str, object] = {"region_name": "us-east-1"}
+
+        assert (
+            apply_auth(Auth.static_credentials("alternator", "secret"), boto_kwargs)
+            is True
+        )
+        assert boto_kwargs["aws_access_key_id"] == "alternator"
+        assert boto_kwargs["aws_secret_access_key"] == "secret"
+        assert boto_kwargs["region_name"] == "us-east-1"
+
+    def test_legacy_boto_credentials_warn_and_enable_auth(self) -> None:
+        """Raw boto credential kwargs still work but are deprecated."""
+        boto_kwargs: dict[str, object] = {
+            "aws_access_key_id": "alternator",
+            "aws_secret_access_key": "secret",
+        }
+
+        with pytest.warns(DeprecationWarning, match="raw boto credential kwargs"):
+            auth_enabled = apply_auth(None, boto_kwargs)
+
+        assert auth_enabled is True
+        assert boto_kwargs["aws_access_key_id"] == "alternator"
+
+    def test_rejects_auth_with_legacy_boto_credentials(self) -> None:
+        """Explicit auth cannot be mixed with raw boto credential kwargs."""
+        boto_kwargs: dict[str, object] = {
+            "aws_access_key_id": "alternator",
+            "aws_secret_access_key": "secret",
+        }
+
+        with pytest.raises(ConfigurationError, match="Do not combine"):
+            apply_auth(Auth.static_credentials("other", "secret"), boto_kwargs)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -113,6 +113,7 @@ class TestDeprecatedConfigNames:
         """Test top-level package exports preferred names."""
         import alternator
 
+        assert alternator.Auth is not None
         assert alternator.Config is Config
         assert alternator.TLS is TLS
 


### PR DESCRIPTION
Closes #27

## Summary
- add `Auth.disabled()` and `Auth.static_credentials(...)`
- make disabled auth the explicit default and document static-credential-only support
- keep raw boto credential kwargs working with deprecation warnings
- wire auth through sync, resource, and async clients

## Tests
- `make lint`
- `make test-unit`