### PR TITLE
Add capability matrix and deterministic test harness

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -1,0 +1,102 @@
+# Alternator Client Capability Roadmap
+
+This roadmap tracks the remaining client capability work for the Python
+Alternator client. Requirements are written in implementation-independent terms
+so each issue has enough context on its own.
+
+## Issue Map
+
+- [#36: Add client capability matrix and deterministic behavior test harness](https://github.com/scylladb/alternator-client-python/issues/36)
+- [#33: Add Helper and AsyncHelper lifecycle facade](https://github.com/scylladb/alternator-client-python/issues/33)
+- [#32: Plan node health tracking and quarantine behavior](https://github.com/scylladb/alternator-client-python/issues/32)
+- [#35: Add explicit routing-scope fallback and topology validation APIs](https://github.com/scylladb/alternator-client-python/issues/35)
+- [#34: Wire transport and configuration options into boto clients](https://github.com/scylladb/alternator-client-python/issues/34)
+- [#38: Add TLS client certificate and key log file support](https://github.com/scylladb/alternator-client-python/issues/38)
+- [#37: Add configurable gzip compression and custom header whitelist callback](https://github.com/scylladb/alternator-client-python/issues/37)
+- [#23: Align key-affinity routing semantics for RMW and BatchWriteItem](https://github.com/scylladb/alternator-client-python/issues/23)
+- [#39: Coordinate compatibility and release decisions for client capability work](https://github.com/scylladb/alternator-client-python/issues/39)
+- [#40: Update documentation, examples, and release notes for client capability work](https://github.com/scylladb/alternator-client-python/issues/40)
+
+## Current Capability Status
+
+Supported or close:
+
+- host-only seeds with one shared port
+- sync boto3 client, boto3 resource, async aioboto3 client
+- `/localnodes` node discovery
+- basic cluster/datacenter/rack routing scopes
+- request-scoped lazy query plans with stable seeded ordering
+- gzip request compression
+- header optimization
+- static Alternator auth, disabled by default
+- TLS server CA and insecure trust-all modes
+- key route affinity with partition-key cache
+- vector search support
+
+Tracked gaps:
+
+- node health tracking and quarantine planning only: [#32](https://github.com/scylladb/alternator-client-python/issues/32)
+- public helper facade and lifecycle inspection: [#33](https://github.com/scylladb/alternator-client-python/issues/33)
+- explicit routing-scope fallback and topology validation: [#35](https://github.com/scylladb/alternator-client-python/issues/35)
+- transport and SDK configuration propagation: [#34](https://github.com/scylladb/alternator-client-python/issues/34)
+- TLS client certificate and key log file support: [#38](https://github.com/scylladb/alternator-client-python/issues/38)
+- configurable compression and header whitelist behavior: [#37](https://github.com/scylladb/alternator-client-python/issues/37)
+- key-affinity RMW and BatchWriteItem routing semantics: [#23](https://github.com/scylladb/alternator-client-python/issues/23)
+- compatibility and release decisions: [#39](https://github.com/scylladb/alternator-client-python/issues/39)
+- documentation, examples, and release notes: [#40](https://github.com/scylladb/alternator-client-python/issues/40)
+
+## Compatibility Decisions
+
+Tracked by [#39](https://github.com/scylladb/alternator-client-python/issues/39).
+
+- Keep current auth behavior: unsigned by default, explicit static credentials
+  for signed Alternator requests.
+- Keep raw boto credential kwargs working with deprecation warnings until a
+  separate removal decision.
+- Keep the current convenience default port unless a major-release migration
+  explicitly changes it.
+- Keep deprecated names such as `AlternatorConfig` and `TlsConfig` working while
+  capability changes land.
+- Treat routing fallback changes as compatibility-sensitive and document a
+  migration path before changing constructor behavior.
+
+## Node Health Constraint
+
+Tracked by [#32](https://github.com/scylladb/alternator-client-python/issues/32).
+
+Node health is planning-only in this roadmap. Do not add node health code, tests,
+configuration objects, routing behavior, or default behavior changes unless a
+separate future request explicitly authorizes implementation.
+
+## Implementation Order
+
+1. Add capability matrix and deterministic fake Alternator test fixtures:
+   [#36](https://github.com/scylladb/alternator-client-python/issues/36).
+2. Add helper lifecycle facade and public inspection methods:
+   [#33](https://github.com/scylladb/alternator-client-python/issues/33).
+3. Keep node health deferred; maintain planning issue only:
+   [#32](https://github.com/scylladb/alternator-client-python/issues/32).
+4. Add explicit routing fallback and topology validation:
+   [#35](https://github.com/scylladb/alternator-client-python/issues/35).
+5. Wire timeout, region, pool, and SDK customizer configuration:
+   [#34](https://github.com/scylladb/alternator-client-python/issues/34).
+6. Add TLS client certificates and key log file support:
+   [#38](https://github.com/scylladb/alternator-client-python/issues/38).
+7. Add gzip level/custom compressor and custom header whitelist support:
+   [#37](https://github.com/scylladb/alternator-client-python/issues/37).
+8. Align key-affinity RMW and BatchWriteItem behavior:
+   [#23](https://github.com/scylladb/alternator-client-python/issues/23).
+9. Record release decisions:
+   [#39](https://github.com/scylladb/alternator-client-python/issues/39).
+10. Update README, examples, and release notes:
+    [#40](https://github.com/scylladb/alternator-client-python/issues/40).
+
+## Final Verification
+
+- `make lint`
+- `make test-unit`
+- `make test-integration`
+- async tests with `[async]` extras installed
+- TLS integration tests
+- package build check
+- example scripts against local Scylla where applicable

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ A Python library that provides client-side load balancing for [ScyllaDB Alternat
 - **TLS Support**: Full TLS/SSL support with custom CA certificates
 - **Async Support**: Full async/await support via aioboto3
 
+See [docs/CAPABILITY_MATRIX.md](docs/CAPABILITY_MATRIX.md) for the current
+capability matrix and planned follow-up work.
+
 ## Installation
 
 ```bash

--- a/alternator/core/deterministic_rand.py
+++ b/alternator/core/deterministic_rand.py
@@ -1,7 +1,7 @@
-"""Go-compatible PRNG (math/rand lagged Fibonacci generator).
+"""Deterministic PRNG for request-scoped node ordering.
 
-Produces identical sequences to Go's math/rand for the same seed,
-enabling cross-language deterministic node selection.
+The generator uses the project's stable lagged-Fibonacci sequence so clients
+can produce reproducible node plans from the same seed.
 """
 
 from __future__ import annotations
@@ -242,12 +242,8 @@ def _to_signed64(v: int) -> int:
     return v
 
 
-class GoRand:
-    """Go-compatible math/rand PRNG (lagged Fibonacci generator).
-
-    Produces identical sequences to Go's ``math/rand.New(math/rand.NewSource(seed))``
-    for the same seed value.
-    """
+class DeterministicRand:
+    """Stable lagged-Fibonacci PRNG used by deterministic query plans."""
 
     __slots__ = ("_tap", "_feed", "_vec")
 
@@ -258,7 +254,7 @@ class GoRand:
         self.seed(seed)
 
     def seed(self, s: int) -> None:
-        """Seed the generator, matching Go's Source.Seed()."""
+        """Seed the generator using the stable project sequence."""
         self._tap = 0
         self._feed = _RNG_LEN - _RNG_TAP  # 334
 
@@ -283,8 +279,8 @@ class GoRand:
     def int63(self) -> int:
         """Return a non-negative pseudo-random 63-bit integer.
 
-        Matches Go's rngSource.Uint64() masked to 63 bits.
-        Go decrements tap and feed *before* the addition.
+        Tap and feed are decremented before addition to preserve the project
+        sequence used by existing deterministic query-plan vectors.
         """
         self._tap -= 1
         if self._tap < 0:
@@ -296,12 +292,10 @@ class GoRand:
         x = _to_signed64((self._vec[self._feed] + self._vec[self._tap]) & _MASK64)
         self._vec[self._feed] = x
 
-        # Go: int64(rng.Uint64() & rngMask) where rngMask = 1<<63 - 1
-        # Uint64 returns uint64(x), so we need the unsigned interpretation
         return (x & _MASK64) & _INT63_MAX
 
     def intn(self, n: int) -> int:
-        """Return a non-negative pseudo-random int in [0, n), matching Go's Intn."""
+        """Return a non-negative pseudo-random int in [0, n)."""
         if n <= 0:
             raise ValueError(f"invalid argument to intn: {n}")
         if n <= _INT32_MAX:
@@ -309,7 +303,7 @@ class GoRand:
         return self._int63n(n)
 
     def _int31n(self, n: int) -> int:
-        """Rejection sampling for n <= 2^31-1, matching Go's Int31n."""
+        """Rejection sampling for n <= 2^31-1."""
         if n & (n - 1) == 0:  # power of two
             return self._int31() & (n - 1)
         max_val = _INT32_MAX - ((1 << 31) % n)
@@ -319,11 +313,11 @@ class GoRand:
         return v % n
 
     def _int31(self) -> int:
-        """Return a non-negative pseudo-random 31-bit integer, matching Go's Int31."""
+        """Return a non-negative pseudo-random 31-bit integer."""
         return self.int63() >> 32
 
     def _int63n(self, n: int) -> int:
-        """Rejection sampling for n > 2^31-1, matching Go's Int63n."""
+        """Rejection sampling for n > 2^31-1."""
         max_val = (1 << 63) - 1 - ((1 << 63) % n)
         v = self.int63()
         while v > max_val:

--- a/alternator/core/query_plan.py
+++ b/alternator/core/query_plan.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
 
-from alternator.core.go_rand import GoRand
+from alternator.core.deterministic_rand import DeterministicRand
 
 
 class LazyQueryPlan(Iterator[str]):
@@ -30,7 +30,7 @@ class LazyQueryPlan(Iterator[str]):
         seed: int,
     ) -> None:
         self._nodes = list(nodes)
-        self._rng = GoRand(seed)
+        self._rng = DeterministicRand(seed)
         self._index = 0
 
     def __next__(self) -> str:

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -1,0 +1,41 @@
+# Alternator Client Capability Matrix
+
+This matrix tracks current Python Alternator client capabilities, planned work,
+and intentionally deferred behavior.
+
+| Capability | Status | Tracking | Notes |
+| --- | --- | --- | --- |
+| Sync DynamoDB client | Supported | Existing API | `create_client`, `AlternatorClient`, and `alternator.client(...)` return standard boto3 clients. |
+| DynamoDB resource | Supported | Existing API | `create_resource` and `AlternatorResource` wrap boto3 resource usage. |
+| Async DynamoDB client | Supported | Existing API | `create_async_client` and `AsyncAlternatorClient` use aioboto3. |
+| Host-only seeds with one shared port | Supported | Existing API | Seeds must not include ports; one port applies to all nodes. |
+| Node discovery | Supported | Existing API | `/localnodes` refresh updates the live node list. |
+| Routing scopes | Partial | [#35](https://github.com/scylladb/alternator-client-python/issues/35) | Cluster, datacenter, and rack scopes exist; explicit fallback control and validation are planned. |
+| Request query plans | Supported | Existing API | Requests use stable seeded node ordering for retries. |
+| Auth | Supported | Existing API | Disabled by default; explicit static credentials enable signing. |
+| Request compression | Partial | [#37](https://github.com/scylladb/alternator-client-python/issues/37) | Gzip exists; configurable levels and custom compressors are planned. |
+| Header optimization | Partial | [#37](https://github.com/scylladb/alternator-client-python/issues/37) | Basic whitelist exists; custom whitelist callback is planned. |
+| TLS server trust | Supported | Existing API | System CA, custom CA, hostname verification, and trust-all mode exist. |
+| TLS client certificates | Missing | [#38](https://github.com/scylladb/alternator-client-python/issues/38) | mTLS config and SDK propagation are planned. |
+| TLS key log file | Missing | [#38](https://github.com/scylladb/alternator-client-python/issues/38) | Debug-only key log file support is planned. |
+| Transport and SDK config knobs | Partial | [#34](https://github.com/scylladb/alternator-client-python/issues/34) | Retry and pool config exist; connect/read timeout and customizer wiring are planned. |
+| Key route affinity | Partial | [#23](https://github.com/scylladb/alternator-client-python/issues/23) | Partition-key cache exists; RMW rules and BatchWriteItem voting need alignment with the request-routing specification. |
+| Helper lifecycle facade | Missing | [#33](https://github.com/scylladb/alternator-client-python/issues/33) | Public lifecycle, diagnostics, and inspection facade is planned. |
+| Node health tracking | Deferred | [#32](https://github.com/scylladb/alternator-client-python/issues/32) | Planning-only. No node health code, tests, config objects, or behavior changes are authorized by this roadmap. |
+| Vector search extension | Supported | Existing API | Python client enables ScyllaDB Alternator vector extensions. |
+| Capability test harness | Partial | [#36](https://github.com/scylladb/alternator-client-python/issues/36) | Fake Alternator server fixture introduced for deterministic unit tests. |
+| Documentation and examples | Partial | [#40](https://github.com/scylladb/alternator-client-python/issues/40) | README and examples should stay aligned with implemented APIs. |
+
+## Deterministic Test Harness
+
+Unit tests can use the `fake_alternator_server` fixture to simulate local
+Alternator HTTP behavior without a running Scylla cluster. The fixture supports:
+
+- `/localnodes` JSON responses
+- arbitrary HTTP status responses
+- request path capture
+- deterministic node add/remove scenarios
+- transport failure tests by pointing clients at unused ports
+
+Use integration tests for real Scylla behavior and the fake server for edge
+cases that need precise control over responses.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,158 @@
 
 from __future__ import annotations
 
+import contextlib
+import json
+import threading
 from collections.abc import Callable
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
 
 import pytest
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping, Sequence
+
     from tests.integration.scylla_version import ScyllaVersion
+
+
+@dataclass(frozen=True)
+class FakeAlternatorResponse:
+    """HTTP response configured on the fake Alternator server."""
+
+    status: int
+    body: bytes
+    headers: Mapping[str, str]
+
+
+class FakeAlternatorServer:
+    """Small deterministic HTTP server for unit tests."""
+
+    def __init__(self) -> None:
+        self.requests: list[str] = []
+        self._routes: dict[str, FakeAlternatorResponse] = {}
+        self._server: HTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        """Start the server on a local ephemeral port."""
+        owner = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                owner.requests.append(self.path)
+                response = owner._routes.get(
+                    self.path,
+                    FakeAlternatorResponse(
+                        status=404,
+                        body=b"not found",
+                        headers={"Content-Type": "text/plain"},
+                    ),
+                )
+                self.send_response(response.status)
+                for key, value in response.headers.items():
+                    self.send_header(key, value)
+                self.end_headers()
+                self.wfile.write(response.body)
+
+            def log_message(self, fmt: str, *args: object) -> None:
+                return
+
+        self._server = HTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            daemon=True,
+            name="fake-alternator-server",
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the server."""
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+        self._server = None
+        self._thread = None
+
+    def url(self, path: str = "/") -> str:
+        """Build an absolute URL for a path on this server."""
+        if self._server is None:
+            raise RuntimeError("fake Alternator server is not started")
+        host, port = self._server.server_address
+        return f"http://{host}:{port}{path}"
+
+    def set_json(
+        self,
+        path: str,
+        body: object,
+        *,
+        status: int = 200,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        """Configure a JSON response."""
+        response_headers = {"Content-Type": "application/json"}
+        if headers is not None:
+            response_headers.update(headers)
+        self._routes[path] = FakeAlternatorResponse(
+            status=status,
+            body=json.dumps(body).encode("utf-8"),
+            headers=response_headers,
+        )
+
+    def set_text(
+        self,
+        path: str,
+        body: str,
+        *,
+        status: int = 200,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        """Configure a text response."""
+        response_headers = {"Content-Type": "text/plain"}
+        if headers is not None:
+            response_headers.update(headers)
+        self._routes[path] = FakeAlternatorResponse(
+            status=status,
+            body=body.encode("utf-8"),
+            headers=response_headers,
+        )
+
+    def set_localnodes(
+        self,
+        nodes: Sequence[str],
+        *,
+        query: str = "",
+        status: int = 200,
+    ) -> None:
+        """Configure a `/localnodes` JSON response."""
+        path = "/localnodes"
+        if query:
+            path = f"{path}?{query}"
+        self.set_json(path, list(nodes), status=status)
+
+    def requested_paths(self) -> list[str]:
+        """Return request paths captured by the server."""
+        return list(self.requests)
+
+    def requested_queries(self) -> list[str]:
+        """Return query strings captured by the server."""
+        return [urlsplit(path).query for path in self.requests]
+
+
+@pytest.fixture
+def fake_alternator_server() -> Iterator[FakeAlternatorServer]:
+    """Provide a deterministic local HTTP server for Alternator unit tests."""
+    server = FakeAlternatorServer()
+    server.start()
+    try:
+        yield server
+    finally:
+        with contextlib.suppress(Exception):
+            server.stop()
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/tests/scylla/scylla.yaml
+++ b/tests/scylla/scylla.yaml
@@ -1,5 +1,5 @@
 # Scylla configuration for integration tests
-# Mirrors Go client's tests/scylla/scylla.yaml
+# Local Scylla configuration for Alternator client integration tests
 
 cluster_name: 'alternator-python-test'
 num_tokens: 256

--- a/tests/unit/test_deterministic_rand.py
+++ b/tests/unit/test_deterministic_rand.py
@@ -1,43 +1,42 @@
-"""Tests for Go-compatible PRNG."""
+"""Tests for deterministic query-plan PRNG."""
 
 from __future__ import annotations
 
 import pytest
 
-from alternator.core.go_rand import GoRand
+from alternator.core.deterministic_rand import DeterministicRand
 
 MAX_INT64 = (1 << 63) - 1
 
 
-class TestGoRandSeedEdgeCases:
+class TestDeterministicRandSeedEdgeCases:
     """Test seed edge cases."""
 
     def test_seed_zero_replaced(self) -> None:
         """Seed 0 is replaced with 89482311 internally."""
-        r = GoRand(0)
+        r = DeterministicRand(0)
         # Should not raise and should produce valid output
         val = r.int63()
         assert 0 <= val < (1 << 63)
 
     def test_negative_seed(self) -> None:
         """Negative seeds work and produce deterministic output."""
-        r1 = GoRand(-1)
-        r2 = GoRand(-1)
+        r1 = DeterministicRand(-1)
+        r2 = DeterministicRand(-1)
         assert [r1.int63() for _ in range(10)] == [r2.int63() for _ in range(10)]
 
     def test_max_int64_seed(self) -> None:
         """MAX_INT64 seed works."""
-        r = GoRand(MAX_INT64)
+        r = DeterministicRand(MAX_INT64)
         val = r.int63()
         assert 0 <= val < (1 << 63)
 
 
-class TestGoRandInt63:
-    """Test int63() output matches Go reference values."""
+class TestDeterministicRandInt63:
+    """Test int63() output matches stable reference values."""
 
-    def test_matches_go_reference(self) -> None:
-        """First 10 int63() values for seed 42 must match Go's math/rand."""
-        # Generated with Go 1.25: rand.New(rand.NewSource(42)).Int63()
+    def test_matches_stable_reference(self) -> None:
+        """First 10 int63() values for seed 42 must match stable vectors."""
         expected = [
             3440579354231278675,
             608747136543856411,
@@ -50,31 +49,31 @@ class TestGoRandInt63:
             3532963341805492868,
             5961769557461764184,
         ]
-        r = GoRand(42)
+        r = DeterministicRand(42)
         actual = [r.int63() for _ in range(10)]
         assert actual == expected
 
     def test_deterministic(self) -> None:
         """Same seed produces same sequence."""
-        r1 = GoRand(42)
-        r2 = GoRand(42)
+        r1 = DeterministicRand(42)
+        r2 = DeterministicRand(42)
         for _ in range(20):
             assert r1.int63() == r2.int63()
 
     def test_range(self) -> None:
         """int63() returns values in [0, 2^63)."""
-        r = GoRand(42)
+        r = DeterministicRand(42)
         for _ in range(100):
             val = r.int63()
             assert 0 <= val < (1 << 63)
 
 
-class TestGoRandIntn:
+class TestDeterministicRandIntn:
     """Test intn() correctness."""
 
     def test_intn_range(self) -> None:
         """intn(n) returns values in [0, n)."""
-        r = GoRand(42)
+        r = DeterministicRand(42)
         for n in [1, 2, 3, 10, 100, 1000]:
             for _ in range(50):
                 val = r.intn(n)
@@ -82,13 +81,13 @@ class TestGoRandIntn:
 
     def test_intn_one_always_zero(self) -> None:
         """intn(1) always returns 0."""
-        r = GoRand(42)
+        r = DeterministicRand(42)
         for _ in range(20):
             assert r.intn(1) == 0
 
     def test_intn_invalid(self) -> None:
         """intn with n<=0 raises ValueError."""
-        r = GoRand(42)
+        r = DeterministicRand(42)
         with pytest.raises(ValueError):
             r.intn(0)
         with pytest.raises(ValueError):
@@ -96,7 +95,7 @@ class TestGoRandIntn:
 
     def test_intn_large_n(self) -> None:
         """intn works for n > 2^31-1 (uses int63n path)."""
-        r = GoRand(42)
+        r = DeterministicRand(42)
         n = (1 << 32) + 1
         for _ in range(20):
             val = r.intn(n)
@@ -104,7 +103,7 @@ class TestGoRandIntn:
 
     def test_intn_deterministic(self) -> None:
         """Same seed produces same intn sequence."""
-        r1 = GoRand(123)
-        r2 = GoRand(123)
+        r1 = DeterministicRand(123)
+        r2 = DeterministicRand(123)
         for _ in range(20):
             assert r1.intn(100) == r2.intn(100)

--- a/tests/unit/test_fake_alternator_server.py
+++ b/tests/unit/test_fake_alternator_server.py
@@ -1,0 +1,30 @@
+"""Tests for the fake Alternator HTTP server fixture."""
+
+from alternator._http import create_sync_http_fetcher
+from tests.conftest import FakeAlternatorServer
+
+
+def test_fake_server_serves_localnodes(
+    fake_alternator_server: FakeAlternatorServer,
+) -> None:
+    """The fake server can drive the real sync node fetcher."""
+    fake_alternator_server.set_localnodes(["node2", "node1"])
+
+    fetcher = create_sync_http_fetcher(timeout_seconds=1.0)
+    nodes = fetcher(fake_alternator_server.url("/localnodes"))
+
+    assert list(nodes) == ["node2", "node1"]
+    assert fake_alternator_server.requested_paths() == ["/localnodes"]
+
+
+def test_fake_server_serves_scoped_localnodes(
+    fake_alternator_server: FakeAlternatorServer,
+) -> None:
+    """The fake server records scoped discovery queries."""
+    fake_alternator_server.set_localnodes(["node1"], query="dc=dc1")
+
+    fetcher = create_sync_http_fetcher(timeout_seconds=1.0)
+    nodes = fetcher(fake_alternator_server.url("/localnodes?dc=dc1"))
+
+    assert list(nodes) == ["node1"]
+    assert fake_alternator_server.requested_queries() == ["dc=dc1"]

--- a/tests/unit/test_query_plan.py
+++ b/tests/unit/test_query_plan.py
@@ -137,12 +137,8 @@ def _node_short(full: str) -> str:
     return full.split(".")[0]
 
 
-class TestCrossLanguageVectors:
-    """Cross-language test vectors from the spec (issue #169).
-
-    These vectors ensure Python produces the same shuffle sequences as
-    Go and Java clients for the same seed and sorted node list.
-    """
+class TestDeterministicVectors:
+    """Stable test vectors from the request-routing specification."""
 
     @pytest.mark.parametrize(
         "seed, expected_first_6",
@@ -158,7 +154,7 @@ class TestCrossLanguageVectors:
         ids=["seed42", "seed123", "seed999", "seed0", "seed-1", "seed12345", "seedMAX"],
     )
     def test_spec_vector(self, seed: int, expected_first_6: list[str]) -> None:
-        """Verify shuffle matches the cross-language spec vectors."""
+        """Verify shuffle matches the deterministic spec vectors."""
         plan = LazyQueryPlan(nodes=_SPEC_NODES, seed=seed)
         actual = [_node_short(next(plan)) for _ in range(6)]
         assert actual == expected_first_6, (


### PR DESCRIPTION
Closes #36

## Summary
- add a language-agnostic capability roadmap and capability matrix
- add a deterministic fake Alternator HTTP server fixture for unit tests
- rename deterministic request-ordering internals away from language-specific names
- keep node health planning-only with no code, tests, config, or behavior changes

## Testing
- uv run pytest tests/unit/test_deterministic_rand.py tests/unit/test_query_plan.py tests/unit/test_fake_alternator_server.py -v --tb=short
- uv run ruff check alternator/ tests/
- uv run ruff format --check alternator/ tests/
- make lint
- make test-unit