### PR TITLE
Add top-level client alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ pip install alternator-client[async]
 
 ### Synchronous Client
 
+For the common case, use the top-level `alternator.client` context manager.
+Seeds are host names or IP addresses only; use `port` for the single Alternator
+port.
+
+```python
+import alternator
+
+with alternator.client(
+    seeds=["192.168.1.1", "192.168.1.2"],
+    port=8000,
+) as client:
+    response = client.list_tables()
+    print(response["TableNames"])
+```
+
 ```python
 from alternator import Config, AlternatorClient
 

--- a/alternator/__init__.py
+++ b/alternator/__init__.py
@@ -79,6 +79,7 @@ from alternator._version import __version__
 from alternator.client import (
     AlternatorClient,
     AlternatorResource,
+    client,
     close_client,
     close_resource,
     create_client,
@@ -121,6 +122,7 @@ __all__ = [
     # Sync Client
     "AlternatorClient",
     "AlternatorResource",
+    "client",
     "close_client",
     "close_resource",
     "create_client",

--- a/alternator/client.py
+++ b/alternator/client.py
@@ -7,16 +7,16 @@ import contextlib
 import logging
 import threading
 import weakref
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from types import TracebackType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import boto3
 from botocore.config import Config as BotoConfig
 
 from alternator._constants import MANAGER_ATTR, PK_CACHE_ATTR
 from alternator._http import create_ssl_context, create_sync_http_fetcher
-from alternator.config import KeyRouteAffinityMode
+from alternator.config import Config, KeyRouteAffinityMode
 from alternator.core.auth import apply_auth
 from alternator.core.handlers import _register_alternator_handlers
 from alternator.core.hashing import hash_attribute_value
@@ -27,15 +27,17 @@ from alternator.core.key_affinity import (
     should_use_affinity,
 )
 from alternator.core.live_nodes import SyncLiveNodesManager
+from alternator.exceptions import ConfigurationError
 from alternator.vector import enable_vector_support
 
 if TYPE_CHECKING:
     from mypy_boto3_dynamodb import DynamoDBClient
     from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource
 
-    from alternator.config import Auth, Config
+    from alternator.config import Auth
 
 logger = logging.getLogger("alternator")
+DEFAULT_PORT = 8000
 
 # Registry of active managers for cleanup on exit
 _active_managers: weakref.WeakValueDictionary[int, SyncLiveNodesManager] = (
@@ -303,6 +305,57 @@ def create_client(
         raise
 
     return client
+
+
+def _seed_has_port(seed: str) -> bool:
+    """Return whether a seed appears to include a port."""
+    if "://" in seed:
+        return True
+    if seed.startswith("["):
+        return "]:" in seed
+    if seed.count(":") == 1:
+        _, maybe_port = seed.rsplit(":", 1)
+        return maybe_port.isdigit()
+    return False
+
+
+def _validate_host_only_seeds(seed_hosts: Sequence[str]) -> None:
+    invalid = [seed for seed in seed_hosts if _seed_has_port(seed)]
+    if invalid:
+        raise ConfigurationError(
+            "seeds must be host names or IP addresses without ports; "
+            "use the port argument for the single Alternator port"
+        )
+
+
+def client(
+    seeds: Sequence[str] | Config | None = None,
+    *,
+    port: int = DEFAULT_PORT,
+    scheme: Literal["http", "https"] = "http",
+    auth: Auth | None = None,
+    **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
+) -> AlternatorClient:
+    """
+    Create a context-manager friendly Alternator client.
+
+    This is a convenience alias for the common case. Seeds are host names or
+    IP addresses only; provide the shared Alternator port with ``port``.
+    """
+    if isinstance(seeds, Config):
+        if port != DEFAULT_PORT or scheme != "http":
+            raise ConfigurationError(
+                "Do not combine a Config object with port or scheme overrides"
+            )
+        config = seeds
+    else:
+        if seeds is None:
+            raise ConfigurationError("seeds is required when Config is not provided")
+        _validate_host_only_seeds(seeds)
+        config = Config(seed_hosts=tuple(seeds), port=port, scheme=scheme)
+
+    _validate_host_only_seeds(config.seed_hosts)
+    return AlternatorClient(config, auth=auth, **boto_kwargs)
 
 
 def create_resource(

--- a/tests/unit/test_client_alias.py
+++ b/tests/unit/test_client_alias.py
@@ -1,0 +1,65 @@
+"""Tests for top-level client convenience alias."""
+
+import pytest
+
+import alternator
+from alternator import AlternatorClient, Auth, Config
+from alternator.client import DEFAULT_PORT, client
+from alternator.exceptions import ConfigurationError
+
+
+class TestClientAlias:
+    """Tests for alternator.client convenience API."""
+
+    def test_builds_context_manager_from_seed_keywords(self) -> None:
+        """The alias builds an AlternatorClient from host-only seeds."""
+        ctx = client(seeds=["node1", "node2"])
+
+        assert isinstance(ctx, AlternatorClient)
+        assert ctx._config.seed_hosts == ("node1", "node2")
+        assert ctx._config.port == DEFAULT_PORT
+        assert ctx._config.scheme == "http"
+
+    def test_accepts_positional_seeds(self) -> None:
+        """The alias also accepts seeds as the first argument."""
+        ctx = client(["node1"], port=8042, scheme="https")
+
+        assert ctx._config.seed_hosts == ("node1",)
+        assert ctx._config.port == 8042
+        assert ctx._config.scheme == "https"
+
+    def test_accepts_config_object(self) -> None:
+        """The alias can wrap an existing Config."""
+        config = Config(seed_hosts=["node1"], port=9000)
+
+        ctx = client(config, auth=Auth.disabled(), region_name="us-east-1")
+
+        assert ctx._config is config
+        assert ctx._auth == Auth.disabled()
+        assert ctx._boto_kwargs["region_name"] == "us-east-1"
+
+    def test_rejects_missing_seeds(self) -> None:
+        """Seeds are required unless a Config object is passed."""
+        with pytest.raises(ConfigurationError, match="seeds is required"):
+            client()
+
+    def test_rejects_host_port_seed(self) -> None:
+        """Seeds must not include ports."""
+        with pytest.raises(ConfigurationError, match="without ports"):
+            client(seeds=["node1:8000"])
+
+    def test_rejects_url_seed(self) -> None:
+        """Seeds must not include URL schemes."""
+        with pytest.raises(ConfigurationError, match="without ports"):
+            client(seeds=["http://node1"])
+
+    def test_rejects_config_with_port_override(self) -> None:
+        """A Config object cannot be mixed with direct port settings."""
+        config = Config(seed_hosts=["node1"], port=9000)
+
+        with pytest.raises(ConfigurationError, match="Config object"):
+            client(config, port=8001)
+
+    def test_top_level_export(self) -> None:
+        """Top-level alternator.client is the convenience alias."""
+        assert alternator.client is client


### PR DESCRIPTION
Closes #25

## Summary
- add top-level `alternator.client(...)` convenience context manager
- support host-only `seeds`, shared `port`, `scheme`, `auth`, and boto kwargs
- reject `host:port` and URL seeds so port remains a single client setting
- add README and unit tests

## Tests
- `make lint`
- `make test-unit`