### PR TITLE
Add TLS client cert and key log config

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -31,6 +31,7 @@ Supported or close:
 - static Alternator auth, disabled by default
 - transport timeout, retry, pool, region, and SDK customizer settings
 - TLS server CA and insecure trust-all modes
+- TLS client certificate and key log file support
 - key route affinity with partition-key cache
 - helper lifecycle facade and public inspection methods
 - vector search support
@@ -38,7 +39,6 @@ Supported or close:
 Tracked gaps:
 
 - node health tracking and quarantine planning only: [#32](https://github.com/scylladb/alternator-client-python/issues/32)
-- TLS client certificate and key log file support: [#38](https://github.com/scylladb/alternator-client-python/issues/38)
 - configurable compression and header whitelist behavior: [#37](https://github.com/scylladb/alternator-client-python/issues/37)
 - key-affinity RMW and BatchWriteItem routing semantics: [#23](https://github.com/scylladb/alternator-client-python/issues/23)
 - compatibility and release decisions: [#39](https://github.com/scylladb/alternator-client-python/issues/39)

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ config = (
 | `min_compression_size_bytes` | `int` | `1024` | Minimum body size to compress |
 | `optimize_headers` | `bool` | `False` | Enable header filtering |
 | `headers_whitelist` | `frozenset[str]` | `None` | Additional headers to keep |
-| `tls` | `TLS` | system default | TLS configuration |
+| `tls` | `TLS` | system default | TLS trust, client certificates, and key logging |
 | `key_affinity` | `KeyRouteAffinityConfig` | `NONE` | Key-based routing |
 | `retries` | `RetryConfig` | standard, 3 attempts | SDK retry behavior |
 | `max_pool_connections` | `int` | `200` | Max connections per host |
@@ -350,6 +350,25 @@ tls = TLS.with_custom_ca(Path("/path/to/ca.pem"))
 # Trust all certificates (INSECURE - dev only)
 tls = TLS.trust_all()
 
+# Mutual TLS with separate certificate and key files
+tls = TLS(
+    custom_ca_cert_paths=[Path("/path/to/ca.pem")],
+    client_cert_path=Path("/path/to/client.crt"),
+    client_key_path=Path("/path/to/client.key"),
+)
+
+# Mutual TLS with a combined certificate/key PEM file
+tls = TLS(
+    custom_ca_cert_paths=[Path("/path/to/ca.pem")],
+    client_cert_path=Path("/path/to/client-combined.pem"),
+)
+
+# Debug TLS traffic with a key log file
+tls = TLS(
+    custom_ca_cert_paths=[Path("/path/to/ca.pem")],
+    key_log_file_path=Path("/secure/tmp/alternator-tls.keys"),
+)
+
 # Full configuration
 tls = TLS(
     custom_ca_cert_paths=[Path("/path/to/ca.pem")],
@@ -360,8 +379,22 @@ tls = TLS(
         cache_size=1024,
         timeout_seconds=86400,
     ),
+    client_cert_path=Path("/path/to/client.crt"),
+    client_key_path=Path("/path/to/client.key"),
+    key_log_file_path=Path("/secure/tmp/alternator-tls.keys"),
 )
 ```
+
+Client certificate settings are loaded into the SSL context used for
+`/localnodes` discovery and passed to the SDK as `client_cert` for HTTPS
+DynamoDB API calls. If you configure custom server CA certificates, continue to
+pass the matching SDK `verify` argument or an equivalent SDK setting for API
+calls.
+
+TLS key logs contain traffic decryption material. Store them only in protected
+temporary locations, delete them after debugging, and never commit them. Key log
+support depends on Python/OpenSSL exposing `SSLContext.keylog_filename`; runtimes
+without that attribute ignore `key_log_file_path`.
 
 ## Request Compression
 
@@ -637,6 +670,8 @@ Async clients created by `create_async_client` / `AsyncAlternatorClient` are saf
 
 - **Request Compression**: Gzip compression requires ScyllaDB 2026.1.0+. Response compression is not yet supported by Alternator.
 - **TLS Session Cache Settings**: The `cache_size` and `timeout_seconds` parameters in `TlsSessionCacheConfig` are not currently used by Python's `ssl` module. Only the `enabled` flag controls session ticket behavior.
+- **TLS Key Logs**: Key log file support depends on Python/OpenSSL runtime support for `SSLContext.keylog_filename` and should only be used in protected debugging environments.
+- **mTLS Integration Fixtures**: The local Scylla fixture in this repository does not require client certificate authentication, so automated tests cover configuration propagation and SSL context setup rather than a full mutual-TLS handshake.
 - **Async Key Affinity**: For async clients, partition key auto-discovery happens asynchronously. The first request for an unknown table will use round-robin routing while discovery runs in the background. Subsequent requests will use affinity. Preloading via `table_pk_map` avoids this initial miss.
 - **Batch Operations**: `BatchWriteItem` key affinity is based on a deterministic `PutRequest` or `DeleteRequest` selected from the batch. Batches with items targeting different partition keys are not split by affinity target.
 

--- a/alternator/config.py
+++ b/alternator/config.py
@@ -17,6 +17,7 @@ from alternator.exceptions import ConfigurationError
 logger = logging.getLogger("alternator")
 
 SDKConfigCustomizer = Callable[[dict[str, Any]], None]
+SDKClientCert = str | tuple[str, str]
 
 
 class CompressionAlgorithm(Enum):
@@ -67,6 +68,27 @@ class TLS:
     # Session caching
     session_cache: TlsSessionCacheConfig = field(default_factory=TlsSessionCacheConfig)
 
+    # Client certificate authentication
+    client_cert_path: Path | None = None
+    client_key_path: Path | None = None
+
+    # TLS key logging for traffic debugging
+    key_log_file_path: Path | None = None
+
+    def __post_init__(self) -> None:
+        """Validate TLS configuration values."""
+        if self.client_key_path is not None and self.client_cert_path is None:
+            raise ConfigurationError("client_key_path requires client_cert_path")
+
+    @property
+    def sdk_client_cert(self) -> SDKClientCert | None:
+        """Return the botocore client_cert value for this TLS config."""
+        if self.client_cert_path is None:
+            return None
+        if self.client_key_path is not None:
+            return (str(self.client_cert_path), str(self.client_key_path))
+        return str(self.client_cert_path)
+
     @classmethod
     def trust_all(cls) -> TLS:
         """
@@ -114,6 +136,7 @@ class TlsConfig(TLS):
     """Deprecated compatibility name for :class:`TLS`."""
 
     def __post_init__(self) -> None:
+        super().__post_init__()
         warnings.warn(
             "TlsConfig is deprecated; use TLS instead.",
             DeprecationWarning,
@@ -573,6 +596,8 @@ def build_sdk_config_kwargs(config: Config) -> dict[str, Any]:
         "connect_timeout": config.timeouts.connect_seconds,
         "read_timeout": config.timeouts.read_seconds,
     }
+    if config.scheme == "https" and config.tls.sdk_client_cert is not None:
+        kwargs["client_cert"] = config.tls.sdk_client_cert
     if config.sdk_config_customizer is not None:
         config.sdk_config_customizer(kwargs)
     return kwargs

--- a/alternator/core/tls.py
+++ b/alternator/core/tls.py
@@ -19,27 +19,39 @@ def create_ssl_context(tls_config: TLS) -> ssl.SSLContext:
     Returns:
         Configured SSL context
     """
+    context = ssl.create_default_context()
     if tls_config.trust_all_certificates:
         # INSECURE - for development only
-        context = ssl.create_default_context()
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
-        return context
+    else:
+        # Configure hostname verification
+        context.check_hostname = tls_config.verify_hostname
 
-    # Create context with verification
-    context = ssl.create_default_context()
-
-    # Configure hostname verification
-    context.check_hostname = tls_config.verify_hostname
-
-    # Load custom CA certificates
-    if tls_config.custom_ca_cert_paths:
+    if not tls_config.trust_all_certificates and tls_config.custom_ca_cert_paths:
         for cert_path in tls_config.custom_ca_cert_paths:
             context.load_verify_locations(str(cert_path))
 
     # If not using system CA and custom certs provided, don't load system certs
-    if not tls_config.trust_system_ca_certs and tls_config.custom_ca_cert_paths:
+    if (
+        not tls_config.trust_all_certificates
+        and not tls_config.trust_system_ca_certs
+        and tls_config.custom_ca_cert_paths
+    ):
         context.verify_mode = ssl.CERT_REQUIRED
+
+    if tls_config.client_cert_path is not None:
+        context.load_cert_chain(
+            certfile=str(tls_config.client_cert_path),
+            keyfile=(
+                str(tls_config.client_key_path)
+                if tls_config.client_key_path is not None
+                else None
+            ),
+        )
+
+    if tls_config.key_log_file_path is not None and hasattr(context, "keylog_filename"):
+        context.keylog_filename = str(tls_config.key_log_file_path)
 
     # Configure session caching
     # Note: Python's ssl module only exposes session ticket control (OP_NO_TICKET).

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -16,8 +16,8 @@ and intentionally deferred behavior.
 | Request compression | Partial | [#37](https://github.com/scylladb/alternator-client-python/issues/37) | Gzip exists; configurable levels and custom compressors are planned. |
 | Header optimization | Partial | [#37](https://github.com/scylladb/alternator-client-python/issues/37) | Basic whitelist exists; custom whitelist callback is planned. |
 | TLS server trust | Supported | Existing API | System CA, custom CA, hostname verification, and trust-all mode exist. |
-| TLS client certificates | Missing | [#38](https://github.com/scylladb/alternator-client-python/issues/38) | mTLS config and SDK propagation are planned. |
-| TLS key log file | Missing | [#38](https://github.com/scylladb/alternator-client-python/issues/38) | Debug-only key log file support is planned. |
+| TLS client certificates | Supported | [#38](https://github.com/scylladb/alternator-client-python/issues/38) | mTLS certificate/key paths are loaded into discovery SSL contexts and SDK `client_cert` config. |
+| TLS key log file | Supported | [#38](https://github.com/scylladb/alternator-client-python/issues/38) | Debug-only key log file paths are applied to SSL contexts when supported by the runtime. |
 | Transport and SDK config knobs | Supported | [#34](https://github.com/scylladb/alternator-client-python/issues/34) | Retry, pool, connect/read timeout, region, and SDK config customizer settings are wired into sync and async SDK clients. |
 | Key route affinity | Partial | [#23](https://github.com/scylladb/alternator-client-python/issues/23) | Partition-key cache exists; RMW rules and BatchWriteItem voting need alignment with the request-routing specification. |
 | Helper lifecycle facade | Supported | [#33](https://github.com/scylladb/alternator-client-python/issues/33) | `Helper` and `AsyncHelper` expose lifecycle, node inspection, topology checks, and partition-key diagnostics. |

--- a/tests/unit/test_boto_config.py
+++ b/tests/unit/test_boto_config.py
@@ -1,11 +1,12 @@
 """Tests for internal BotoConfig creation."""
 
 import contextlib
+from pathlib import Path
 
 from botocore import UNSIGNED
 
 from alternator.client import _create_boto_config
-from alternator.config import Config, RetryConfig, RetryMode, TimeoutConfig
+from alternator.config import TLS, Config, RetryConfig, RetryMode, TimeoutConfig
 
 
 class TestCreateBotoConfig:
@@ -93,6 +94,32 @@ class TestCreateBotoConfig:
         assert unsigned_config.signature_version is UNSIGNED
         assert "signature_version" not in signed_config._user_provided_options
 
+    def test_client_cert_propagated_for_https(self) -> None:
+        """TLS client certificate settings flow into BotoConfig."""
+        config = self._make_config(
+            scheme="https",
+            tls=TLS(
+                client_cert_path=Path("/path/to/client.crt"),
+                client_key_path=Path("/path/to/client.key"),
+            ),
+        )
+        boto_config = _create_boto_config(config, auth_enabled=False)
+
+        assert boto_config.client_cert == (
+            "/path/to/client.crt",
+            "/path/to/client.key",
+        )
+
+    def test_combined_client_cert_propagated_for_https(self) -> None:
+        """A combined client certificate/key file flows into BotoConfig."""
+        config = self._make_config(
+            scheme="https",
+            tls=TLS(client_cert_path=Path("/path/to/client-combined.pem")),
+        )
+        boto_config = _create_boto_config(config, auth_enabled=False)
+
+        assert boto_config.client_cert == "/path/to/client-combined.pem"
+
 
 class TestCreateAioConfig:
     """Tests for async SDK config creation."""
@@ -104,6 +131,11 @@ class TestCreateAioConfig:
         config = Config(
             seed_hosts=["localhost"],
             port=9998,
+            scheme="https",
+            tls=TLS(
+                client_cert_path=Path("/path/to/client.crt"),
+                client_key_path=Path("/path/to/client.key"),
+            ),
             retries=RetryConfig(max_attempts=4, mode=RetryMode.STANDARD),
             max_pool_connections=17,
             timeouts=TimeoutConfig(
@@ -121,6 +153,10 @@ class TestCreateAioConfig:
         assert aio_config.connect_timeout == 3.0
         assert aio_config.read_timeout == 11.0
         assert aio_config.signature_version is UNSIGNED
+        assert aio_config.client_cert == (
+            "/path/to/client.crt",
+            "/path/to/client.key",
+        )
 
 
 class TestUnsignedRequestNoAuthHeader:

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -2,11 +2,13 @@
 
 import ssl
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from alternator.config import TLS, TlsSessionCacheConfig
 from alternator.core.tls import create_ssl_context
+from alternator.exceptions import ConfigurationError
 
 
 class TestCreateSslContext:
@@ -112,6 +114,46 @@ class TestCreateSslContext:
         else:
             pytest.skip("No system CA file available for testing")
 
+    def test_client_cert_chain_is_loaded(self, tmp_path: Path) -> None:
+        """Test TLS client certificate paths load into the SSL context."""
+        cert_path = tmp_path / "client.crt"
+        key_path = tmp_path / "client.key"
+
+        with patch("ssl.SSLContext.load_cert_chain") as mock_load:
+            tls_config = TLS(
+                client_cert_path=cert_path,
+                client_key_path=key_path,
+            )
+            create_ssl_context(tls_config)
+
+        mock_load.assert_called_once_with(
+            certfile=str(cert_path),
+            keyfile=str(key_path),
+        )
+
+    def test_combined_client_cert_chain_is_loaded(self, tmp_path: Path) -> None:
+        """Test combined certificate/key PEM path loads without a key path."""
+        cert_path = tmp_path / "client-combined.pem"
+
+        with patch("ssl.SSLContext.load_cert_chain") as mock_load:
+            tls_config = TLS(client_cert_path=cert_path)
+            create_ssl_context(tls_config)
+
+        mock_load.assert_called_once_with(
+            certfile=str(cert_path),
+            keyfile=None,
+        )
+
+    def test_key_log_file_is_configured(self, tmp_path: Path) -> None:
+        """Test TLS key log path is assigned to the SSL context when available."""
+        key_log_path = tmp_path / "tls.keys"
+        tls_config = TLS(key_log_file_path=key_log_path)
+        ctx = create_ssl_context(tls_config)
+
+        if hasattr(ctx, "keylog_filename"):
+            assert ctx.keylog_filename == str(key_log_path)
+            assert key_log_path.parent == tmp_path
+
 
 class TestTlsConfig:
     """Tests for TLS class."""
@@ -125,6 +167,9 @@ class TestTlsConfig:
         assert config.trust_all_certificates is False
         assert config.verify_hostname is True
         assert config.session_cache.enabled is True
+        assert config.client_cert_path is None
+        assert config.client_key_path is None
+        assert config.key_log_file_path is None
 
     def test_trust_all_factory(self) -> None:
         """Test TLS.trust_all() factory method."""
@@ -148,6 +193,29 @@ class TestTlsConfig:
         config = TLS.with_custom_ca(path1, path2)
 
         assert config.custom_ca_cert_paths == (path1, path2)
+
+    def test_client_key_without_cert_raises(self) -> None:
+        """Test client private key path requires a client certificate path."""
+        with pytest.raises(ConfigurationError, match="client_key_path requires"):
+            TLS(client_key_path=Path("/path/to/client.key"))
+
+    def test_sdk_client_cert_with_cert_and_key(self) -> None:
+        """Test botocore client_cert value for separate cert and key files."""
+        config = TLS(
+            client_cert_path=Path("/path/to/client.crt"),
+            client_key_path=Path("/path/to/client.key"),
+        )
+
+        assert config.sdk_client_cert == (
+            "/path/to/client.crt",
+            "/path/to/client.key",
+        )
+
+    def test_sdk_client_cert_with_combined_cert(self) -> None:
+        """Test botocore client_cert value for a combined cert/key file."""
+        config = TLS(client_cert_path=Path("/path/to/client-combined.pem"))
+
+        assert config.sdk_client_cert == "/path/to/client-combined.pem"
 
 
 class TestTlsSessionCacheConfig:


### PR DESCRIPTION
Closes #38

## Summary
- add TLS client certificate/key path settings and SDK `client_cert` propagation for HTTPS clients
- load client certificates and key log file paths into discovery SSL contexts
- document mTLS usage, key-log security limits, and local fixture coverage limits
- keep node health untouched; the roadmap still marks it as planning-only

## Testing
- `uv run pytest tests/unit/test_tls.py tests/unit/test_boto_config.py -v --tb=short`
- `uv run ruff check alternator/ tests/unit/test_tls.py tests/unit/test_boto_config.py`
- `uv run ruff format --check alternator/ tests/unit/test_tls.py tests/unit/test_boto_config.py`
- `make lint`
- `make test-unit`