### PR TITLE
Align key affinity routing semantics

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -32,14 +32,13 @@ Supported or close:
 - transport timeout, retry, pool, region, and SDK customizer settings
 - TLS server CA and insecure trust-all modes
 - TLS client certificate and key log file support
-- key route affinity with partition-key cache
+- key route affinity with partition-key cache and batch-write voting
 - helper lifecycle facade and public inspection methods
 - vector search support
 
 Tracked gaps:
 
 - node health tracking and quarantine planning only: [#32](https://github.com/scylladb/alternator-client-python/issues/32)
-- key-affinity RMW and BatchWriteItem routing semantics: [#23](https://github.com/scylladb/alternator-client-python/issues/23)
 - compatibility and release decisions: [#39](https://github.com/scylladb/alternator-client-python/issues/39)
 - documentation, examples, and release notes: [#40](https://github.com/scylladb/alternator-client-python/issues/40)
 

--- a/README.md
+++ b/README.md
@@ -334,8 +334,20 @@ config = (
 | Mode | Description |
 |------|-------------|
 | `NONE` | Disabled (default round-robin) |
-| `RMW` | Only for operations with `ConditionExpression` or `ReturnValues` |
+| `RMW` | Only for write operations that require a read-before-write path |
 | `ANY_WRITE` | For all write operations (`PutItem`, `UpdateItem`, `DeleteItem`, `BatchWriteItem`) |
+
+`RMW` mode applies affinity to conditional `PutItem`/`DeleteItem`, `ALL_OLD`
+returns, and `UpdateItem` requests that need prior item state, including
+non-empty update or condition expressions, `Expected`, selected `ReturnValues`,
+`ADD`, and value-bearing `DELETE` attribute updates. `BatchWriteItem` does not
+use affinity in `RMW` mode.
+
+`ANY_WRITE` mode applies affinity to single-item writes using the request
+partition key. For `BatchWriteItem`, each valid put/delete votes for its
+preferred node. The request tries the unique winning node first and keeps the
+remaining nodes in the retry plan. Missing partition-key metadata, unsupported
+key values, no active nodes, no votes, or tied votes fall back to normal routing.
 
 ## TLS Configuration
 

--- a/alternator/async_client.py
+++ b/alternator/async_client.py
@@ -24,13 +24,10 @@ from alternator._http import (
 from alternator.config import KeyRouteAffinityMode, build_sdk_config_kwargs
 from alternator.core.auth import apply_auth
 from alternator.core.handlers import _register_alternator_handlers
-from alternator.core.hashing import hash_attribute_value
 from alternator.core.key_affinity import (
-    extract_partition_key,
-    get_table_name,
-    should_use_affinity,
+    select_affinity_node,
 )
-from alternator.core.live_nodes import AsyncLiveNodesManager
+from alternator.core.live_nodes import AsyncLiveNodesManager, NodeList
 from alternator.vector import enable_vector_support
 
 if TYPE_CHECKING:
@@ -203,19 +200,19 @@ class AsyncPartitionKeyCache:
         self._cache.update(table_pk_map)
 
 
-def _create_async_affinity_hash_computer(
+def _create_async_affinity_node_computer(
     config: Config,
     pk_cache: AsyncPartitionKeyCache | None,
-) -> Callable[[str, dict[str, Any]], int | None] | None:
+) -> Callable[[str, dict[str, Any], NodeList], str | None] | None:
     """
-    Create a function that computes the partition key hash for affinity routing.
+    Create a function that selects the preferred key-affinity node.
 
     Args:
         config: Alternator configuration
         pk_cache: Partition key cache (if affinity enabled)
 
     Returns:
-        Function that computes partition key hash, or None if affinity is disabled
+        Function that selects the affinity node, or None if affinity is disabled
     """
     affinity_mode = config.key_affinity.mode
 
@@ -223,20 +220,7 @@ def _create_async_affinity_hash_computer(
     if affinity_mode == KeyRouteAffinityMode.NONE or pk_cache is None:
         return None
 
-    def compute_affinity_hash(
-        operation_name: str, params: dict[str, Any]
-    ) -> int | None:
-        """Compute partition key hash for affinity routing."""
-        # Check if this operation should use affinity
-        if not should_use_affinity(affinity_mode.name, operation_name, params):
-            return None
-
-        # Get table name
-        table_name = get_table_name(params)
-        if not table_name:
-            return None
-
-        # Get partition key name from cache (fast sync path)
+    def get_cached_pk_name(table_name: str) -> str | None:
         pk_name = pk_cache._cache.get(table_name)
         if not pk_name:
             # Schedule async discovery for future requests
@@ -250,26 +234,23 @@ def _create_async_affinity_hash_computer(
                 table_name,
             )
             return None
+        return pk_name
 
-        # Extract partition key value
-        pk_info = extract_partition_key(params, pk_name)
-        if not pk_info:
-            logger.debug(
-                "Could not extract partition key %s from request",
-                pk_name,
-            )
-            return None
+    def compute_affinity_node(
+        operation_name: str,
+        params: dict[str, Any],
+        nodes: NodeList,
+    ) -> str | None:
+        """Select the preferred key-affinity node for this request."""
+        return select_affinity_node(
+            mode=affinity_mode.name,
+            operation_name=operation_name,
+            params=params,
+            nodes=nodes,
+            get_pk_name=get_cached_pk_name,
+        )
 
-        attr_type, value = pk_info
-
-        # Compute and return hash
-        try:
-            return hash_attribute_value(attr_type, value)
-        except (ValueError, TypeError, UnicodeEncodeError) as e:
-            logger.debug("Error hashing partition key: %s", e)
-            return None
-
-    return compute_affinity_hash
+    return compute_affinity_node
 
 
 async def _create_async_manager(
@@ -392,7 +373,7 @@ async def _create_async_client_with_manager(
             client.meta.events,
             manager,
             config,
-            _create_async_affinity_hash_computer(config, pk_cache),
+            _create_async_affinity_node_computer(config, pk_cache),
             auth_enabled=auth_enabled,
         )
 

--- a/alternator/client.py
+++ b/alternator/client.py
@@ -19,14 +19,11 @@ from alternator._http import create_ssl_context, create_sync_http_fetcher
 from alternator.config import Config, KeyRouteAffinityMode, build_sdk_config_kwargs
 from alternator.core.auth import apply_auth
 from alternator.core.handlers import _register_alternator_handlers
-from alternator.core.hashing import hash_attribute_value
 from alternator.core.key_affinity import (
     PartitionKeyCache,
-    extract_partition_key,
-    get_table_name,
-    should_use_affinity,
+    select_affinity_node,
 )
-from alternator.core.live_nodes import SyncLiveNodesManager
+from alternator.core.live_nodes import NodeList, SyncLiveNodesManager
 from alternator.exceptions import ConfigurationError
 from alternator.vector import enable_vector_support
 
@@ -167,19 +164,19 @@ def _create_boto_config(config: Config, *, auth_enabled: bool) -> BotoConfig:
     return BotoConfig(**kwargs)
 
 
-def _create_affinity_hash_computer(
+def _create_affinity_node_computer(
     config: Config,
     client: DynamoDBClient,
-) -> Callable[[str, dict[str, Any]], int | None] | None:
+) -> Callable[[str, dict[str, Any], NodeList], str | None] | None:
     """
-    Create a function that computes the partition key hash for affinity routing.
+    Create a function that selects the preferred key-affinity node.
 
     Args:
         config: Alternator configuration
         client: boto3 client for DescribeTable calls
 
     Returns:
-        Function that computes partition key hash, or None if affinity is disabled
+        Function that selects the affinity node, or None if affinity is disabled
     """
     affinity_mode = config.key_affinity.mode
 
@@ -197,47 +194,21 @@ def _create_affinity_hash_computer(
     # Store pk_cache on client for cleanup/access
     setattr(client, PK_CACHE_ATTR, pk_cache)
 
-    def compute_affinity_hash(
-        operation_name: str, params: dict[str, Any]
-    ) -> int | None:
-        """Compute partition key hash for affinity routing."""
-        # Check if this operation should use affinity
-        if not should_use_affinity(affinity_mode.name, operation_name, params):
-            return None
+    def compute_affinity_node(
+        operation_name: str,
+        params: dict[str, Any],
+        nodes: NodeList,
+    ) -> str | None:
+        """Select the preferred key-affinity node for this request."""
+        return select_affinity_node(
+            mode=affinity_mode.name,
+            operation_name=operation_name,
+            params=params,
+            nodes=nodes,
+            get_pk_name=pk_cache.get_pk_name,
+        )
 
-        # Get table name
-        table_name = get_table_name(params)
-        if not table_name:
-            return None
-
-        # Get partition key name (from config or auto-discover)
-        pk_name = pk_cache.get_pk_name(table_name)
-        if not pk_name:
-            logger.debug(
-                "Could not determine partition key for table %s",
-                table_name,
-            )
-            return None
-
-        # Extract partition key value
-        pk_info = extract_partition_key(params, pk_name)
-        if not pk_info:
-            logger.debug(
-                "Could not extract partition key %s from request",
-                pk_name,
-            )
-            return None
-
-        attr_type, value = pk_info
-
-        # Compute and return hash
-        try:
-            return hash_attribute_value(attr_type, value)
-        except (ValueError, TypeError, UnicodeEncodeError) as e:
-            logger.error("Error hashing partition key: %s", e)
-            return None
-
-    return compute_affinity_hash
+    return compute_affinity_node
 
 
 def _create_client_with_manager(
@@ -273,7 +244,7 @@ def _create_client_with_manager(
         client.meta.events,
         manager,
         config,
-        _create_affinity_hash_computer(config, client),
+        _create_affinity_node_computer(config, client),
         auth_enabled=auth_enabled,
     )
 
@@ -461,7 +432,7 @@ def _create_resource_with_manager(
         resource.meta.client.meta.events,
         manager,
         config,
-        _create_affinity_hash_computer(config, resource.meta.client),
+        _create_affinity_node_computer(config, resource.meta.client),
         auth_enabled=auth_enabled,
     )
 

--- a/alternator/core/handlers.py
+++ b/alternator/core/handlers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import random
 from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
@@ -43,7 +44,8 @@ def _register_alternator_handlers(
     events: BaseEventHooks,
     manager: _HasNodes,
     config: Config,
-    compute_affinity_hash: Callable[[str, DynamoDBParams], int | None] | None = None,
+    compute_affinity_node: Callable[[str, DynamoDBParams, NodeList], str | None]
+    | None = None,
     *,
     auth_enabled: bool = False,
 ) -> None:
@@ -56,8 +58,7 @@ def _register_alternator_handlers(
         events: The boto3/aioboto3 events object to register handlers on
         manager: Object with a ``nodes`` property returning a ``NodeList``
         config: Alternator configuration
-        compute_affinity_hash: Optional function to compute partition key hash
-                              for deterministic node ordering
+        compute_affinity_node: Optional function to select a preferred affinity node
     """
     scheme = config.scheme
     port = config.port
@@ -68,16 +69,25 @@ def _register_alternator_handlers(
         {"PutItem", "UpdateItem", "DeleteItem", "BatchWriteItem", "GetItem"}
     )
 
-    def create_query_plan(affinity_hash: int | None) -> Iterator[str]:
+    def create_query_plan(
+        nodes: NodeList,
+        preferred_node: str | None,
+    ) -> Iterator[str]:
         """Create a URI iterator for a single request."""
-        nodes = manager.nodes
-        if not nodes:
-            raise NoNodesAvailableError(
-                "No nodes available",
-                scope_name=scope_name,
+        node_addresses = nodes.nodes
+        if preferred_node is not None and preferred_node in node_addresses:
+            yield f"{scheme}://{preferred_node}:{port}"
+            remaining_nodes = tuple(
+                node for node in node_addresses if node != preferred_node
             )
-        seed = affinity_hash if affinity_hash is not None else random.getrandbits(64)
-        plan = LazyQueryPlan(nodes=nodes.nodes, seed=seed)
+            seed = _stable_seed(preferred_node)
+            plan = LazyQueryPlan(nodes=remaining_nodes, seed=seed)
+            for node in plan:
+                yield f"{scheme}://{node}:{port}"
+            return
+
+        seed = random.getrandbits(64)
+        plan = LazyQueryPlan(nodes=node_addresses, seed=seed)
         for node in plan:
             yield f"{scheme}://{node}:{port}"
 
@@ -87,16 +97,27 @@ def _register_alternator_handlers(
         # Get or create query plan
         plan: Iterator[str] | None = getattr(request, _QUERY_PLAN_ATTR, None)
         if plan is None:
-            # First attempt: create plan with optional affinity hash
-            affinity_hash = None
-            if compute_affinity_hash is not None:
+            nodes = manager.nodes
+            if not nodes:
+                raise NoNodesAvailableError(
+                    "No nodes available",
+                    scope_name=scope_name,
+                )
+
+            # First attempt: create plan with optional affinity preferred node
+            preferred_node = None
+            if compute_affinity_node is not None:
                 # Check operation name first (cheap header read) before
                 # parsing the JSON body (expensive)
                 operation_name = extract_operation_name(request)
                 if operation_name in _affinity_operations:
                     params = extract_request_params(request)
-                    affinity_hash = compute_affinity_hash(operation_name, params)
-            plan = create_query_plan(affinity_hash)
+                    preferred_node = compute_affinity_node(
+                        operation_name,
+                        params,
+                        nodes,
+                    )
+            plan = create_query_plan(nodes, preferred_node)
             setattr(request, _QUERY_PLAN_ATTR, plan)
 
         # Get next node from plan
@@ -128,3 +149,8 @@ def _register_alternator_handlers(
         )
         header_filter = create_header_filter_handler(whitelist)
         events.register("before-send.dynamodb.*", header_filter)
+
+
+def _stable_seed(value: str) -> int:
+    digest = hashlib.blake2b(value.encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, "big")

--- a/alternator/core/key_affinity.py
+++ b/alternator/core/key_affinity.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import json
 import logging
 import threading
+from collections import Counter
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 from alternator._constants import PK_DISCOVERY_TIMEOUT_SECONDS
+from alternator.core.hashing import hash_attribute_value
 
 if TYPE_CHECKING:
     from mypy_boto3_dynamodb import DynamoDBClient
@@ -23,6 +26,11 @@ class _BatchWriteRoutingTarget(NamedTuple):
     sort_key: tuple[str, str, str]
 
 
+class _BatchWriteCandidate(NamedTuple):
+    table_name: str
+    attributes: dict[str, Any]
+
+
 class AffinitySelector:
     """
     Hash-based node selector for key affinity routing.
@@ -35,21 +43,23 @@ class AffinitySelector:
         if not nodes:
             return None
 
+        sorted_nodes = tuple(sorted(nodes.nodes))
+
         # Use hash to deterministically select node
-        index = abs(hash_value) % len(nodes)
-        selected = nodes.nodes[index]
+        index = abs(hash_value) % len(sorted_nodes)
+        selected = sorted_nodes[index]
         logger.debug(
             "Affinity selection: hash=%d -> node_index=%d -> %s (of %d nodes)",
             hash_value,
             index,
             selected,
-            len(nodes),
+            len(sorted_nodes),
             extra={
                 "event": "affinity_selection",
                 "hash_value": hash_value,
                 "node_index": index,
                 "selected_node": selected,
-                "node_count": len(nodes),
+                "node_count": len(sorted_nodes),
             },
         )
         return selected
@@ -59,16 +69,32 @@ def is_rmw_operation(operation_name: str, params: dict[str, Any]) -> bool:
     """
     Check if operation is a read-modify-write operation.
 
-    RMW operations have ConditionExpression or non-NONE ReturnValues.
+    RMW operations require a read-before-write path.
     """
-    if operation_name not in ("UpdateItem", "PutItem", "DeleteItem"):
+    if operation_name not in {"UpdateItem", "PutItem", "DeleteItem"}:
         return False
 
-    if "ConditionExpression" in params:
+    if "Expected" in params:
         return True
 
-    return_values = params.get("ReturnValues", "NONE")
-    return bool(return_values != "NONE")
+    if _non_empty_string(params.get("ConditionExpression")):
+        return True
+
+    return_values = params.get("ReturnValues")
+
+    if operation_name in {"PutItem", "DeleteItem"}:
+        return return_values == "ALL_OLD"
+
+    if operation_name == "UpdateItem":
+        if _non_empty_string(params.get("UpdateExpression")):
+            return True
+
+        if return_values not in (None, "", "NONE", "UPDATED_NEW"):
+            return True
+
+        return _attribute_updates_need_read(params.get("AttributeUpdates"))
+
+    return False
 
 
 def is_write_operation(operation_name: str) -> bool:
@@ -85,6 +111,50 @@ def should_use_affinity(mode: str, operation_name: str, params: dict[str, Any]) 
     if mode == "ANY_WRITE":
         return is_write_operation(operation_name)
     return False
+
+
+def select_affinity_node(
+    *,
+    mode: str,
+    operation_name: str,
+    params: dict[str, Any],
+    nodes: NodeList,
+    get_pk_name: Callable[[str], str | None],
+) -> str | None:
+    """Select the preferred affinity node for a request, or None for fallback."""
+    if not should_use_affinity(mode, operation_name, params):
+        return None
+
+    if not nodes:
+        return None
+
+    if operation_name == "BatchWriteItem":
+        if mode != "ANY_WRITE":
+            return None
+        return _select_batch_write_affinity_node(params, nodes, get_pk_name)
+
+    table_name = get_table_name(params)
+    if not table_name:
+        return None
+
+    pk_name = get_pk_name(table_name)
+    if not pk_name:
+        logger.debug("Could not determine partition key for table %s", table_name)
+        return None
+
+    pk_info = extract_partition_key(params, pk_name)
+    if not pk_info:
+        logger.debug("Could not extract partition key %s from request", pk_name)
+        return None
+
+    attr_type, value = pk_info
+    try:
+        hash_value = hash_attribute_value(attr_type, value)
+    except (ValueError, TypeError, UnicodeEncodeError) as e:
+        logger.debug("Error hashing partition key: %s", e)
+        return None
+
+    return AffinitySelector().select(nodes, hash_value)
 
 
 def extract_partition_key(
@@ -119,6 +189,106 @@ def _extract_typed_value(attr_value: dict[str, Any]) -> tuple[str, Any] | None:
         if attr_type in attr_value:
             return (attr_type, attr_value[attr_type])
     return None
+
+
+def _select_batch_write_affinity_node(
+    params: dict[str, Any],
+    nodes: NodeList,
+    get_pk_name: Callable[[str], str | None],
+) -> str | None:
+    votes: Counter[str] = Counter()
+    selector = AffinitySelector()
+
+    for candidate in _iter_batch_write_candidates(params):
+        pk_name = get_pk_name(candidate.table_name)
+        if not pk_name:
+            continue
+
+        pk_value = candidate.attributes.get(pk_name)
+        if not isinstance(pk_value, dict):
+            continue
+
+        pk_info = _extract_typed_value(pk_value)
+        if pk_info is None:
+            continue
+
+        attr_type, value = pk_info
+        try:
+            hash_value = hash_attribute_value(attr_type, value)
+        except (ValueError, TypeError, UnicodeEncodeError):
+            continue
+
+        node = selector.select(nodes, hash_value)
+        if node is not None:
+            votes[node] += 1
+
+    if not votes:
+        return None
+
+    top_count = max(votes.values())
+    winners = [node for node, count in votes.items() if count == top_count]
+    if len(winners) != 1:
+        return None
+    return winners[0]
+
+
+def _iter_batch_write_candidates(
+    params: dict[str, Any],
+) -> Iterable[_BatchWriteCandidate]:
+    request_items = params.get("RequestItems")
+    if not isinstance(request_items, dict):
+        return ()
+
+    candidates: list[_BatchWriteCandidate] = []
+    for table_name, writes in sorted(
+        request_items.items(), key=lambda item: str(item[0])
+    ):
+        if not isinstance(table_name, str) or not isinstance(writes, list):
+            continue
+        for write in writes:
+            if not isinstance(write, dict):
+                continue
+
+            put_request = write.get("PutRequest")
+            if isinstance(put_request, dict):
+                item = put_request.get("Item")
+                if isinstance(item, dict):
+                    candidates.append(_BatchWriteCandidate(table_name, item))
+
+            delete_request = write.get("DeleteRequest")
+            if isinstance(delete_request, dict):
+                key = delete_request.get("Key")
+                if isinstance(key, dict):
+                    candidates.append(_BatchWriteCandidate(table_name, key))
+
+    return tuple(candidates)
+
+
+def _non_empty_string(value: object) -> bool:
+    return isinstance(value, str) and value != ""
+
+
+def _attribute_updates_need_read(attribute_updates: object) -> bool:
+    if not isinstance(attribute_updates, dict):
+        return False
+
+    for update in attribute_updates.values():
+        if not isinstance(update, dict):
+            continue
+        action = update.get("Action")
+        if action == "ADD":
+            return True
+        if action == "DELETE" and _attribute_update_value_is_non_empty(
+            update.get("Value")
+        ):
+            return True
+    return False
+
+
+def _attribute_update_value_is_non_empty(value: object) -> bool:
+    if not isinstance(value, dict):
+        return bool(value)
+    return any(bool(item) for item in value.values())
 
 
 def get_table_name(params: dict[str, Any]) -> str | None:

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -19,7 +19,7 @@ and intentionally deferred behavior.
 | TLS client certificates | Supported | [#38](https://github.com/scylladb/alternator-client-python/issues/38) | mTLS certificate/key paths are loaded into discovery SSL contexts and SDK `client_cert` config. |
 | TLS key log file | Supported | [#38](https://github.com/scylladb/alternator-client-python/issues/38) | Debug-only key log file paths are applied to SSL contexts when supported by the runtime. |
 | Transport and SDK config knobs | Supported | [#34](https://github.com/scylladb/alternator-client-python/issues/34) | Retry, pool, connect/read timeout, region, and SDK config customizer settings are wired into sync and async SDK clients. |
-| Key route affinity | Partial | [#23](https://github.com/scylladb/alternator-client-python/issues/23) | Partition-key cache exists; RMW rules and BatchWriteItem voting need alignment with the request-routing specification. |
+| Key route affinity | Supported | [#23](https://github.com/scylladb/alternator-client-python/issues/23) | RMW detection, single-write affinity, and BatchWriteItem preferred-node voting are implemented with fallback on missing or ambiguous routing data. |
 | Helper lifecycle facade | Supported | [#33](https://github.com/scylladb/alternator-client-python/issues/33) | `Helper` and `AsyncHelper` expose lifecycle, node inspection, topology checks, and partition-key diagnostics. |
 | Node health tracking | Deferred | [#32](https://github.com/scylladb/alternator-client-python/issues/32) | Planning-only. No node health code, tests, config objects, or behavior changes are authorized by this roadmap. |
 | Vector search extension | Supported | Existing API | Python client enables ScyllaDB Alternator vector extensions. |

--- a/tests/unit/test_key_affinity.py
+++ b/tests/unit/test_key_affinity.py
@@ -1,11 +1,14 @@
 """Tests for key route affinity module."""
 
+import copy
 import threading
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from unittest.mock import MagicMock
 
+from alternator.config import Config
+from alternator.core.handlers import _register_alternator_handlers
 from alternator.core.hashing import hash_attribute_value
 from alternator.core.key_affinity import (
     AffinitySelector,
@@ -14,6 +17,7 @@ from alternator.core.key_affinity import (
     get_table_name,
     is_rmw_operation,
     is_write_operation,
+    select_affinity_node,
     should_use_affinity,
 )
 from alternator.core.live_nodes import NodeList
@@ -31,6 +35,16 @@ def _batch_write_routing_target(
     return (table_name, pk, hash_attribute_value(attr_type, value))
 
 
+def _pk_value_for_node(nodes: NodeList, target_node: str, prefix: str) -> str:
+    selector = AffinitySelector()
+    for index in range(1000):
+        value = f"{prefix}-{index}"
+        hash_value = hash_attribute_value("S", value)
+        if selector.select(nodes, hash_value) == target_node:
+            return value
+    raise AssertionError(f"could not find value for node {target_node}")
+
+
 class TestIsRmwOperation:
     """Tests for is_rmw_operation function."""
 
@@ -44,10 +58,50 @@ class TestIsRmwOperation:
         params = {"ConditionExpression": "attribute_not_exists(pk)"}
         assert is_rmw_operation("PutItem", params) is True
 
+    def test_put_with_empty_condition_is_not_rmw(self) -> None:
+        """Test PutItem with empty ConditionExpression is not RMW."""
+        params = {"ConditionExpression": ""}
+        assert is_rmw_operation("PutItem", params) is False
+
+    def test_put_with_expected_is_rmw(self) -> None:
+        """Test PutItem with Expected is RMW."""
+        params = {"Expected": {}}
+        assert is_rmw_operation("PutItem", params) is True
+
+    def test_put_with_all_old_return_values_is_rmw(self) -> None:
+        """Test PutItem with ALL_OLD ReturnValues is RMW."""
+        params = {"ReturnValues": "ALL_OLD"}
+        assert is_rmw_operation("PutItem", params) is True
+
+    def test_put_with_none_return_values_is_not_rmw(self) -> None:
+        """Test PutItem with NONE ReturnValues is not RMW."""
+        params = {"ReturnValues": "NONE"}
+        assert is_rmw_operation("PutItem", params) is False
+
     def test_delete_with_condition_is_rmw(self) -> None:
         """Test DeleteItem with ConditionExpression is RMW."""
         params = {"ConditionExpression": "version = :v"}
         assert is_rmw_operation("DeleteItem", params) is True
+
+    def test_delete_with_empty_condition_is_not_rmw(self) -> None:
+        """Test DeleteItem with empty ConditionExpression is not RMW."""
+        params = {"ConditionExpression": ""}
+        assert is_rmw_operation("DeleteItem", params) is False
+
+    def test_delete_with_expected_is_rmw(self) -> None:
+        """Test DeleteItem with Expected is RMW."""
+        params = {"Expected": {}}
+        assert is_rmw_operation("DeleteItem", params) is True
+
+    def test_delete_with_all_old_return_values_is_rmw(self) -> None:
+        """Test DeleteItem with ALL_OLD ReturnValues is RMW."""
+        params = {"ReturnValues": "ALL_OLD"}
+        assert is_rmw_operation("DeleteItem", params) is True
+
+    def test_delete_with_updated_new_return_values_is_not_rmw(self) -> None:
+        """Test DeleteItem only treats ALL_OLD ReturnValues as RMW."""
+        params = {"ReturnValues": "UPDATED_NEW"}
+        assert is_rmw_operation("DeleteItem", params) is False
 
     def test_update_with_return_values_is_rmw(self) -> None:
         """Test UpdateItem with non-NONE ReturnValues is RMW."""
@@ -62,6 +116,55 @@ class TestIsRmwOperation:
     def test_update_without_condition_or_return_not_rmw(self) -> None:
         """Test UpdateItem without condition or return values is not RMW."""
         params = {"Key": {"pk": {"S": "123"}}}
+        assert is_rmw_operation("UpdateItem", params) is False
+
+    def test_update_with_update_expression_is_rmw(self) -> None:
+        """Test UpdateItem with UpdateExpression is RMW."""
+        params = {"UpdateExpression": "SET value = :v"}
+        assert is_rmw_operation("UpdateItem", params) is True
+
+    def test_update_with_empty_update_expression_is_not_rmw(self) -> None:
+        """Test empty UpdateExpression alone is not RMW."""
+        params = {"UpdateExpression": ""}
+        assert is_rmw_operation("UpdateItem", params) is False
+
+    def test_update_with_expected_is_rmw(self) -> None:
+        """Test UpdateItem with Expected is RMW."""
+        params = {"Expected": {}}
+        assert is_rmw_operation("UpdateItem", params) is True
+
+    def test_update_with_empty_return_values_is_not_rmw(self) -> None:
+        """Test UpdateItem with empty ReturnValues is not RMW."""
+        params = {"ReturnValues": ""}
+        assert is_rmw_operation("UpdateItem", params) is False
+
+    def test_update_with_updated_new_return_values_is_not_rmw(self) -> None:
+        """Test UpdateItem UPDATED_NEW ReturnValues is not RMW."""
+        params = {"ReturnValues": "UPDATED_NEW"}
+        assert is_rmw_operation("UpdateItem", params) is False
+
+    def test_update_with_all_new_return_values_is_rmw(self) -> None:
+        """Test UpdateItem ReturnValues other than allowed no-read values is RMW."""
+        params = {"ReturnValues": "ALL_NEW"}
+        assert is_rmw_operation("UpdateItem", params) is True
+
+    def test_update_with_attribute_updates_add_is_rmw(self) -> None:
+        """Test AttributeUpdates ADD action is RMW."""
+        params = {"AttributeUpdates": {"count": {"Action": "ADD", "Value": {"N": "1"}}}}
+        assert is_rmw_operation("UpdateItem", params) is True
+
+    def test_update_with_attribute_updates_delete_with_value_is_rmw(self) -> None:
+        """Test AttributeUpdates DELETE action with a value is RMW."""
+        params = {
+            "AttributeUpdates": {
+                "tags": {"Action": "DELETE", "Value": {"SS": ["old"]}},
+            }
+        }
+        assert is_rmw_operation("UpdateItem", params) is True
+
+    def test_update_with_attribute_updates_delete_without_value_not_rmw(self) -> None:
+        """Test AttributeUpdates DELETE action without a value is not RMW."""
+        params = {"AttributeUpdates": {"tags": {"Action": "DELETE"}}}
         assert is_rmw_operation("UpdateItem", params) is False
 
     def test_get_item_is_not_rmw(self) -> None:
@@ -156,6 +259,351 @@ class TestShouldUseAffinity:
         params = {}
         assert should_use_affinity("ANY_WRITE", "GetItem", params) is False
         assert should_use_affinity("ANY_WRITE", "Query", params) is False
+
+
+class TestSelectAffinityNode:
+    """Tests for preferred node selection."""
+
+    def test_single_put_item_selects_node(self) -> None:
+        """Test single PutItem routes by the item partition key."""
+        nodes = NodeList(nodes=("a", "b", "c"), scope_name="test")
+        value = _pk_value_for_node(nodes, "b", "put")
+        params = {
+            "TableName": "orders",
+            "Item": {"pk": {"S": value}},
+        }
+
+        assert (
+            select_affinity_node(
+                mode="ANY_WRITE",
+                operation_name="PutItem",
+                params=params,
+                nodes=nodes,
+                get_pk_name={"orders": "pk"}.get,
+            )
+            == "b"
+        )
+
+    def test_single_delete_item_selects_node(self) -> None:
+        """Test single DeleteItem routes by the key partition key."""
+        nodes = NodeList(nodes=("a", "b", "c"), scope_name="test")
+        value = _pk_value_for_node(nodes, "c", "delete")
+        params = {
+            "TableName": "orders",
+            "Key": {"pk": {"S": value}},
+        }
+
+        assert (
+            select_affinity_node(
+                mode="ANY_WRITE",
+                operation_name="DeleteItem",
+                params=params,
+                nodes=nodes,
+                get_pk_name={"orders": "pk"}.get,
+            )
+            == "c"
+        )
+
+    def test_batch_write_single_put_selects_node(self) -> None:
+        """Test BatchWriteItem with a single PutRequest selects its node."""
+        nodes = NodeList(nodes=("a", "b", "c"), scope_name="test")
+        value = _pk_value_for_node(nodes, "a", "batch-put")
+        params = {
+            "RequestItems": {
+                "orders": [{"PutRequest": {"Item": {"pk": {"S": value}}}}],
+            }
+        }
+
+        assert (
+            select_affinity_node(
+                mode="ANY_WRITE",
+                operation_name="BatchWriteItem",
+                params=params,
+                nodes=nodes,
+                get_pk_name={"orders": "pk"}.get,
+            )
+            == "a"
+        )
+
+    def test_batch_write_single_delete_selects_node(self) -> None:
+        """Test BatchWriteItem with a single DeleteRequest selects its node."""
+        nodes = NodeList(nodes=("a", "b", "c"), scope_name="test")
+        value = _pk_value_for_node(nodes, "c", "batch-delete")
+        params = {
+            "RequestItems": {
+                "orders": [{"DeleteRequest": {"Key": {"pk": {"S": value}}}}],
+            }
+        }
+
+        assert (
+            select_affinity_node(
+                mode="ANY_WRITE",
+                operation_name="BatchWriteItem",
+                params=params,
+                nodes=nodes,
+                get_pk_name={"orders": "pk"}.get,
+            )
+            == "c"
+        )
+
+    def test_batch_write_mixed_put_delete_unique_winner(self) -> None:
+        """Test BatchWriteItem votes for the unique preferred node."""
+        nodes = NodeList(nodes=("a", "b", "c"), scope_name="test")
+        b1 = _pk_value_for_node(nodes, "b", "b1")
+        b2 = _pk_value_for_node(nodes, "b", "b2")
+        c1 = _pk_value_for_node(nodes, "c", "c1")
+        params = {
+            "RequestItems": {
+                "orders": [
+                    {"PutRequest": {"Item": {"pk": {"S": b1}}}},
+                    {"DeleteRequest": {"Key": {"pk": {"S": b2}}}},
+                    {"PutRequest": {"Item": {"pk": {"S": c1}}}},
+                ],
+            }
+        }
+
+        assert (
+            select_affinity_node(
+                mode="ANY_WRITE",
+                operation_name="BatchWriteItem",
+                params=params,
+                nodes=nodes,
+                get_pk_name={"orders": "pk"}.get,
+            )
+            == "b"
+        )
+
+    def test_batch_write_multi_table_reversed_order_same_winner(self) -> None:
+        """Test batch voting is independent of table and request order."""
+        nodes = NodeList(nodes=("a", "b", "c"), scope_name="test")
+        b1 = _pk_value_for_node(nodes, "b", "orders-b1")
+        b2 = _pk_value_for_node(nodes, "b", "sessions-b2")
+        a1 = _pk_value_for_node(nodes, "a", "orders-a1")
+        orders = [
+            {"PutRequest": {"Item": {"pk": {"S": b1}}}},
+            {"PutRequest": {"Item": {"pk": {"S": a1}}}},
+        ]
+        sessions = [{"DeleteRequest": {"Key": {"pk": {"S": b2}}}}]
+        params_a = {"RequestItems": {"orders": orders, "sessions": sessions}}
+        params_b = {
+            "RequestItems": {
+                "sessions": list(reversed(sessions)),
+                "orders": list(reversed(orders)),
+            }
+        }
+
+        for params in (params_a, params_b):
+            assert (
+                select_affinity_node(
+                    mode="ANY_WRITE",
+                    operation_name="BatchWriteItem",
+                    params=params,
+                    nodes=nodes,
+                    get_pk_name={"orders": "pk", "sessions": "pk"}.get,
+                )
+                == "b"
+            )
+
+    def test_batch_write_missing_pk_metadata_falls_back(self) -> None:
+        """Test missing partition-key metadata produces no preferred node."""
+        nodes = NodeList(nodes=("a", "b", "c"), scope_name="test")
+        params = {
+            "RequestItems": {
+                "orders": [{"PutRequest": {"Item": {"pk": {"S": "value"}}}}],
+            }
+        }
+
+        assert (
+            select_affinity_node(
+                mode="ANY_WRITE",
+                operation_name="BatchWriteItem",
+                params=params,
+                nodes=nodes,
+                get_pk_name={}.get,
+            )
+            is None
+        )
+
+    def test_batch_write_missing_pk_value_falls_back(self) -> None:
+        """Test missing partition-key value produces no preferred node."""
+        nodes = NodeList(nodes=("a", "b", "c"), scope_name="test")
+        params = {
+            "RequestItems": {
+                "orders": [{"PutRequest": {"Item": {"other": {"S": "value"}}}}],
+            }
+        }
+
+        assert (
+            select_affinity_node(
+                mode="ANY_WRITE",
+                operation_name="BatchWriteItem",
+                params=params,
+                nodes=nodes,
+                get_pk_name={"orders": "pk"}.get,
+            )
+            is None
+        )
+
+    def test_batch_write_unsupported_pk_type_falls_back(self) -> None:
+        """Test unsupported partition-key type produces no preferred node."""
+        nodes = NodeList(nodes=("a", "b", "c"), scope_name="test")
+        params = {
+            "RequestItems": {
+                "orders": [{"PutRequest": {"Item": {"pk": {"BOOL": True}}}}],
+            }
+        }
+
+        assert (
+            select_affinity_node(
+                mode="ANY_WRITE",
+                operation_name="BatchWriteItem",
+                params=params,
+                nodes=nodes,
+                get_pk_name={"orders": "pk"}.get,
+            )
+            is None
+        )
+
+    def test_batch_write_no_nodes_falls_back(self) -> None:
+        """Test no active nodes produces no preferred node."""
+        nodes = NodeList(nodes=(), scope_name="test")
+        params = {
+            "RequestItems": {
+                "orders": [{"PutRequest": {"Item": {"pk": {"S": "value"}}}}],
+            }
+        }
+
+        assert (
+            select_affinity_node(
+                mode="ANY_WRITE",
+                operation_name="BatchWriteItem",
+                params=params,
+                nodes=nodes,
+                get_pk_name={"orders": "pk"}.get,
+            )
+            is None
+        )
+
+    def test_batch_write_tied_votes_fall_back(self) -> None:
+        """Test tied preferred-node votes produce no preferred node."""
+        nodes = NodeList(nodes=("a", "b", "c"), scope_name="test")
+        a1 = _pk_value_for_node(nodes, "a", "tie-a")
+        b1 = _pk_value_for_node(nodes, "b", "tie-b")
+        params = {
+            "RequestItems": {
+                "orders": [
+                    {"PutRequest": {"Item": {"pk": {"S": a1}}}},
+                    {"PutRequest": {"Item": {"pk": {"S": b1}}}},
+                ],
+            }
+        }
+
+        assert (
+            select_affinity_node(
+                mode="ANY_WRITE",
+                operation_name="BatchWriteItem",
+                params=params,
+                nodes=nodes,
+                get_pk_name={"orders": "pk"}.get,
+            )
+            is None
+        )
+
+    def test_batch_write_binary_pk_selects_stable_node(self) -> None:
+        """Test binary partition-key values use stable hashing."""
+        nodes = NodeList(nodes=("a", "b", "c"), scope_name="test")
+        binary_value = b"\x00\x01stable"
+        expected = AffinitySelector().select(
+            nodes,
+            hash_attribute_value("B", binary_value),
+        )
+        params = {
+            "RequestItems": {
+                "orders": [
+                    {"PutRequest": {"Item": {"pk": {"B": binary_value}}}},
+                ],
+            }
+        }
+
+        assert (
+            select_affinity_node(
+                mode="ANY_WRITE",
+                operation_name="BatchWriteItem",
+                params=params,
+                nodes=nodes,
+                get_pk_name={"orders": "pk"}.get,
+            )
+            == expected
+        )
+
+    def test_batch_write_selection_does_not_mutate_params(self) -> None:
+        """Test BatchWriteItem affinity selection leaves request params unchanged."""
+        nodes = NodeList(nodes=("a", "b", "c"), scope_name="test")
+        value = _pk_value_for_node(nodes, "b", "no-mutate")
+        params = {
+            "RequestItems": {
+                "orders": [{"PutRequest": {"Item": {"pk": {"S": value}}}}],
+            }
+        }
+        original = copy.deepcopy(params)
+
+        select_affinity_node(
+            mode="ANY_WRITE",
+            operation_name="BatchWriteItem",
+            params=params,
+            nodes=nodes,
+            get_pk_name={"orders": "pk"}.get,
+        )
+
+        assert params == original
+
+
+class TestAffinityHandlerRouting:
+    """Tests for preferred-node routing through shared request handlers."""
+
+    def test_preferred_node_first_and_remaining_nodes_preserved(self) -> None:
+        """Test handler tries preferred node first without dropping retries."""
+        config = Config(seed_hosts=["seed"], port=8000)
+        manager = MagicMock()
+        manager.nodes = NodeList(nodes=("a", "b", "c"), scope_name="cluster")
+        events = MagicMock()
+
+        def compute_affinity_node(
+            operation_name: str,
+            params: dict[str, Any],
+            nodes: NodeList,
+        ) -> str | None:
+            assert operation_name == "PutItem"
+            assert params == {"TableName": "orders"}
+            assert nodes.nodes == ("a", "b", "c")
+            return "b"
+
+        _register_alternator_handlers(
+            events,
+            manager,
+            config,
+            compute_affinity_node,
+        )
+        handlers = {
+            call[0][1].__name__: call[0][1] for call in events.register.call_args_list
+        }
+
+        request = MagicMock()
+        request.url = "http://seed:8000/"
+        request.headers = {"X-Amz-Target": "DynamoDB_20120810.PutItem"}
+        request.body = b'{"TableName": "orders"}'
+        request._alternator_query_plan = None
+
+        update_endpoint = handlers["update_endpoint"]
+        update_endpoint(request)
+        first_url = request.url
+        update_endpoint(request)
+        second_url = request.url
+        update_endpoint(request)
+        third_url = request.url
+
+        assert first_url == "http://b:8000/"
+        assert {second_url, third_url} == {"http://a:8000/", "http://c:8000/"}
 
 
 class TestExtractPartitionKey:


### PR DESCRIPTION
Closes #23

## Summary
- tighten RMW detection for PutItem, DeleteItem, and UpdateItem according to read-before-write rules
- route single-item writes through a preferred-node selector and keep remaining nodes in the retry plan
- add BatchWriteItem preferred-node voting with fallback on missing metadata, unsupported values, no nodes, no votes, or tied votes
- document the updated affinity modes and mark the roadmap/matrix entry supported

## Testing
- `uv run pytest tests/unit/test_key_affinity.py tests/unit/test_hashing_properties.py tests/unit/test_query_plan.py -v --tb=short`
- `uv run ruff check alternator/ tests/unit/test_key_affinity.py tests/unit/test_hashing_properties.py tests/unit/test_query_plan.py`
- `uv run ruff format --check alternator/ tests/unit/test_key_affinity.py tests/unit/test_hashing_properties.py tests/unit/test_query_plan.py`
- `make lint`
- `make test-unit`