### PR TITLE
Add explicit routing fallback validation

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -24,7 +24,7 @@ Supported or close:
 - host-only seeds with one shared port
 - sync boto3 client, boto3 resource, async aioboto3 client
 - `/localnodes` node discovery
-- basic cluster/datacenter/rack routing scopes
+- explicit cluster/datacenter/rack routing scopes and fallback chains
 - request-scoped lazy query plans with stable seeded ordering
 - gzip request compression
 - header optimization
@@ -37,7 +37,6 @@ Supported or close:
 Tracked gaps:
 
 - node health tracking and quarantine planning only: [#32](https://github.com/scylladb/alternator-client-python/issues/32)
-- explicit routing-scope fallback and topology validation: [#35](https://github.com/scylladb/alternator-client-python/issues/35)
 - transport and SDK configuration propagation: [#34](https://github.com/scylladb/alternator-client-python/issues/34)
 - TLS client certificate and key log file support: [#38](https://github.com/scylladb/alternator-client-python/issues/38)
 - configurable compression and header whitelist behavior: [#37](https://github.com/scylladb/alternator-client-python/issues/37)

--- a/README.md
+++ b/README.md
@@ -259,14 +259,14 @@ config = Config(
     routing_scope=ClusterScope(),
 )
 
-# Route to nodes in a specific datacenter
+# Route to nodes in a specific datacenter, then fall back to cluster
 config = Config(
     seed_hosts=["node1"],
     port=8000,
     routing_scope=DatacenterScope(datacenter="us-east-1"),
 )
 
-# Route to nodes in a specific rack (with fallback)
+# Route to nodes in a specific rack, then fall back to datacenter and cluster
 config = Config(
     seed_hosts=["node1"],
     port=8000,
@@ -274,8 +274,32 @@ config = Config(
 )
 ```
 
-Scopes automatically fall back to broader scopes if no nodes are available:
-- `RackScope` → `DatacenterScope` → `ClusterScope`
+Default constructors keep compatibility fallback behavior:
+
+- `DatacenterScope("dc1")` uses `DatacenterScope` -> `ClusterScope`
+- `RackScope("dc1", "rack1")` uses `RackScope` -> `DatacenterScope` -> `ClusterScope`
+
+Use the named `fallback` argument for explicit routing constraints:
+
+```python
+from alternator import ClusterScope, DatacenterScope, RackScope
+
+cluster_only = ClusterScope()
+datacenter_only = DatacenterScope("dc1", fallback=None)
+datacenter_then_cluster = DatacenterScope("dc1", fallback=ClusterScope())
+rack_only = RackScope("dc1", "rack1", fallback=None)
+rack_then_datacenter = RackScope(
+    "dc1",
+    "rack1",
+    fallback=DatacenterScope("dc1", fallback=None),
+)
+rack_then_datacenter_then_cluster = RackScope.with_default_fallback("dc1", "rack1")
+```
+
+`Helper.check_rack_and_datacenter_set_correctly()` validates the configured
+scope by querying `/localnodes` with the configured datacenter and rack filters
+without replacing the helper's current live-node list.
+`AsyncHelper` exposes the same validation methods as awaitable methods.
 
 ## Key Affinity (LWT Optimization)
 

--- a/alternator/async_client.py
+++ b/alternator/async_client.py
@@ -272,7 +272,11 @@ def _create_async_affinity_hash_computer(
     return compute_affinity_hash
 
 
-async def _create_async_manager(config: Config) -> AsyncLiveNodesManager:
+async def _create_async_manager(
+    config: Config,
+    *,
+    initial_refresh: bool = True,
+) -> AsyncLiveNodesManager:
     """Create and initialize an async live-node manager."""
     # Create SSL context if using HTTPS
     ssl_context = None
@@ -288,11 +292,15 @@ async def _create_async_manager(config: Config) -> AsyncLiveNodesManager:
     manager = AsyncLiveNodesManager(config, http_fetcher)
 
     # Perform initial node fetch
-    if not await manager.refresh_nodes():
-        logger.warning("Initial node discovery failed, using seed hosts")
-        from alternator.core.routing_scope import ClusterScope
+    if initial_refresh and not await manager.refresh_nodes():
+        from alternator.core.routing_scope import (
+            ClusterScope,
+            scope_chain_includes_cluster,
+        )
 
-        manager.set_fallback_nodes(list(config.seed_hosts), ClusterScope())
+        if scope_chain_includes_cluster(config.routing_scope):
+            logger.warning("Initial node discovery failed, using seed hosts")
+            manager.set_fallback_nodes(list(config.seed_hosts), ClusterScope())
 
     return manager
 
@@ -577,29 +585,29 @@ class AsyncHelper:
         """Return quarantined nodes; node quarantine is not implemented."""
         return []
 
-    def check_rack_and_datacenter_set_correctly(self) -> bool:
-        """Return whether the configured rack/datacenter scope is complete."""
-        from alternator.core.routing_scope import DatacenterScope, RackScope
+    async def check_rack_and_datacenter_set_correctly(self) -> bool:
+        """Validate configured rack/datacenter scope without changing state."""
+        manager = self._manager
+        if manager is not None:
+            return await manager.check_rack_and_datacenter_set_correctly()
 
-        scope = self._config.routing_scope
-        if isinstance(scope, RackScope):
-            return bool(scope.datacenter and scope.rack)
-        if isinstance(scope, DatacenterScope):
-            return bool(scope.datacenter)
-        return True
+        manager = await _create_async_manager(self._config, initial_refresh=False)
+        try:
+            return await manager.check_rack_and_datacenter_set_correctly()
+        finally:
+            await _close_async_manager(manager)
 
-    def check_rack_datacenter_feature_supported(self) -> bool:
-        """Return whether this client supports rack/datacenter scoped discovery."""
-        from alternator.core.routing_scope import (
-            ClusterScope,
-            DatacenterScope,
-            RackScope,
-        )
+    async def check_rack_datacenter_feature_supported(self) -> bool:
+        """Report whether scoped rack/datacenter discovery appears supported."""
+        manager = self._manager
+        if manager is not None:
+            return await manager.check_rack_datacenter_feature_supported()
 
-        return isinstance(
-            self._config.routing_scope,
-            ClusterScope | DatacenterScope | RackScope,
-        )
+        manager = await _create_async_manager(self._config, initial_refresh=False)
+        try:
+            return await manager.check_rack_datacenter_feature_supported()
+        finally:
+            await _close_async_manager(manager)
 
     async def get_partition_key_name(self, table_name: str) -> str | None:
         """Return a known partition key name for diagnostics."""

--- a/alternator/client.py
+++ b/alternator/client.py
@@ -99,7 +99,11 @@ def _cleanup_all_managers() -> None:
             manager.stop()
 
 
-def _create_manager(config: Config) -> SyncLiveNodesManager:
+def _create_manager(
+    config: Config,
+    *,
+    initial_refresh: bool = True,
+) -> SyncLiveNodesManager:
     """
     Create and initialize a SyncLiveNodesManager.
 
@@ -128,11 +132,15 @@ def _create_manager(config: Config) -> SyncLiveNodesManager:
     manager = SyncLiveNodesManager(config, http_fetcher)
 
     # Perform initial node fetch (blocking)
-    if not manager.refresh_nodes():
-        logger.warning("Initial node discovery failed, using seed hosts")
-        from alternator.core.routing_scope import ClusterScope
+    if initial_refresh and not manager.refresh_nodes():
+        from alternator.core.routing_scope import (
+            ClusterScope,
+            scope_chain_includes_cluster,
+        )
 
-        manager.set_fallback_nodes(list(config.seed_hosts), ClusterScope())
+        if scope_chain_includes_cluster(config.routing_scope):
+            logger.warning("Initial node discovery failed, using seed hosts")
+            manager.set_fallback_nodes(list(config.seed_hosts), ClusterScope())
 
     return manager
 
@@ -629,27 +637,27 @@ class Helper:
 
     def check_rack_and_datacenter_set_correctly(self) -> bool:
         """Return whether the configured rack/datacenter scope is complete."""
-        from alternator.core.routing_scope import DatacenterScope, RackScope
+        manager = self._manager
+        if manager is not None:
+            return manager.check_rack_and_datacenter_set_correctly()
 
-        scope = self._config.routing_scope
-        if isinstance(scope, RackScope):
-            return bool(scope.datacenter and scope.rack)
-        if isinstance(scope, DatacenterScope):
-            return bool(scope.datacenter)
-        return True
+        manager = _create_manager(self._config, initial_refresh=False)
+        try:
+            return manager.check_rack_and_datacenter_set_correctly()
+        finally:
+            manager.stop()
 
     def check_rack_datacenter_feature_supported(self) -> bool:
         """Return whether this client supports rack/datacenter scoped discovery."""
-        from alternator.core.routing_scope import (
-            ClusterScope,
-            DatacenterScope,
-            RackScope,
-        )
+        manager = self._manager
+        if manager is not None:
+            return manager.check_rack_datacenter_feature_supported()
 
-        return isinstance(
-            self._config.routing_scope,
-            ClusterScope | DatacenterScope | RackScope,
-        )
+        manager = _create_manager(self._config, initial_refresh=False)
+        try:
+            return manager.check_rack_datacenter_feature_supported()
+        finally:
+            manager.stop()
 
     def get_partition_key_name(self, table_name: str) -> str | None:
         """Return a known partition key name for diagnostics."""

--- a/alternator/core/live_nodes.py
+++ b/alternator/core/live_nodes.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from alternator._http import AsyncHttpFetcher, SyncHttpFetcher
-from alternator.exceptions import NoNodesAvailableError
+from alternator.exceptions import ConfigurationError, NoNodesAvailableError
 
 if TYPE_CHECKING:
     from alternator.config import Config
@@ -207,6 +207,29 @@ class LiveNodesManagerCore:
         )
 
 
+def _uses_topology_filter(scope: RoutingScope) -> bool:
+    from alternator.core.routing_scope import DatacenterScope, RackScope
+
+    return isinstance(scope, DatacenterScope | RackScope)
+
+
+def _validate_topology_scope_values(scope: RoutingScope) -> None:
+    from alternator.core.routing_scope import DatacenterScope, RackScope
+
+    if isinstance(scope, RackScope):
+        if not scope.datacenter or not scope.rack:
+            raise ConfigurationError(
+                "Rack routing requires non-empty datacenter and rack names"
+            )
+        return
+    if isinstance(scope, DatacenterScope) and not scope.datacenter:
+        raise ConfigurationError("Datacenter routing requires a non-empty datacenter")
+
+
+def _no_nodes_for_scope_error(scope: RoutingScope) -> ConfigurationError:
+    return ConfigurationError(f"No nodes found for routing scope: {scope.description}")
+
+
 class SyncLiveNodesManager:
     """
     Synchronous LiveNodesManager with background refresh thread.
@@ -301,6 +324,27 @@ class SyncLiveNodesManager:
         """
         return self._refresh_nodes()
 
+    def check_rack_datacenter_feature_supported(self) -> bool:
+        """Report whether scoped rack/datacenter discovery appears supported."""
+        scope = self._config.routing_scope
+        if not _uses_topology_filter(scope):
+            return True
+        try:
+            _validate_topology_scope_values(scope)
+        except ConfigurationError:
+            return False
+        return bool(self._fetch_scope_nodes(scope))
+
+    def check_rack_and_datacenter_set_correctly(self) -> bool:
+        """Validate configured rack/datacenter scope without changing state."""
+        scope = self._config.routing_scope
+        if not _uses_topology_filter(scope):
+            return True
+        _validate_topology_scope_values(scope)
+        if self._fetch_scope_nodes(scope):
+            return True
+        raise _no_nodes_for_scope_error(scope)
+
     def _refresh_loop(self) -> None:
         """Background thread that refreshes node list."""
         while not self._stop_event.is_set():
@@ -334,6 +378,19 @@ class SyncLiveNodesManager:
 
         self._core.log_all_scopes_failed()
         return False
+
+    def _fetch_scope_nodes(self, scope: RoutingScope) -> list[str]:
+        """Fetch nodes for one scope without updating current routing state."""
+        for seed in self._config.seed_hosts:
+            url = self._core.build_localnodes_url(scope, seed)
+            try:
+                nodes = list(self._http_fetch(url))
+            except Exception as e:
+                self._core.log_fetch_error(scope, e)
+                continue
+            if nodes:
+                return nodes
+        return []
 
 
 class AsyncLiveNodesManager:
@@ -430,6 +487,27 @@ class AsyncLiveNodesManager:
         """
         return await self._refresh_nodes()
 
+    async def check_rack_datacenter_feature_supported(self) -> bool:
+        """Report whether scoped rack/datacenter discovery appears supported."""
+        scope = self._config.routing_scope
+        if not _uses_topology_filter(scope):
+            return True
+        try:
+            _validate_topology_scope_values(scope)
+        except ConfigurationError:
+            return False
+        return bool(await self._fetch_scope_nodes(scope))
+
+    async def check_rack_and_datacenter_set_correctly(self) -> bool:
+        """Validate configured rack/datacenter scope without changing state."""
+        scope = self._config.routing_scope
+        if not _uses_topology_filter(scope):
+            return True
+        _validate_topology_scope_values(scope)
+        if await self._fetch_scope_nodes(scope):
+            return True
+        raise _no_nodes_for_scope_error(scope)
+
     async def _refresh_loop(self) -> None:
         """Background task that refreshes node list."""
         while not self._stop_event.is_set():
@@ -467,3 +545,16 @@ class AsyncLiveNodesManager:
 
         self._core.log_all_scopes_failed()
         return False
+
+    async def _fetch_scope_nodes(self, scope: RoutingScope) -> list[str]:
+        """Fetch nodes for one scope without updating current routing state."""
+        for seed in self._config.seed_hosts:
+            url = self._core.build_localnodes_url(scope, seed)
+            try:
+                nodes = list(await self._http_fetch(url))
+            except Exception as e:
+                self._core.log_fetch_error(scope, e)
+                continue
+            if nodes:
+                return nodes
+        return []

--- a/alternator/core/routing_scope.py
+++ b/alternator/core/routing_scope.py
@@ -6,6 +6,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from urllib.parse import quote
 
+_DEFAULT_FALLBACK = object()
+
 
 class RoutingScope(ABC):
     """Base class for topology-aware routing scopes."""
@@ -54,12 +56,41 @@ class ClusterScope(RoutingScope):
         return ""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class DatacenterScope(RoutingScope):
     """Route to nodes in a specific datacenter."""
 
     datacenter: str
     _fallback: RoutingScope | None = None
+
+    def __init__(
+        self,
+        datacenter: str,
+        _fallback: RoutingScope | None | object = _DEFAULT_FALLBACK,
+        *,
+        fallback: RoutingScope | None | object = _DEFAULT_FALLBACK,
+    ) -> None:
+        """Create a datacenter scope.
+
+        Omitting fallback preserves the historical datacenter-to-cluster
+        fallback. Passing ``fallback=None`` disables fallback explicitly.
+        """
+        object.__setattr__(self, "datacenter", datacenter)
+        object.__setattr__(
+            self,
+            "_fallback",
+            _resolve_datacenter_fallback(_fallback, fallback),
+        )
+
+    @classmethod
+    def with_default_fallback(cls, datacenter: str) -> DatacenterScope:
+        """Create a datacenter scope that falls back to cluster scope."""
+        return cls(datacenter, fallback=ClusterScope())
+
+    @classmethod
+    def without_fallback(cls, datacenter: str) -> DatacenterScope:
+        """Create a datacenter-only scope."""
+        return cls(datacenter, fallback=None)
 
     @property
     def name(self) -> str:
@@ -71,19 +102,54 @@ class DatacenterScope(RoutingScope):
 
     @property
     def fallback(self) -> RoutingScope | None:
-        return self._fallback if self._fallback is not None else ClusterScope()
+        return self._fallback
 
     def get_localnodes_query(self) -> str:
         return f"dc={quote(self.datacenter, safe='')}"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class RackScope(RoutingScope):
     """Route to nodes in a specific rack within a datacenter."""
 
     datacenter: str
     rack: str
     _fallback: RoutingScope | None = None
+
+    def __init__(
+        self,
+        datacenter: str,
+        rack: str,
+        _fallback: RoutingScope | None | object = _DEFAULT_FALLBACK,
+        *,
+        fallback: RoutingScope | None | object = _DEFAULT_FALLBACK,
+    ) -> None:
+        """Create a rack scope.
+
+        Omitting fallback preserves the historical rack-to-datacenter-to-cluster
+        fallback. Passing ``fallback=None`` disables fallback explicitly.
+        """
+        object.__setattr__(self, "datacenter", datacenter)
+        object.__setattr__(self, "rack", rack)
+        object.__setattr__(
+            self,
+            "_fallback",
+            _resolve_rack_fallback(datacenter, _fallback, fallback),
+        )
+
+    @classmethod
+    def with_default_fallback(cls, datacenter: str, rack: str) -> RackScope:
+        """Create a rack scope that falls back to datacenter and then cluster."""
+        return cls(
+            datacenter,
+            rack,
+            fallback=DatacenterScope.with_default_fallback(datacenter),
+        )
+
+    @classmethod
+    def without_fallback(cls, datacenter: str, rack: str) -> RackScope:
+        """Create a rack-only scope."""
+        return cls(datacenter, rack, fallback=None)
 
     @property
     def name(self) -> str:
@@ -95,9 +161,51 @@ class RackScope(RoutingScope):
 
     @property
     def fallback(self) -> RoutingScope | None:
-        if self._fallback is None:
-            return DatacenterScope(self.datacenter)
         return self._fallback
 
     def get_localnodes_query(self) -> str:
         return f"dc={quote(self.datacenter, safe='')}&rack={quote(self.rack, safe='')}"
+
+
+def _resolve_datacenter_fallback(
+    legacy_fallback: RoutingScope | None | object,
+    fallback: RoutingScope | None | object,
+) -> RoutingScope | None:
+    if fallback is not _DEFAULT_FALLBACK:
+        return _validate_fallback(fallback)
+    if legacy_fallback is not _DEFAULT_FALLBACK and legacy_fallback is not None:
+        return _validate_fallback(legacy_fallback)
+    return ClusterScope()
+
+
+def _resolve_rack_fallback(
+    datacenter: str,
+    legacy_fallback: RoutingScope | None | object,
+    fallback: RoutingScope | None | object,
+) -> RoutingScope | None:
+    if fallback is not _DEFAULT_FALLBACK:
+        return _validate_fallback(fallback)
+    if legacy_fallback is not _DEFAULT_FALLBACK and legacy_fallback is not None:
+        return _validate_fallback(legacy_fallback)
+    return DatacenterScope.with_default_fallback(datacenter)
+
+
+def _validate_fallback(fallback: RoutingScope | None | object) -> RoutingScope | None:
+    if fallback is None or isinstance(fallback, RoutingScope):
+        return fallback
+    raise TypeError(f"fallback must be a RoutingScope or None, got {type(fallback)!r}")
+
+
+def scope_chain_includes_cluster(scope: RoutingScope) -> bool:
+    """Return whether a scope chain can fall back to cluster scope."""
+    seen: set[int] = set()
+    current: RoutingScope | None = scope
+    while current is not None:
+        current_id = id(current)
+        if current_id in seen:
+            return False
+        seen.add(current_id)
+        if isinstance(current, ClusterScope):
+            return True
+        current = current.fallback
+    return False

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -10,7 +10,7 @@ and intentionally deferred behavior.
 | Async DynamoDB client | Supported | Existing API | `create_async_client` and `AsyncAlternatorClient` use aioboto3. |
 | Host-only seeds with one shared port | Supported | Existing API | Seeds must not include ports; one port applies to all nodes. |
 | Node discovery | Supported | Existing API | `/localnodes` refresh updates the live node list. |
-| Routing scopes | Partial | [#35](https://github.com/scylladb/alternator-client-python/issues/35) | Cluster, datacenter, and rack scopes exist; explicit fallback control and validation are planned. |
+| Routing scopes | Supported | [#35](https://github.com/scylladb/alternator-client-python/issues/35) | Cluster, datacenter, and rack scopes support explicit fallback chains and scoped validation helpers. |
 | Request query plans | Supported | Existing API | Requests use stable seeded node ordering for retries. |
 | Auth | Supported | Existing API | Disabled by default; explicit static credentials enable signing. |
 | Request compression | Partial | [#37](https://github.com/scylladb/alternator-client-python/issues/37) | Gzip exists; configurable levels and custom compressors are planned. |

--- a/tests/integration/test_wrong_dc_rack.py
+++ b/tests/integration/test_wrong_dc_rack.py
@@ -12,9 +12,13 @@ import pytest
 from alternator import (
     AlternatorClient,
     AlternatorConfigBuilder,
+    Config,
     DatacenterScope,
+    Helper,
+    NoNodesAvailableError,
     RackScope,
 )
+from alternator.exceptions import ConfigurationError
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
 
 pytestmark = [
@@ -62,6 +66,17 @@ class TestWrongDatacenter:
             for _ in range(5):
                 response = client.list_tables()
                 assert "TableNames" in response
+
+    def test_wrong_datacenter_without_fallback_fails(self) -> None:
+        """Explicit datacenter-only routing fails when that datacenter is absent."""
+        config = Config(
+            seed_hosts=[SCYLLA_HOST],
+            port=SCYLLA_PORT,
+            routing_scope=DatacenterScope("bad_dc", fallback=None),
+        )
+
+        with pytest.raises(NoNodesAvailableError), AlternatorClient(config):
+            pass
 
 
 class TestWrongRack:
@@ -167,3 +182,24 @@ class TestRackDatacenterFeatureSupport:
         with AlternatorClient(config) as client:
             response = client.list_tables()
             assert "TableNames" in response
+
+    def test_helper_validates_correct_datacenter(self) -> None:
+        """Helper validation succeeds for a known datacenter."""
+        config = Config(
+            seed_hosts=[SCYLLA_HOST],
+            port=SCYLLA_PORT,
+            routing_scope=DatacenterScope("datacenter1", fallback=None),
+        )
+
+        assert Helper(config).check_rack_and_datacenter_set_correctly()
+
+    def test_helper_validation_rejects_wrong_datacenter(self) -> None:
+        """Helper validation raises a clear error for an absent datacenter."""
+        config = Config(
+            seed_hosts=[SCYLLA_HOST],
+            port=SCYLLA_PORT,
+            routing_scope=DatacenterScope("bad_dc", fallback=None),
+        )
+
+        with pytest.raises(ConfigurationError, match="No nodes found"):
+            Helper(config).check_rack_and_datacenter_set_correctly()

--- a/tests/unit/test_async_manager.py
+++ b/tests/unit/test_async_manager.py
@@ -8,7 +8,8 @@ import pytest
 from alternator.async_client import AsyncPartitionKeyCache
 from alternator.config import Config
 from alternator.core.live_nodes import AsyncLiveNodesManager, NoNodesAvailableError
-from alternator.core.routing_scope import ClusterScope, DatacenterScope
+from alternator.core.routing_scope import ClusterScope, DatacenterScope, RackScope
+from alternator.exceptions import ConfigurationError
 
 
 @pytest.fixture
@@ -189,6 +190,50 @@ class TestAsyncLiveNodesManager:
         # Second fetch fails but nodes remain
         await manager.refresh_nodes()
         assert manager.nodes.nodes == initial_nodes
+
+    @pytest.mark.asyncio
+    async def test_topology_validation_uses_scope_without_state_update(self) -> None:
+        """Validation queries one scoped endpoint without replacing live nodes."""
+        call_urls: list[str] = []
+
+        async def mock_fetch(url: str) -> list[str]:
+            call_urls.append(url)
+            if "dc=dc1" in url:
+                return ["node1"]
+            return []
+
+        config = Config(
+            seed_hosts=["seed1"],
+            port=8000,
+            routing_scope=DatacenterScope("dc1", fallback=None),
+        )
+        manager = AsyncLiveNodesManager(config, mock_fetch)
+
+        assert await manager.check_rack_and_datacenter_set_correctly() is True
+        assert await manager.check_rack_datacenter_feature_supported() is True
+        assert manager.nodes.nodes == ()
+        assert call_urls == [
+            "http://seed1:8000/localnodes?dc=dc1",
+            "http://seed1:8000/localnodes?dc=dc1",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_topology_validation_raises_for_missing_scope(self) -> None:
+        """Validation raises a clear error when no scoped nodes exist."""
+
+        async def mock_fetch(url: str) -> list[str]:
+            return []
+
+        config = Config(
+            seed_hosts=["seed1"],
+            port=8000,
+            routing_scope=RackScope("dc1", "missing", fallback=None),
+        )
+        manager = AsyncLiveNodesManager(config, mock_fetch)
+
+        assert await manager.check_rack_datacenter_feature_supported() is False
+        with pytest.raises(ConfigurationError, match="No nodes found"):
+            await manager.check_rack_and_datacenter_set_correctly()
 
 
 class TestAsyncPartitionKeyCache:

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -7,7 +7,7 @@ from urllib.parse import urlsplit
 import pytest
 
 import alternator
-from alternator import Auth, Config, Helper, close_client
+from alternator import Auth, Config, Helper, close_client, create_client
 from alternator._constants import MANAGER_ATTR, MANAGER_OWNS_ATTR
 from alternator.async_client import AsyncHelper
 from alternator.config import KeyRouteAffinityConfig
@@ -17,6 +17,7 @@ from alternator.core.routing_scope import (
     RackScope,
     RoutingScope,
 )
+from alternator.exceptions import ConfigurationError, NoNodesAvailableError
 from tests.conftest import FakeAlternatorServer
 
 
@@ -101,6 +102,9 @@ def test_helper_update_returns_new_helper(
 
 def test_helper_topology_checks(fake_alternator_server: FakeAlternatorServer) -> None:
     """Helper exposes lightweight topology configuration checks."""
+    fake_alternator_server.set_localnodes(["node1"], query="dc=dc1")
+    fake_alternator_server.set_localnodes(["node1"], query="dc=dc1&rack=rack1")
+
     assert Helper(
         _config_for_server(fake_alternator_server, routing_scope=ClusterScope())
     ).check_rack_and_datacenter_set_correctly()
@@ -110,12 +114,17 @@ def test_helper_topology_checks(fake_alternator_server: FakeAlternatorServer) ->
             routing_scope=DatacenterScope(datacenter="dc1"),
         )
     ).check_rack_and_datacenter_set_correctly()
-    assert not Helper(
+
+    invalid_helper = Helper(
         _config_for_server(
             fake_alternator_server,
             routing_scope=RackScope(datacenter="dc1", rack=""),
         )
-    ).check_rack_and_datacenter_set_correctly()
+    )
+    assert not invalid_helper.check_rack_datacenter_feature_supported()
+    with pytest.raises(ConfigurationError, match="non-empty"):
+        invalid_helper.check_rack_and_datacenter_set_correctly()
+
     assert Helper(
         _config_for_server(
             fake_alternator_server,
@@ -137,6 +146,19 @@ def test_helper_partition_key_diagnostics_from_config(
 
     assert helper.get_partition_key_name("tbl") == "pk"
     assert helper.get_partition_key_name("missing") is None
+
+
+def test_no_fallback_scope_does_not_use_seed_hosts(
+    fake_alternator_server: FakeAlternatorServer,
+) -> None:
+    """Explicit no-fallback scopes stay constrained when discovery is empty."""
+    config = _config_for_server(
+        fake_alternator_server,
+        routing_scope=DatacenterScope("missing", fallback=None),
+    )
+
+    with pytest.raises(NoNodesAvailableError):
+        create_client(config)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_routing_scope.py
+++ b/tests/unit/test_routing_scope.py
@@ -5,6 +5,7 @@ from alternator.core.routing_scope import (
     DatacenterScope,
     RackScope,
     RoutingScope,
+    scope_chain_includes_cluster,
 )
 
 
@@ -62,6 +63,26 @@ class TestDatacenterScope:
         scope = DatacenterScope(datacenter="us-east-1", _fallback=custom_fallback)
         assert scope.fallback is custom_fallback
 
+    def test_explicit_no_fallback(self) -> None:
+        """fallback=None creates a datacenter-only scope."""
+        scope = DatacenterScope(datacenter="us-east-1", fallback=None)
+        assert scope.fallback is None
+
+    def test_legacy_none_fallback_keeps_default(self) -> None:
+        """The legacy positional fallback=None keeps default fallback behavior."""
+        scope = DatacenterScope("us-east-1", None)
+        assert isinstance(scope.fallback, ClusterScope)
+
+    def test_with_default_fallback(self) -> None:
+        """Compatibility constructor creates datacenter-to-cluster fallback."""
+        scope = DatacenterScope.with_default_fallback("us-east-1")
+        assert isinstance(scope.fallback, ClusterScope)
+
+    def test_without_fallback(self) -> None:
+        """Named constructor creates datacenter-only fallback."""
+        scope = DatacenterScope.without_fallback("us-east-1")
+        assert scope.fallback is None
+
 
 class TestRackScope:
     """Tests for RackScope."""
@@ -93,6 +114,28 @@ class TestRackScope:
         custom_fallback = ClusterScope()
         scope = RackScope(datacenter="dc1", rack="r1", _fallback=custom_fallback)
         assert scope.fallback is custom_fallback
+
+    def test_explicit_no_fallback(self) -> None:
+        """fallback=None creates a rack-only scope."""
+        scope = RackScope(datacenter="dc1", rack="r1", fallback=None)
+        assert scope.fallback is None
+
+    def test_legacy_none_fallback_keeps_default(self) -> None:
+        """The legacy positional fallback=None keeps default fallback behavior."""
+        scope = RackScope("dc1", "r1", None)
+        assert isinstance(scope.fallback, DatacenterScope)
+
+    def test_with_default_fallback(self) -> None:
+        """Compatibility constructor creates rack-to-datacenter-to-cluster fallback."""
+        scope = RackScope.with_default_fallback("dc1", "r1")
+        fallback = scope.fallback
+        assert isinstance(fallback, DatacenterScope)
+        assert isinstance(fallback.fallback, ClusterScope)
+
+    def test_without_fallback(self) -> None:
+        """Named constructor creates rack-only fallback."""
+        scope = RackScope.without_fallback("dc1", "r1")
+        assert scope.fallback is None
 
 
 class TestFallbackChain:
@@ -130,3 +173,33 @@ class TestFallbackChain:
         assert isinstance(ClusterScope(), RoutingScope)
         assert isinstance(DatacenterScope(datacenter="dc"), RoutingScope)
         assert isinstance(RackScope(datacenter="dc", rack="r"), RoutingScope)
+
+    def test_scope_chain_includes_cluster(self) -> None:
+        """Detect whether a scope chain can fall back to cluster scope."""
+        assert scope_chain_includes_cluster(ClusterScope())
+        assert scope_chain_includes_cluster(DatacenterScope("dc1"))
+        assert scope_chain_includes_cluster(RackScope("dc1", "r1"))
+        assert not scope_chain_includes_cluster(DatacenterScope("dc1", fallback=None))
+        assert not scope_chain_includes_cluster(RackScope("dc1", "r1", fallback=None))
+
+    def test_all_supported_fallback_shapes(self) -> None:
+        """Represent every supported explicit fallback shape."""
+        cluster_only = ClusterScope()
+        dc_only = DatacenterScope("dc1", fallback=None)
+        dc_cluster = DatacenterScope("dc1", fallback=ClusterScope())
+        rack_only = RackScope("dc1", "r1", fallback=None)
+        rack_dc = RackScope("dc1", "r1", fallback=DatacenterScope("dc1", fallback=None))
+        rack_dc_cluster = RackScope(
+            "dc1",
+            "r1",
+            fallback=DatacenterScope("dc1", fallback=ClusterScope()),
+        )
+
+        assert cluster_only.fallback is None
+        assert dc_only.fallback is None
+        assert isinstance(dc_cluster.fallback, ClusterScope)
+        assert rack_only.fallback is None
+        assert isinstance(rack_dc.fallback, DatacenterScope)
+        assert rack_dc.fallback.fallback is None
+        assert isinstance(rack_dc_cluster.fallback, DatacenterScope)
+        assert isinstance(rack_dc_cluster.fallback.fallback, ClusterScope)

--- a/tests/unit/test_sync_manager.py
+++ b/tests/unit/test_sync_manager.py
@@ -7,7 +7,8 @@ import pytest
 
 from alternator.config import Config
 from alternator.core.live_nodes import NoNodesAvailableError, SyncLiveNodesManager
-from alternator.core.routing_scope import DatacenterScope
+from alternator.core.routing_scope import DatacenterScope, RackScope
+from alternator.exceptions import ConfigurationError
 
 
 class TestSyncLiveNodesManager:
@@ -202,3 +203,62 @@ class TestSyncLiveNodesManager:
 
         # Nodes should still be available
         assert manager.nodes.nodes == initial_nodes
+
+    def test_topology_validation_uses_scope_without_state_update(self) -> None:
+        """Validation queries one scoped endpoint without replacing live nodes."""
+        config = Config(
+            seed_hosts=["seed1"],
+            port=8000,
+            routing_scope=DatacenterScope("dc1", fallback=None),
+        )
+        calls: list[str] = []
+
+        def mock_fetch(url: str) -> Sequence[str]:
+            calls.append(url)
+            if "dc=dc1" in url:
+                return ["node1"]
+            return []
+
+        manager = SyncLiveNodesManager(config, mock_fetch)
+
+        assert manager.check_rack_and_datacenter_set_correctly() is True
+        assert manager.check_rack_datacenter_feature_supported() is True
+        assert manager.nodes.nodes == ()
+        assert calls == [
+            "http://seed1:8000/localnodes?dc=dc1",
+            "http://seed1:8000/localnodes?dc=dc1",
+        ]
+
+    def test_topology_validation_raises_for_missing_scope(self) -> None:
+        """Validation raises a clear error when no scoped nodes exist."""
+        config = Config(
+            seed_hosts=["seed1"],
+            port=8000,
+            routing_scope=RackScope("dc1", "missing", fallback=None),
+        )
+
+        def mock_fetch(url: str) -> Sequence[str]:
+            return []
+
+        manager = SyncLiveNodesManager(config, mock_fetch)
+
+        assert manager.check_rack_datacenter_feature_supported() is False
+        with pytest.raises(ConfigurationError, match="No nodes found"):
+            manager.check_rack_and_datacenter_set_correctly()
+
+    def test_topology_validation_rejects_empty_scope_values(self) -> None:
+        """Validation rejects incomplete rack/datacenter config."""
+        config = Config(
+            seed_hosts=["seed1"],
+            port=8000,
+            routing_scope=RackScope("dc1", "", fallback=None),
+        )
+
+        def mock_fetch(url: str) -> Sequence[str]:
+            return ["node1"]
+
+        manager = SyncLiveNodesManager(config, mock_fetch)
+
+        assert manager.check_rack_datacenter_feature_supported() is False
+        with pytest.raises(ConfigurationError, match="non-empty"):
+            manager.check_rack_and_datacenter_set_correctly()


### PR DESCRIPTION
Closes #35

## Summary
- add explicit `fallback=` support for datacenter and rack routing scopes while preserving existing default fallback behavior
- add compatibility constructors for default fallback and no-fallback routing shapes
- prevent explicit no-fallback scoped routing from silently falling back to seed hosts when scoped discovery is empty
- add sync and async validation methods that query scoped `/localnodes` without replacing the current live-node list
- document explicit fallback chains and validation helpers; update the roadmap and capability matrix
- keep node health behavior untouched

## Testing
- uv run pytest tests/unit/test_routing_scope.py tests/unit/test_sync_manager.py tests/unit/test_async_manager.py tests/unit/test_helper.py -v --tb=short
- make lint
- make test-unit