### PR TITLE
Record compatibility and release decisions

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -9,6 +9,7 @@ so each issue has enough context on its own.
 - [#36: Add client capability matrix and deterministic behavior test harness](https://github.com/scylladb/alternator-client-python/issues/36)
 - [#33: Add Helper and AsyncHelper lifecycle facade](https://github.com/scylladb/alternator-client-python/issues/33)
 - [#32: Plan node health tracking and quarantine behavior](https://github.com/scylladb/alternator-client-python/issues/32)
+- [#3: Ensure decommission and dead-node scenarios are handled properly](https://github.com/scylladb/alternator-client-python/issues/3)
 - [#35: Add explicit routing-scope fallback and topology validation APIs](https://github.com/scylladb/alternator-client-python/issues/35)
 - [#34: Wire transport and configuration options into boto clients](https://github.com/scylladb/alternator-client-python/issues/34)
 - [#38: Add TLS client certificate and key log file support](https://github.com/scylladb/alternator-client-python/issues/38)
@@ -34,17 +35,21 @@ Supported or close:
 - TLS client certificate and key log file support
 - key route affinity with partition-key cache and batch-write voting
 - helper lifecycle facade and public inspection methods
+- compatibility and release decision record
 - vector search support
 
 Tracked gaps:
 
 - node health tracking and quarantine planning only: [#32](https://github.com/scylladb/alternator-client-python/issues/32)
-- compatibility and release decisions: [#39](https://github.com/scylladb/alternator-client-python/issues/39)
+- decommission and dead-node scenario tracking, covered by the deferred node
+  health plan: [#3](https://github.com/scylladb/alternator-client-python/issues/3)
 - documentation, examples, and release notes: [#40](https://github.com/scylladb/alternator-client-python/issues/40)
 
 ## Compatibility Decisions
 
-Tracked by [#39](https://github.com/scylladb/alternator-client-python/issues/39).
+Tracked by [#39](https://github.com/scylladb/alternator-client-python/issues/39)
+and recorded in
+[docs/COMPATIBILITY_AND_RELEASE.md](docs/COMPATIBILITY_AND_RELEASE.md).
 
 - Keep current auth behavior: unsigned by default, explicit static credentials
   for signed Alternator requests.
@@ -56,6 +61,10 @@ Tracked by [#39](https://github.com/scylladb/alternator-client-python/issues/39)
   capability changes land.
 - Treat routing fallback changes as compatibility-sensitive and document a
   migration path before changing constructor behavior.
+- Keep node health default behavior unchanged; any future node health behavior
+  should start opt-in, and default-enabled behavior requires a major release.
+- Use a minor release for additive compatible APIs, and reserve major releases
+  for changed defaults or removed compatibility APIs.
 
 ## Node Health Constraint
 
@@ -73,8 +82,10 @@ separate future request explicitly authorizes implementation.
    [#36](https://github.com/scylladb/alternator-client-python/issues/36).
 2. Add helper lifecycle facade and public inspection methods:
    [#33](https://github.com/scylladb/alternator-client-python/issues/33).
-3. Keep node health deferred; maintain planning issue only:
-   [#32](https://github.com/scylladb/alternator-client-python/issues/32).
+3. Keep node health, decommission handling, and dead-node handling deferred;
+   maintain planning issues only:
+   [#32](https://github.com/scylladb/alternator-client-python/issues/32),
+   [#3](https://github.com/scylladb/alternator-client-python/issues/3).
 4. Add explicit routing fallback and topology validation:
    [#35](https://github.com/scylladb/alternator-client-python/issues/35).
 5. Wire timeout, region, pool, and SDK customizer configuration:

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ config = Config(
 
 > **Compatibility:** `AlternatorConfig` and `TlsConfig` remain available for
 > existing callers, but are deprecated. Prefer `Config` and `TLS` for new code.
+> See [docs/COMPATIBILITY_AND_RELEASE.md](docs/COMPATIBILITY_AND_RELEASE.md)
+> for compatibility and versioning decisions.
 
 ### Using the Builder Pattern
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,6 +10,20 @@ This document describes how to release a new version of the Alternator Load Bala
 
 ## Creating a Release
 
+### Compatibility Decision Gate
+
+Before choosing the next version, review
+[docs/COMPATIBILITY_AND_RELEASE.md](docs/COMPATIBILITY_AND_RELEASE.md).
+
+Use a minor release for additive compatible APIs and opt-in capabilities. Use a
+major release for changed defaults, removed deprecated names, removed legacy
+credential kwargs, changed default routing fallback, changed default auth, or
+default-enabled node health/quarantine behavior.
+
+Release notes for capability work should call out auth defaults, routing
+fallback behavior, deprecated-name migration, key-affinity behavior, and whether
+node health remains planning-only.
+
 ### 1. Update Version
 
 Update the version in `alternator/_version.py`:

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -21,6 +21,7 @@ and intentionally deferred behavior.
 | Transport and SDK config knobs | Supported | [#34](https://github.com/scylladb/alternator-client-python/issues/34) | Retry, pool, connect/read timeout, region, and SDK config customizer settings are wired into sync and async SDK clients. |
 | Key route affinity | Supported | [#23](https://github.com/scylladb/alternator-client-python/issues/23) | RMW detection, single-write affinity, and BatchWriteItem preferred-node voting are implemented with fallback on missing or ambiguous routing data. |
 | Helper lifecycle facade | Supported | [#33](https://github.com/scylladb/alternator-client-python/issues/33) | `Helper` and `AsyncHelper` expose lifecycle, node inspection, topology checks, and partition-key diagnostics. |
+| Compatibility and release decisions | Supported | [#39](https://github.com/scylladb/alternator-client-python/issues/39) | Decision record lives in [docs/COMPATIBILITY_AND_RELEASE.md](COMPATIBILITY_AND_RELEASE.md). |
 | Node health tracking | Deferred | [#32](https://github.com/scylladb/alternator-client-python/issues/32) | Planning-only. No node health code, tests, config objects, or behavior changes are authorized by this roadmap. |
 | Vector search extension | Supported | Existing API | Python client enables ScyllaDB Alternator vector extensions. |
 | Capability test harness | Partial | [#36](https://github.com/scylladb/alternator-client-python/issues/36) | Fake Alternator server fixture introduced for deterministic unit tests. |

--- a/docs/COMPATIBILITY_AND_RELEASE.md
+++ b/docs/COMPATIBILITY_AND_RELEASE.md
@@ -1,0 +1,135 @@
+# Compatibility And Release Decisions
+
+This document records compatibility and release decisions for the client
+capability roadmap tracked by
+[#39](https://github.com/scylladb/alternator-client-python/issues/39). Use it
+with [RELEASING.md](../RELEASING.md) when preparing releases and with
+[FEATURE_PARITY.md](../FEATURE_PARITY.md) when evaluating behavior-changing
+roadmap work.
+
+## Scope
+
+These decisions apply to the capability work covering helper lifecycle APIs,
+routing fallback, transport configuration, TLS options, compression/header
+configuration, and key-affinity behavior. Node health, decommission handling,
+and dead-node handling remain planning-only in
+[#32](https://github.com/scylladb/alternator-client-python/issues/32) and
+[#3](https://github.com/scylladb/alternator-client-python/issues/3).
+
+## Decisions
+
+### Default Port
+
+Keep the convenience default port at `8000`. `Config` continues to require an
+explicit `port`, while convenience helpers and builders keep their existing
+`8000` default.
+
+Changing this default would be an incompatible behavior change. It requires a
+major release, release notes, and migration guidance that tells users to pass
+the desired `port` explicitly.
+
+### Authentication Default
+
+Keep request signing disabled by default. Users who need Alternator request
+signing should pass `auth=Auth.static_credentials(...)`.
+
+The client-managed authentication API supports explicit static credentials only.
+SDK environment, profile, and provider-chain credentials are not used for
+Alternator auth.
+
+Raw SDK credential keyword arguments such as `aws_access_key_id` remain accepted
+for compatibility and continue to emit deprecation warnings. Do not remove these
+kwargs in the same release as the capability work.
+
+### Routing Scope Fallback
+
+Keep existing fallback behavior for default routing-scope constructors:
+
+- `DatacenterScope("dc1")` falls back to `ClusterScope()`.
+- `RackScope("dc1", "rack1")` falls back to `DatacenterScope("dc1")` and then
+  `ClusterScope()`.
+
+New code should prefer explicit fallback configuration with `fallback=...`,
+`with_default_fallback(...)`, or `without_fallback(...)`.
+
+Changing default fallback behavior requires a warning period and a major
+release. Release notes must include migration examples for callers that need
+cluster fallback, datacenter fallback, or no fallback.
+
+### Node Health
+
+Node health, quarantine behavior, decommission handling, and dead-node handling
+are not part of the current implementation scope. Do not add node health code,
+tests, config objects, routing behavior, or default behavior changes unless a
+separate future request explicitly authorizes implementation.
+
+Future node health behavior should start as opt-in. Making it default behavior
+would be compatibility-sensitive and should only happen in a major release with
+migration notes.
+
+### Deprecated Names
+
+Keep deprecated compatibility names such as `AlternatorConfig` and `TlsConfig`
+working while capability changes land. They should continue to warn and point to
+`Config` and `TLS`.
+
+Do not remove deprecated names in the same release as these capability changes.
+Any removal requires a separate release decision and a major release.
+
+### Additive Capability APIs
+
+Helper lifecycle APIs, transport configuration, TLS client certificate/key log
+settings, compression/header configuration, and key-affinity controls are
+additive public API changes as long as existing defaults remain unchanged.
+
+Header optimization, request compression, key-affinity modes, TLS client
+certificates, TLS key logs, and SDK config customization remain opt-in. The
+client continues to own endpoint routing and authentication signature settings
+after SDK config customization.
+
+### Key-Affinity Semantics
+
+Key-affinity behavior is compatibility-sensitive because it affects which node
+is tried first for eligible writes. The current behavior keeps normal routing as
+the fallback when partition-key metadata is missing, key values are unsupported,
+there are no active nodes, there are no eligible batch votes, or batch votes
+tie.
+
+Release notes should call out tightened read-modify-write detection and
+`BatchWriteItem` preferred-node voting so operators can validate routing
+expectations before enabling key affinity in production.
+
+## Versioning Guidance
+
+Use semantic versioning:
+
+- Minor release: additive compatible APIs, new opt-in capabilities, and
+  documentation-only compatibility decisions.
+- Patch release: compatible bug fixes with no new public capability surface.
+- Major release: changed defaults, removed deprecated names, removed legacy
+  credential kwargs, changed default routing fallback, changed default auth, or
+  default-enabled node health/quarantine behavior.
+
+The capability batch should be released as a minor version unless a separate
+maintainer decision adds an incompatible change.
+
+## Release Checklist Additions
+
+Before releasing this capability batch:
+
+- Update README, examples, and release notes for the implemented public API.
+- State that node health remains planning-only unless a separate implementation
+  has landed.
+- Document migration impact for auth, routing fallback, deprecated names, and
+  key-affinity behavior.
+- Run `make lint`.
+- Run `make test-unit`.
+- Run integration tests against local Scylla where release validation requires
+  real Alternator behavior.
+- Run async tests with async extras installed.
+- Run TLS integration checks where TLS behavior changed.
+- Run the package build check from the release workflow.
+
+Behavior-changing issues and pull requests in this roadmap should link back to
+this document or to
+[#39](https://github.com/scylladb/alternator-client-python/issues/39).


### PR DESCRIPTION
## Summary
- add a compatibility and release decision record for the capability roadmap
- link the decision record from the roadmap, capability matrix, README, and release process
- keep node health, decommission handling, and dead-node handling explicitly planning-only

Closes #39

## Testing
- make lint
- make test-unit