### PR TITLE
Add helper lifecycle facade

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -31,12 +31,12 @@ Supported or close:
 - static Alternator auth, disabled by default
 - TLS server CA and insecure trust-all modes
 - key route affinity with partition-key cache
+- helper lifecycle facade and public inspection methods
 - vector search support
 
 Tracked gaps:
 
 - node health tracking and quarantine planning only: [#32](https://github.com/scylladb/alternator-client-python/issues/32)
-- public helper facade and lifecycle inspection: [#33](https://github.com/scylladb/alternator-client-python/issues/33)
 - explicit routing-scope fallback and topology validation: [#35](https://github.com/scylladb/alternator-client-python/issues/35)
 - transport and SDK configuration propagation: [#34](https://github.com/scylladb/alternator-client-python/issues/34)
 - TLS client certificate and key log file support: [#38](https://github.com/scylladb/alternator-client-python/issues/38)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,47 @@ async def main():
 asyncio.run(main())
 ```
 
+### Helper Facade
+
+Use `Helper` when you need explicit lifecycle control or diagnostics in addition
+to standard boto3 clients and resources.
+
+```python
+from alternator import Config, Helper
+
+config = Config(seed_hosts=["192.168.1.1", "192.168.1.2"], port=8000)
+
+with Helper(config) as helper:
+    client = helper.client()
+    resource = helper.resource()
+
+    helper.update_live_nodes()
+    print(helper.get_nodes())
+    print(helper.next_node())
+
+    client.list_tables()
+    resource.Table("my_table").get_item(Key={"pk": "user123"})
+```
+
+Async code can use `AsyncHelper`:
+
+```python
+from alternator import Config
+from alternator.async_client import AsyncHelper
+
+config = Config(seed_hosts=["192.168.1.1"], port=8000)
+
+async with AsyncHelper(config) as helper:
+    client = await helper.client()
+    await helper.update_live_nodes()
+    print(helper.get_nodes())
+    await client.list_tables()
+```
+
+`get_active_nodes()` currently returns the live-node list, and
+`get_quarantined_nodes()` returns an empty list because node health and
+quarantine behavior are intentionally deferred.
+
 ## Configuration
 
 ### Basic Configuration

--- a/alternator/__init__.py
+++ b/alternator/__init__.py
@@ -51,6 +51,8 @@ for a fluent builder pattern::
 Key Classes
 -----------
 - ``AlternatorClient``: Sync context manager for load-balanced connections
+- ``Helper``: Sync lifecycle and diagnostics facade
+- ``AsyncHelper``: Async lifecycle and diagnostics facade
 - ``AsyncAlternatorClient``: Async context manager for load-balanced connections
 - ``Config``: Main configuration dataclass
 - ``Auth``: Explicit disabled/static-credentials auth settings
@@ -79,6 +81,7 @@ from alternator._version import __version__
 from alternator.client import (
     AlternatorClient,
     AlternatorResource,
+    Helper,
     client,
     close_client,
     close_resource,
@@ -122,12 +125,14 @@ __all__ = [
     # Sync Client
     "AlternatorClient",
     "AlternatorResource",
+    "Helper",
     "client",
     "close_client",
     "close_resource",
     "create_client",
     "create_resource",
     # Async Client (requires [async] extra)
+    "AsyncHelper",
     "AsyncAlternatorClient",
     "close_async_client",
     "create_async_client",
@@ -164,7 +169,12 @@ __all__ = [
 
 def __getattr__(name: str) -> object:
     """Lazy import async client components to avoid requiring async dependencies."""
-    if name in ("AsyncAlternatorClient", "close_async_client", "create_async_client"):
+    if name in (
+        "AsyncHelper",
+        "AsyncAlternatorClient",
+        "close_async_client",
+        "create_async_client",
+    ):
         from alternator import async_client
 
         return getattr(async_client, name)

--- a/alternator/_constants.py
+++ b/alternator/_constants.py
@@ -2,6 +2,7 @@
 
 # Attribute names used to store manager and pk_cache references on boto3 clients
 MANAGER_ATTR = "_alternator_manager"
+MANAGER_OWNS_ATTR = "_alternator_manager_owns_lifecycle"
 PK_CACHE_ATTR = "_alternator_pk_cache"
 
 # Timeout in seconds for waiting on partition key discovery from concurrent requests

--- a/alternator/async_client.py
+++ b/alternator/async_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
 import logging
 from collections.abc import Callable
@@ -11,6 +12,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from alternator._constants import (
     MANAGER_ATTR,
+    MANAGER_OWNS_ATTR,
     PK_CACHE_ATTR,
     PK_DISCOVERY_TIMEOUT_SECONDS,
 )
@@ -37,6 +39,7 @@ if TYPE_CHECKING:
     from alternator.config import Auth, Config
 
 logger = logging.getLogger("alternator")
+_AUTH_UNSET = object()
 
 
 class AsyncPartitionKeyCache:
@@ -269,53 +272,8 @@ def _create_async_affinity_hash_computer(
     return compute_affinity_hash
 
 
-async def create_async_client(
-    config: Config,
-    *,
-    auth: Auth | None = None,
-    **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
-) -> AsyncDynamoDBClient:
-    """
-    Create a load-balanced async DynamoDB client for Alternator.
-
-    The returned client is an aioboto3 DynamoDB client that
-    transparently distributes requests across cluster nodes.
-
-    Note:
-        Authentication is disabled by default. Alternator authentication
-        currently supports only static credentials; pass
-        ``auth=Auth.static_credentials(...)`` to enable request signing.
-
-    Args:
-        config: Alternator configuration
-        auth: Explicit Alternator auth settings. Defaults to disabled auth.
-        **boto_kwargs: Additional arguments passed to aioboto3.client()
-
-    Returns:
-        An async DynamoDB client with load balancing enabled
-
-    Example:
-        from alternator import Config
-        from alternator.async_client import create_async_client
-
-        config = Config(
-            seed_hosts=["node1.example.com"],
-            port=8000,
-        )
-        client = await create_async_client(config)
-
-        # Use like a normal aioboto3 client
-        response = await client.list_tables()
-    """
-    try:
-        import aioboto3
-        from aiobotocore.config import AioConfig
-    except ImportError as e:
-        raise ImportError(
-            "aioboto3 is required for async support. "
-            "Install with: pip install alternator[async]"
-        ) from e
-
+async def _create_async_manager(config: Config) -> AsyncLiveNodesManager:
+    """Create and initialize an async live-node manager."""
     # Create SSL context if using HTTPS
     ssl_context = None
     if config.scheme == "https":
@@ -326,7 +284,7 @@ async def create_async_client(
         ssl_context, timeout_seconds=config.timeouts.discovery_seconds
     )
 
-    # Create and start async live nodes manager
+    # Create async live nodes manager
     manager = AsyncLiveNodesManager(config, http_fetcher)
 
     # Perform initial node fetch
@@ -336,8 +294,41 @@ async def create_async_client(
 
         manager.set_fallback_nodes(list(config.seed_hosts), ClusterScope())
 
-    # Start background refresh task
-    await manager.start()
+    return manager
+
+
+async def _close_async_manager(manager: AsyncLiveNodesManager) -> None:
+    """Stop an async manager and close its discovery fetcher."""
+    await manager.stop()
+    http_fetch = manager._http_fetch
+    if isinstance(http_fetch, AsyncNodeFetcher):
+        await http_fetch.close()
+        return
+
+    http_close = getattr(http_fetch, "close", None)
+    if http_close is not None:
+        result = http_close()
+        if inspect.isawaitable(result):
+            await result
+
+
+async def _create_async_client_with_manager(
+    config: Config,
+    manager: AsyncLiveNodesManager,
+    *,
+    auth: Auth | None = None,
+    owns_manager: bool,
+    **boto_kwargs: Any,  # noqa: ANN401 -- aioboto3 kwargs are untyped
+) -> AsyncDynamoDBClient:
+    """Create an aioboto3 client using an already initialized manager."""
+    try:
+        import aioboto3
+        from aiobotocore.config import AioConfig
+    except ImportError as e:
+        raise ImportError(
+            "aioboto3 is required for async support. "
+            "Install with: pip install alternator[async]"
+        ) from e
 
     # Get initial endpoint
     initial_endpoint = manager.next_node_uri()
@@ -393,24 +384,68 @@ async def create_async_client(
 
         # Attach manager for cleanup reference
         setattr(client, MANAGER_ATTR, manager)
+        setattr(client, MANAGER_OWNS_ATTR, owns_manager)
 
         # Enable Alternator vector search extensions
         enable_vector_support(client)
     except Exception:
-        # Clean up the HTTP fetcher session on failure
-        if isinstance(http_fetcher, AsyncNodeFetcher):
-            await http_fetcher.close()
-        else:
-            http_close = getattr(http_fetcher, "close", None)
-            if http_close is not None:
-                result = http_close()
-                if inspect.isawaitable(result):
-                    await result
-        await manager.stop()
         await client_ctx.__aexit__(None, None, None)
         raise
 
     return cast("AsyncDynamoDBClient", client)
+
+
+async def create_async_client(
+    config: Config,
+    *,
+    auth: Auth | None = None,
+    **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
+) -> AsyncDynamoDBClient:
+    """
+    Create a load-balanced async DynamoDB client for Alternator.
+
+    The returned client is an aioboto3 DynamoDB client that
+    transparently distributes requests across cluster nodes.
+
+    Note:
+        Authentication is disabled by default. Alternator authentication
+        currently supports only static credentials; pass
+        ``auth=Auth.static_credentials(...)`` to enable request signing.
+
+    Args:
+        config: Alternator configuration
+        auth: Explicit Alternator auth settings. Defaults to disabled auth.
+        **boto_kwargs: Additional arguments passed to aioboto3.client()
+
+    Returns:
+        An async DynamoDB client with load balancing enabled
+
+    Example:
+        from alternator import Config
+        from alternator.async_client import create_async_client
+
+        config = Config(
+            seed_hosts=["node1.example.com"],
+            port=8000,
+        )
+        client = await create_async_client(config)
+
+        # Use like a normal aioboto3 client
+        response = await client.list_tables()
+    """
+    manager = await _create_async_manager(config)
+    await manager.start()
+    try:
+        return await _create_async_client_with_manager(
+            config,
+            manager,
+            auth=auth,
+            owns_manager=True,
+            **boto_kwargs,
+        )
+    except Exception:
+        await _close_async_manager(manager)
+        raise
 
 
 async def close_async_client(client: AsyncDynamoDBClient) -> None:
@@ -423,18 +458,11 @@ async def close_async_client(client: AsyncDynamoDBClient) -> None:
     try:
         manager = getattr(client, MANAGER_ATTR, None)
         if manager is not None:
-            await manager.stop()
-            # Close the HTTP fetcher session if it has a close method
-            http_fetch = manager._http_fetch
-            if isinstance(http_fetch, AsyncNodeFetcher):
-                await http_fetch.close()
-            else:
-                http_close = getattr(http_fetch, "close", None)
-                if http_close is not None:
-                    result = http_close()
-                    if inspect.isawaitable(result):
-                        await result
+            owns_manager = bool(getattr(client, MANAGER_OWNS_ATTR, True))
+            if owns_manager:
+                await _close_async_manager(manager)
             setattr(client, MANAGER_ATTR, None)
+            setattr(client, MANAGER_OWNS_ATTR, False)
 
         # Clear PK cache reference
         if hasattr(client, PK_CACHE_ATTR):
@@ -442,6 +470,160 @@ async def close_async_client(client: AsyncDynamoDBClient) -> None:
     finally:
         # Always close the underlying client
         await client.__aexit__(None, None, None)
+
+
+class AsyncHelper:
+    """
+    Async facade for Alternator client lifecycle and diagnostics.
+
+    The helper owns one async live-node manager and can create standard
+    aioboto3 DynamoDB clients that share that discovery state.
+    """
+
+    def __init__(
+        self,
+        config: Config,
+        *,
+        auth: Auth | None = None,
+        **boto_kwargs: Any,  # noqa: ANN401 -- aioboto3 kwargs are untyped
+    ) -> None:
+        self._config = config
+        self._auth = auth
+        self._boto_kwargs = dict(boto_kwargs)
+        self._manager: AsyncLiveNodesManager | None = None
+        self._clients: list[AsyncDynamoDBClient] = []
+
+    async def __aenter__(self) -> AsyncHelper:
+        await self.start()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        await self.stop()
+
+    @property
+    def config(self) -> Config:
+        """Return this helper's configuration."""
+        return self._config
+
+    def update(
+        self,
+        config: Config | None = None,
+        *,
+        auth: Auth | None | object = _AUTH_UNSET,
+        **boto_kwargs: Any,  # noqa: ANN401 -- aioboto3 kwargs are untyped
+    ) -> AsyncHelper:
+        """Return a new async helper with updated config, auth, or boto kwargs."""
+        next_auth = self._auth if auth is _AUTH_UNSET else cast("Auth | None", auth)
+        next_kwargs = {**self._boto_kwargs, **boto_kwargs}
+        return type(self)(config or self._config, auth=next_auth, **next_kwargs)
+
+    async def start(self) -> AsyncHelper:
+        """Start background node discovery."""
+        await (await self._ensure_manager()).start()
+        return self
+
+    async def stop(self) -> None:
+        """Stop background node discovery and close helper-created clients."""
+        for created_client in list(self._clients):
+            with contextlib.suppress(Exception):
+                await close_async_client(created_client)
+        self._clients.clear()
+
+        if self._manager is not None:
+            await _close_async_manager(self._manager)
+            self._manager = None
+
+    async def client(
+        self,
+        **boto_kwargs: Any,  # noqa: ANN401 -- aioboto3 kwargs are untyped
+    ) -> AsyncDynamoDBClient:
+        """Create a standard aioboto3 DynamoDB client using this helper."""
+        manager = await self._ensure_manager()
+        await manager.start()
+        client = await _create_async_client_with_manager(
+            self._config,
+            manager,
+            auth=self._auth,
+            owns_manager=False,
+            **{**self._boto_kwargs, **boto_kwargs},
+        )
+        self._clients.append(client)
+        return client
+
+    async def update_live_nodes(self) -> bool:
+        """Refresh the live-node list immediately."""
+        return await (await self._ensure_manager()).refresh_nodes()
+
+    async def next_node(self) -> str | None:
+        """Return the next live node selected for diagnostics."""
+        return (await self._ensure_manager()).next_node()
+
+    def get_nodes(self) -> list[str]:
+        """Return the current live-node hostnames."""
+        if self._manager is None:
+            return []
+        return list(self._manager.nodes.nodes)
+
+    def get_active_nodes(self) -> list[str]:
+        """Return active nodes; currently this is the live-node list."""
+        return self.get_nodes()
+
+    def get_quarantined_nodes(self) -> list[str]:
+        """Return quarantined nodes; node quarantine is not implemented."""
+        return []
+
+    def check_rack_and_datacenter_set_correctly(self) -> bool:
+        """Return whether the configured rack/datacenter scope is complete."""
+        from alternator.core.routing_scope import DatacenterScope, RackScope
+
+        scope = self._config.routing_scope
+        if isinstance(scope, RackScope):
+            return bool(scope.datacenter and scope.rack)
+        if isinstance(scope, DatacenterScope):
+            return bool(scope.datacenter)
+        return True
+
+    def check_rack_datacenter_feature_supported(self) -> bool:
+        """Return whether this client supports rack/datacenter scoped discovery."""
+        from alternator.core.routing_scope import (
+            ClusterScope,
+            DatacenterScope,
+            RackScope,
+        )
+
+        return isinstance(
+            self._config.routing_scope,
+            ClusterScope | DatacenterScope | RackScope,
+        )
+
+    async def get_partition_key_name(self, table_name: str) -> str | None:
+        """Return a known partition key name for diagnostics."""
+        configured = self._config.key_affinity.table_pk_attributes.get(table_name)
+        if configured is not None:
+            return configured
+
+        for created_client in self._clients:
+            pk_cache = getattr(created_client, PK_CACHE_ATTR, None)
+            if pk_cache is None:
+                continue
+            get_pk_name = getattr(pk_cache, "get_pk_name", None)
+            if not callable(get_pk_name):
+                continue
+            result = get_pk_name(table_name)
+            if inspect.isawaitable(result):
+                return cast("str | None", await result)
+            return cast("str | None", result)
+        return None
+
+    async def _ensure_manager(self) -> AsyncLiveNodesManager:
+        if self._manager is None:
+            self._manager = await _create_async_manager(self._config)
+        return self._manager
 
 
 class AsyncAlternatorClient:

--- a/alternator/client.py
+++ b/alternator/client.py
@@ -9,12 +9,12 @@ import threading
 import weakref
 from collections.abc import Callable, Sequence
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import boto3
 from botocore.config import Config as BotoConfig
 
-from alternator._constants import MANAGER_ATTR, PK_CACHE_ATTR
+from alternator._constants import MANAGER_ATTR, MANAGER_OWNS_ATTR, PK_CACHE_ATTR
 from alternator._http import create_ssl_context, create_sync_http_fetcher
 from alternator.config import Config, KeyRouteAffinityMode
 from alternator.core.auth import apply_auth
@@ -44,6 +44,7 @@ _active_managers: weakref.WeakValueDictionary[int, SyncLiveNodesManager] = (
     weakref.WeakValueDictionary()
 )
 _registry_lock = threading.Lock()
+_AUTH_UNSET = object()
 
 
 def _cleanup_manager(manager_id: int) -> None:
@@ -65,13 +66,24 @@ def _cleanup_manager(manager_id: int) -> None:
         pass
 
 
+def _register_active_manager(manager: SyncLiveNodesManager) -> None:
+    """Register a manager for process-exit cleanup."""
+    with _registry_lock:
+        _active_managers[id(manager)] = manager
+
+
+def _unregister_active_manager(manager: SyncLiveNodesManager) -> None:
+    """Remove a manager from process-exit cleanup tracking."""
+    with _registry_lock:
+        _active_managers.pop(id(manager), None)
+
+
 def _register_manager(
     manager: SyncLiveNodesManager, client: DynamoDBClient | DynamoDBServiceResource
 ) -> None:
     """Register a manager for cleanup tracking and set up GC finalizer."""
     manager_id = id(manager)
-    with _registry_lock:
-        _active_managers[manager_id] = manager
+    _register_active_manager(manager)
     weakref.finalize(client, _cleanup_manager, manager_id)
 
 
@@ -87,7 +99,7 @@ def _cleanup_all_managers() -> None:
             manager.stop()
 
 
-def _create_and_start_manager(config: Config) -> SyncLiveNodesManager:
+def _create_manager(config: Config) -> SyncLiveNodesManager:
     """
     Create and initialize a SyncLiveNodesManager.
 
@@ -95,7 +107,6 @@ def _create_and_start_manager(config: Config) -> SyncLiveNodesManager:
     - SSL context creation for HTTPS
     - HTTP fetcher setup
     - Initial node discovery with fallback
-    - Starting background refresh thread
 
     Args:
         config: Alternator configuration
@@ -123,9 +134,13 @@ def _create_and_start_manager(config: Config) -> SyncLiveNodesManager:
 
         manager.set_fallback_nodes(list(config.seed_hosts), ClusterScope())
 
-    # Start background refresh thread
-    manager.start()
+    return manager
 
+
+def _create_and_start_manager(config: Config) -> SyncLiveNodesManager:
+    """Create a manager and start its background refresh thread."""
+    manager = _create_manager(config)
+    manager.start()
     return manager
 
 
@@ -222,6 +237,56 @@ def _create_affinity_hash_computer(
     return compute_affinity_hash
 
 
+def _create_client_with_manager(
+    config: Config,
+    manager: SyncLiveNodesManager,
+    *,
+    auth: Auth | None = None,
+    owns_manager: bool,
+    **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
+) -> DynamoDBClient:
+    """Create a boto3 client using an already initialized manager."""
+    # BotoConfig is managed internally — don't let callers override it
+    boto_kwargs.pop("config", None)
+
+    # Get initial endpoint and merged boto config
+    initial_endpoint = manager.next_node_uri()
+    auth_enabled = apply_auth(auth, boto_kwargs)
+    boto_config = _create_boto_config(config, auth_enabled=auth_enabled)
+
+    # Create boto3 client
+    # Alternator doesn't use AWS regions, but boto3 requires one;
+    # default to "us-east-1" unless the caller overrides it.
+    boto_kwargs.setdefault("region_name", "us-east-1")
+    client: DynamoDBClient = boto3.client(
+        "dynamodb",
+        endpoint_url=initial_endpoint,
+        config=boto_config,
+        **boto_kwargs,
+    )
+
+    # Register all handlers
+    _register_alternator_handlers(
+        client.meta.events,
+        manager,
+        config,
+        _create_affinity_hash_computer(config, client),
+        auth_enabled=auth_enabled,
+    )
+
+    # Attach manager for cleanup reference
+    setattr(client, MANAGER_ATTR, manager)
+    setattr(client, MANAGER_OWNS_ATTR, owns_manager)
+
+    # Enable Alternator vector search extensions before registering finalizers.
+    enable_vector_support(client)
+
+    if owns_manager:
+        _register_manager(manager, client)
+
+    return client
+
+
 def create_client(
     config: Config,
     *,
@@ -260,51 +325,19 @@ def create_client(
         # Use like a normal boto3 client
         response = client.list_tables()
     """
-    # BotoConfig is managed internally — don't let callers override it
-    boto_kwargs.pop("config", None)
-
-    # Create and start manager (handles SSL, HTTP fetcher, node discovery)
     manager = _create_and_start_manager(config)
-
-    # Get initial endpoint and merged boto config
-    initial_endpoint = manager.next_node_uri()
-    auth_enabled = apply_auth(auth, boto_kwargs)
-    boto_config = _create_boto_config(config, auth_enabled=auth_enabled)
-
-    # Create boto3 client
-    # Alternator doesn't use AWS regions, but boto3 requires one;
-    # default to "us-east-1" unless the caller overrides it.
-    boto_kwargs.setdefault("region_name", "us-east-1")
-    client: DynamoDBClient = boto3.client(
-        "dynamodb",
-        endpoint_url=initial_endpoint,
-        config=boto_config,
-        **boto_kwargs,
-    )
-
-    # Register manager for cleanup tracking (with GC finalizer on client)
-    _register_manager(manager, client)
-
-    # Register all handlers
-    _register_alternator_handlers(
-        client.meta.events,
-        manager,
-        config,
-        _create_affinity_hash_computer(config, client),
-        auth_enabled=auth_enabled,
-    )
-
-    # Attach manager for cleanup reference
-    setattr(client, MANAGER_ATTR, manager)
-
-    # Enable Alternator vector search extensions
     try:
-        enable_vector_support(client)
+        return _create_client_with_manager(
+            config,
+            manager,
+            auth=auth,
+            owns_manager=True,
+            **boto_kwargs,
+        )
     except Exception:
         manager.stop()
+        _unregister_active_manager(manager)
         raise
-
-    return client
 
 
 def _seed_has_port(seed: str) -> bool:
@@ -377,11 +410,32 @@ def create_resource(
         table = resource.Table("my_table")
         table.put_item(Item={"pk": "123", "data": "hello"})
     """
+    manager = _create_and_start_manager(config)
+    try:
+        return _create_resource_with_manager(
+            config,
+            manager,
+            auth=auth,
+            owns_manager=True,
+            **boto_kwargs,
+        )
+    except Exception:
+        manager.stop()
+        _unregister_active_manager(manager)
+        raise
+
+
+def _create_resource_with_manager(
+    config: Config,
+    manager: SyncLiveNodesManager,
+    *,
+    auth: Auth | None = None,
+    owns_manager: bool,
+    **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
+) -> DynamoDBServiceResource:
+    """Create a boto3 resource using an already initialized manager."""
     # BotoConfig is managed internally — don't let callers override it
     boto_kwargs.pop("config", None)
-
-    # Create and start manager (handles SSL, HTTP fetcher, node discovery)
-    manager = _create_and_start_manager(config)
 
     # Get initial endpoint and merged boto config
     initial_endpoint = manager.next_node_uri()
@@ -399,9 +453,6 @@ def create_resource(
         **boto_kwargs,
     )
 
-    # Register manager for cleanup tracking (with GC finalizer on resource)
-    _register_manager(manager, resource)
-
     # Register all handlers
     _register_alternator_handlers(
         resource.meta.client.meta.events,
@@ -413,13 +464,13 @@ def create_resource(
 
     # Attach manager for cleanup reference
     setattr(resource, MANAGER_ATTR, manager)
+    setattr(resource, MANAGER_OWNS_ATTR, owns_manager)
 
-    # Enable Alternator vector search extensions
-    try:
-        enable_vector_support(resource)
-    except Exception:
-        manager.stop()
-        raise
+    # Enable Alternator vector search extensions before registering finalizers.
+    enable_vector_support(resource)
+
+    if owns_manager:
+        _register_manager(manager, resource)
 
     return resource
 
@@ -436,17 +487,208 @@ def close_client(client: DynamoDBClient | DynamoDBServiceResource) -> None:
     """
     manager = getattr(client, MANAGER_ATTR, None)
     if manager is not None:
-        # Remove from registry first
-        manager_id = id(manager)
-        with _registry_lock:
-            _active_managers.pop(manager_id, None)
-
-        manager.stop()
+        owns_manager = bool(getattr(client, MANAGER_OWNS_ATTR, True))
+        if owns_manager:
+            _unregister_active_manager(manager)
+            manager.stop()
         setattr(client, MANAGER_ATTR, None)
+        setattr(client, MANAGER_OWNS_ATTR, False)
 
     # Clear PK cache reference
     if hasattr(client, PK_CACHE_ATTR):
         setattr(client, PK_CACHE_ATTR, None)
+
+
+class Helper:
+    """
+    Public facade for Alternator client lifecycle and diagnostics.
+
+    The helper owns one live-node manager and can create standard boto3
+    DynamoDB clients and resources that share that discovery state.
+    """
+
+    def __init__(
+        self,
+        config: Config,
+        *,
+        auth: Auth | None = None,
+        **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
+    ) -> None:
+        self._config = config
+        self._auth = auth
+        self._boto_kwargs = dict(boto_kwargs)
+        self._manager: SyncLiveNodesManager | None = None
+        self._manager_finalizer: Any | None = None
+        self._clients: list[DynamoDBClient | DynamoDBServiceResource] = []
+
+    def __enter__(self) -> Helper:
+        self.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.stop()
+
+    @property
+    def config(self) -> Config:
+        """Return this helper's configuration."""
+        return self._config
+
+    def update(
+        self,
+        config: Config | None = None,
+        *,
+        auth: Auth | None | object = _AUTH_UNSET,
+        **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
+    ) -> Helper:
+        """Return a new helper with updated config, auth, or boto kwargs."""
+        next_auth = self._auth if auth is _AUTH_UNSET else cast("Auth | None", auth)
+        next_kwargs = {**self._boto_kwargs, **boto_kwargs}
+        return type(self)(config or self._config, auth=next_auth, **next_kwargs)
+
+    def start(self) -> Helper:
+        """Start background node discovery."""
+        self._ensure_manager().start()
+        return self
+
+    def stop(self) -> None:
+        """Stop background node discovery and detach helper-created clients."""
+        for created_client in list(self._clients):
+            with contextlib.suppress(Exception):
+                close_client(created_client)
+        self._clients.clear()
+
+        if self._manager is not None:
+            _unregister_active_manager(self._manager)
+            self._manager.stop()
+            self._manager = None
+
+        if self._manager_finalizer is not None:
+            self._manager_finalizer.detach()
+            self._manager_finalizer = None
+
+    def client(
+        self,
+        **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
+    ) -> DynamoDBClient:
+        """Create a standard boto3 DynamoDB client using this helper."""
+        manager = self._ensure_manager()
+        manager.start()
+        client = _create_client_with_manager(
+            self._config,
+            manager,
+            auth=self._auth,
+            owns_manager=False,
+            **{**self._boto_kwargs, **boto_kwargs},
+        )
+        self._clients.append(client)
+        return client
+
+    def resource(
+        self,
+        **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
+    ) -> DynamoDBServiceResource:
+        """Create a standard boto3 DynamoDB resource using this helper."""
+        manager = self._ensure_manager()
+        manager.start()
+        resource = _create_resource_with_manager(
+            self._config,
+            manager,
+            auth=self._auth,
+            owns_manager=False,
+            **{**self._boto_kwargs, **boto_kwargs},
+        )
+        self._clients.append(resource)
+        return resource
+
+    def update_live_nodes(self) -> bool:
+        """Refresh the live-node list immediately."""
+        return self._ensure_manager().refresh_nodes()
+
+    def next_node(self) -> str | None:
+        """Return the next live node selected for diagnostics."""
+        return self._ensure_manager().next_node()
+
+    def get_nodes(self) -> list[str]:
+        """Return the current live-node hostnames."""
+        if self._manager is None:
+            return []
+        return list(self._manager.nodes.nodes)
+
+    def get_active_nodes(self) -> list[str]:
+        """Return active nodes; currently this is the live-node list."""
+        return self.get_nodes()
+
+    def get_quarantined_nodes(self) -> list[str]:
+        """Return quarantined nodes; node quarantine is not implemented."""
+        return []
+
+    def check_rack_and_datacenter_set_correctly(self) -> bool:
+        """Return whether the configured rack/datacenter scope is complete."""
+        from alternator.core.routing_scope import DatacenterScope, RackScope
+
+        scope = self._config.routing_scope
+        if isinstance(scope, RackScope):
+            return bool(scope.datacenter and scope.rack)
+        if isinstance(scope, DatacenterScope):
+            return bool(scope.datacenter)
+        return True
+
+    def check_rack_datacenter_feature_supported(self) -> bool:
+        """Return whether this client supports rack/datacenter scoped discovery."""
+        from alternator.core.routing_scope import (
+            ClusterScope,
+            DatacenterScope,
+            RackScope,
+        )
+
+        return isinstance(
+            self._config.routing_scope,
+            ClusterScope | DatacenterScope | RackScope,
+        )
+
+    def get_partition_key_name(self, table_name: str) -> str | None:
+        """Return a known partition key name for diagnostics."""
+        configured = self._config.key_affinity.table_pk_attributes.get(table_name)
+        if configured is not None:
+            return configured
+
+        for created_client in self._clients:
+            pk_cache = self._get_partition_key_cache(created_client)
+            if pk_cache is None:
+                continue
+            get_pk_name = getattr(pk_cache, "get_pk_name", None)
+            if callable(get_pk_name):
+                return cast("str | None", get_pk_name(table_name))
+        return None
+
+    def _ensure_manager(self) -> SyncLiveNodesManager:
+        if self._manager is None:
+            manager = _create_manager(self._config)
+            _register_active_manager(manager)
+            self._manager_finalizer = weakref.finalize(
+                self,
+                _cleanup_manager,
+                id(manager),
+            )
+            self._manager = manager
+        return self._manager
+
+    def _get_partition_key_cache(
+        self,
+        created_client: DynamoDBClient | DynamoDBServiceResource,
+    ) -> object | None:
+        pk_cache = getattr(created_client, PK_CACHE_ATTR, None)
+        if pk_cache is not None:
+            return cast(object, pk_cache)
+
+        meta = getattr(created_client, "meta", None)
+        service_client = getattr(meta, "client", None)
+        return cast(object | None, getattr(service_client, PK_CACHE_ATTR, None))
 
 
 class AlternatorClient:

--- a/alternator/core/live_nodes.py
+++ b/alternator/core/live_nodes.py
@@ -237,6 +237,9 @@ class SyncLiveNodesManager:
 
     def start(self) -> None:
         """Start background refresh thread."""
+        if self._refresh_thread is not None and self._refresh_thread.is_alive():
+            return
+        self._stop_event.clear()
         self._refresh_thread = threading.Thread(
             target=self._refresh_loop,
             daemon=True,
@@ -249,11 +252,16 @@ class SyncLiveNodesManager:
         self._stop_event.set()
         if self._refresh_thread:
             self._refresh_thread.join(timeout=5.0)
+            self._refresh_thread = None
 
     @property
     def nodes(self) -> NodeList:
         """Get current node list."""
         return self._core.nodes
+
+    def next_node(self) -> str | None:
+        """Get next node hostname using round-robin."""
+        return self._core.next_node()
 
     def set_fallback_nodes(self, nodes: Sequence[str], scope: RoutingScope) -> None:
         """
@@ -358,6 +366,8 @@ class AsyncLiveNodesManager:
 
     async def start(self) -> None:
         """Start background refresh task."""
+        if self._refresh_task is not None and not self._refresh_task.done():
+            return
         self._stop_event.clear()
         self._refresh_task = asyncio.create_task(
             self._refresh_loop(),
@@ -377,6 +387,10 @@ class AsyncLiveNodesManager:
     def nodes(self) -> NodeList:
         """Get current node list."""
         return self._core.nodes
+
+    def next_node(self) -> str | None:
+        """Get next node hostname using round-robin."""
+        return self._core.next_node()
 
     def set_fallback_nodes(self, nodes: Sequence[str], scope: RoutingScope) -> None:
         """

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -20,7 +20,7 @@ and intentionally deferred behavior.
 | TLS key log file | Missing | [#38](https://github.com/scylladb/alternator-client-python/issues/38) | Debug-only key log file support is planned. |
 | Transport and SDK config knobs | Partial | [#34](https://github.com/scylladb/alternator-client-python/issues/34) | Retry and pool config exist; connect/read timeout and customizer wiring are planned. |
 | Key route affinity | Partial | [#23](https://github.com/scylladb/alternator-client-python/issues/23) | Partition-key cache exists; RMW rules and BatchWriteItem voting need alignment with the request-routing specification. |
-| Helper lifecycle facade | Missing | [#33](https://github.com/scylladb/alternator-client-python/issues/33) | Public lifecycle, diagnostics, and inspection facade is planned. |
+| Helper lifecycle facade | Supported | [#33](https://github.com/scylladb/alternator-client-python/issues/33) | `Helper` and `AsyncHelper` expose lifecycle, node inspection, topology checks, and partition-key diagnostics. |
 | Node health tracking | Deferred | [#32](https://github.com/scylladb/alternator-client-python/issues/32) | Planning-only. No node health code, tests, config objects, or behavior changes are authorized by this roadmap. |
 | Vector search extension | Supported | Existing API | Python client enables ScyllaDB Alternator vector extensions. |
 | Capability test harness | Partial | [#36](https://github.com/scylladb/alternator-client-python/issues/36) | Fake Alternator server fixture introduced for deterministic unit tests. |

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -1,0 +1,161 @@
+"""Tests for public Helper facades."""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+import pytest
+
+import alternator
+from alternator import Auth, Config, Helper, close_client
+from alternator._constants import MANAGER_ATTR, MANAGER_OWNS_ATTR
+from alternator.async_client import AsyncHelper
+from alternator.config import KeyRouteAffinityConfig
+from alternator.core.routing_scope import (
+    ClusterScope,
+    DatacenterScope,
+    RackScope,
+    RoutingScope,
+)
+from tests.conftest import FakeAlternatorServer
+
+
+def _config_for_server(
+    server: FakeAlternatorServer,
+    *,
+    routing_scope: RoutingScope | None = None,
+    key_affinity: KeyRouteAffinityConfig | None = None,
+) -> Config:
+    parsed = urlsplit(server.url("/"))
+    assert parsed.hostname is not None
+    assert parsed.port is not None
+
+    return Config(
+        seed_hosts=[parsed.hostname],
+        port=parsed.port,
+        routing_scope=routing_scope or ClusterScope(),
+        key_affinity=key_affinity or KeyRouteAffinityConfig(),
+    )
+
+
+def test_helper_is_exported() -> None:
+    """Helper is available from the top-level package."""
+    assert alternator.Helper is Helper
+    assert alternator.AsyncHelper is AsyncHelper
+
+
+def test_helper_lifecycle_and_node_diagnostics(
+    fake_alternator_server: FakeAlternatorServer,
+) -> None:
+    """Helper exposes explicit lifecycle and live-node inspection."""
+    fake_alternator_server.set_localnodes(["node2", "node1"])
+    helper = Helper(_config_for_server(fake_alternator_server))
+
+    assert helper.get_nodes() == []
+    assert helper.update_live_nodes() is True
+    assert helper.get_nodes() == ["node1", "node2"]
+    assert helper.get_active_nodes() == ["node1", "node2"]
+    assert helper.get_quarantined_nodes() == []
+    assert helper.next_node() == "node1"
+    assert helper.next_node() == "node2"
+
+    helper.start()
+    helper.start()
+    helper.stop()
+    helper.stop()
+    assert helper.get_nodes() == []
+
+
+def test_helper_created_clients_borrow_helper_manager(
+    fake_alternator_server: FakeAlternatorServer,
+) -> None:
+    """Closing a helper-created client does not stop the helper manager."""
+    fake_alternator_server.set_localnodes(["node1"])
+
+    with Helper(_config_for_server(fake_alternator_server)) as helper:
+        client = helper.client()
+        resource = helper.resource()
+
+        assert getattr(client, MANAGER_ATTR) is helper._manager
+        assert getattr(resource, MANAGER_ATTR) is helper._manager
+        assert getattr(client, MANAGER_OWNS_ATTR) is False
+        assert getattr(resource, MANAGER_OWNS_ATTR) is False
+
+        close_client(client)
+        assert helper.update_live_nodes() is True
+
+
+def test_helper_update_returns_new_helper(
+    fake_alternator_server: FakeAlternatorServer,
+) -> None:
+    """update returns a fresh helper with merged settings."""
+    config = _config_for_server(fake_alternator_server)
+    helper = Helper(config, auth=Auth.disabled(), region_name="us-west-2")
+    updated = helper.update(region_name="us-east-1")
+
+    assert updated is not helper
+    assert updated.config is config
+    assert updated._auth == Auth.disabled()
+    assert updated._boto_kwargs["region_name"] == "us-east-1"
+
+
+def test_helper_topology_checks(fake_alternator_server: FakeAlternatorServer) -> None:
+    """Helper exposes lightweight topology configuration checks."""
+    assert Helper(
+        _config_for_server(fake_alternator_server, routing_scope=ClusterScope())
+    ).check_rack_and_datacenter_set_correctly()
+    assert Helper(
+        _config_for_server(
+            fake_alternator_server,
+            routing_scope=DatacenterScope(datacenter="dc1"),
+        )
+    ).check_rack_and_datacenter_set_correctly()
+    assert not Helper(
+        _config_for_server(
+            fake_alternator_server,
+            routing_scope=RackScope(datacenter="dc1", rack=""),
+        )
+    ).check_rack_and_datacenter_set_correctly()
+    assert Helper(
+        _config_for_server(
+            fake_alternator_server,
+            routing_scope=RackScope(datacenter="dc1", rack="rack1"),
+        )
+    ).check_rack_datacenter_feature_supported()
+
+
+def test_helper_partition_key_diagnostics_from_config(
+    fake_alternator_server: FakeAlternatorServer,
+) -> None:
+    """Configured partition-key mappings are exposed without private access."""
+    helper = Helper(
+        _config_for_server(
+            fake_alternator_server,
+            key_affinity=KeyRouteAffinityConfig(table_pk_attributes={"tbl": "pk"}),
+        )
+    )
+
+    assert helper.get_partition_key_name("tbl") == "pk"
+    assert helper.get_partition_key_name("missing") is None
+
+
+@pytest.mark.asyncio
+async def test_async_helper_lifecycle_and_node_diagnostics(
+    fake_alternator_server: FakeAlternatorServer,
+) -> None:
+    """AsyncHelper exposes async lifecycle and live-node inspection."""
+    fake_alternator_server.set_localnodes(["node2", "node1"])
+    helper = AsyncHelper(_config_for_server(fake_alternator_server))
+
+    assert helper.get_nodes() == []
+    assert await helper.update_live_nodes() is True
+    assert helper.get_nodes() == ["node1", "node2"]
+    assert helper.get_active_nodes() == ["node1", "node2"]
+    assert helper.get_quarantined_nodes() == []
+    assert await helper.next_node() == "node1"
+
+    await helper.start()
+    await helper.start()
+    await helper.stop()
+    await helper.stop()
+    assert helper.get_nodes() == []


### PR DESCRIPTION
Closes #33

## Summary
- add `Helper` and `AsyncHelper` lifecycle facades for client creation, explicit start/stop, live-node refresh, node inspection, topology checks, and partition-key diagnostics
- keep existing `create_client`, `create_resource`, `AlternatorClient`, `AlternatorResource`, and async client APIs behaviorally compatible
- make manager ownership explicit so helper-created clients borrow the helper manager while convenience factories still own cleanup
- document helper usage and mark the helper capability as supported in the roadmap and matrix
- keep node health and quarantine behavior deferred; `get_quarantined_nodes()` returns an empty list and no node-health behavior is implemented

## Testing
- uv run pytest tests/unit/test_helper.py tests/unit/test_sync_manager.py tests/unit/test_async_manager.py -v --tb=short
- make lint
- make test-unit