### PR TITLE
Update capability docs examples and release notes

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -36,6 +36,7 @@ Supported or close:
 - key route affinity with partition-key cache and batch-write voting
 - helper lifecycle facade and public inspection methods
 - compatibility and release decision record
+- documentation, examples, and release-note guidance
 - vector search support
 
 Tracked gaps:
@@ -43,7 +44,6 @@ Tracked gaps:
 - node health tracking and quarantine planning only: [#32](https://github.com/scylladb/alternator-client-python/issues/32)
 - decommission and dead-node scenario tracking, covered by the deferred node
   health plan: [#3](https://github.com/scylladb/alternator-client-python/issues/3)
-- documentation, examples, and release notes: [#40](https://github.com/scylladb/alternator-client-python/issues/40)
 
 ## Compatibility Decisions
 

--- a/Makefile
+++ b/Makefile
@@ -36,19 +36,20 @@ test:
 
 # Run linters
 lint:
-	uv run ruff check alternator/ tests/
-	uv run ruff format --check alternator/ tests/
+	uv run ruff check alternator/ tests/ examples/
+	uv run ruff format --check alternator/ tests/ examples/
+	uv run python -m py_compile examples/*.py
 	uv run mypy alternator/ --strict
 	@# Ensure every noqa/type: ignore has an explanation after it
-	@if grep -rn --include='*.py' -P '#\s*(noqa|type:\s*ignore)(?::\s*\S+)?\s*$$' alternator/ tests/; then \
+	@if grep -rn --include='*.py' -P '#\s*(noqa|type:\s*ignore)(?::\s*\S+)?\s*$$' alternator/ tests/ examples/; then \
 		echo "ERROR: Found noqa/type: ignore comments without explanations. Add ' -- reason' after each."; \
 		exit 1; \
 	fi
 
 # Auto-fix linting issues
 lint-fix:
-	uv run ruff check --fix alternator/ tests/
-	uv run ruff format alternator/ tests/
+	uv run ruff check --fix alternator/ tests/ examples/
+	uv run ruff format alternator/ tests/ examples/
 
 # Remove build artifacts
 clean:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ pip install alternator-client[async]
 
 ## Quick Start
 
+### Which API Should I Use?
+
+Use `alternator.client(...)` for the common synchronous case where a context
+manager can own the SDK client and background node refresh.
+
+Use `create_client` / `close_client` when the SDK client must be created in one
+place and closed elsewhere. Use `create_resource` / `close_resource` for the
+boto3 table-oriented resource interface.
+
+Use `Helper` or `AsyncHelper` when one object should own client/resource
+lifecycle and expose topology diagnostics such as node refresh, node inspection,
+routing validation, and partition-key cache inspection.
+
 ### Synchronous Client
 
 For the common case, use the top-level `alternator.client` context manager.
@@ -683,6 +696,22 @@ your own deadline wrapper for end-to-end call deadlines.
 to the generated SDK config. `aws_region` is a placeholder required by the SDK;
 Alternator request routing still uses discovered Alternator endpoints.
 
+```python
+from alternator import Config, RetryConfig, RetryMode, TimeoutConfig
+
+config = Config(
+    seed_hosts=["node1", "node2"],
+    port=8000,
+    retries=RetryConfig(max_attempts=4, mode=RetryMode.STANDARD),
+    max_pool_connections=300,
+    timeouts=TimeoutConfig(
+        discovery_seconds=3.0,
+        connect_seconds=2.0,
+        read_seconds=10.0,
+    ),
+)
+```
+
 Use `sdk_config_customizer` for supported SDK config kwargs that are not modeled
 directly:
 
@@ -709,7 +738,7 @@ instead.
 
 - **Connection pool sizing**: The default `max_pool_connections=200` works for most workloads. Increase if you see connection pool exhaustion warnings under high concurrency.
 - **Refresh intervals**: Default active refresh (1s) is appropriate for dynamic clusters. For stable clusters, increase `active_refresh_interval_ms` to reduce discovery overhead.
-- **Timeouts**: Default `discovery_timeout_seconds=5.0` and `read_timeout_seconds=30.0` are conservative. Tune based on your network latency and query complexity.
+- **Timeouts**: Default `TimeoutConfig.discovery_seconds=5.0`, `connect_seconds=5.0`, and `read_seconds=30.0` are conservative. Tune based on your network latency and query complexity.
 - **Monitoring**: Enable `INFO`-level logging for the `alternator` logger to track node discovery events. Use `DEBUG` for detailed routing decisions during troubleshooting.
 - **Seed hosts**: Configure at least 2-3 seed hosts for redundancy in case one seed is temporarily unavailable during startup.
 
@@ -727,7 +756,21 @@ Async clients created by `create_async_client` / `AsyncAlternatorClient` are saf
 - **TLS Key Logs**: Key log file support depends on Python/OpenSSL runtime support for `SSLContext.keylog_filename` and should only be used in protected debugging environments.
 - **mTLS Integration Fixtures**: The local Scylla fixture in this repository does not require client certificate authentication, so automated tests cover configuration propagation and SSL context setup rather than a full mutual-TLS handshake.
 - **Async Key Affinity**: For async clients, partition key auto-discovery happens asynchronously. The first request for an unknown table will use round-robin routing while discovery runs in the background. Subsequent requests will use affinity. Preloading via `table_pk_map` avoids this initial miss.
-- **Batch Operations**: `BatchWriteItem` key affinity is based on a deterministic `PutRequest` or `DeleteRequest` selected from the batch. Batches with items targeting different partition keys are not split by affinity target.
+- **Batch Operations**: `BatchWriteItem` key affinity in `ANY_WRITE` mode uses preferred-node voting across eligible put/delete entries. Ties, missing partition-key metadata, unsupported key values, no active nodes, or no eligible votes fall back to normal routing. Batches are not split by affinity target.
+- **Node Health**: Node health, quarantine behavior, decommission handling, and dead-node handling are planning-only. `get_quarantined_nodes()` returns an empty list until a future implementation is explicitly added.
+
+## Examples
+
+- `examples/sync_demo.py`: synchronous client lifecycle and basic operations
+- `examples/async_demo.py`: async client lifecycle and concurrent operations
+- `examples/compare_aws_sdk.py`: Alternator client setup compared with a regular AWS SDK DynamoDB client
+- `examples/capability_configuration.py`: helper lifecycle, explicit routing fallback, static auth, timeouts/retries, mTLS, compression/header optimization, and key affinity configuration recipes
+
+## Release Notes
+
+See [docs/RELEASE_NOTES.md](docs/RELEASE_NOTES.md) for capability release-note
+guidance covering additive APIs, deprecations, behavior notes, migration steps,
+and versioning expectations.
 
 ## Development
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,7 +22,8 @@ default-enabled node health/quarantine behavior.
 
 Release notes for capability work should call out auth defaults, routing
 fallback behavior, deprecated-name migration, key-affinity behavior, and whether
-node health remains planning-only.
+node health remains planning-only. Use
+[docs/RELEASE_NOTES.md](docs/RELEASE_NOTES.md) as the release-note source.
 
 ### 1. Update Version
 

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -25,7 +25,7 @@ and intentionally deferred behavior.
 | Node health tracking | Deferred | [#32](https://github.com/scylladb/alternator-client-python/issues/32) | Planning-only. No node health code, tests, config objects, or behavior changes are authorized by this roadmap. |
 | Vector search extension | Supported | Existing API | Python client enables ScyllaDB Alternator vector extensions. |
 | Capability test harness | Partial | [#36](https://github.com/scylladb/alternator-client-python/issues/36) | Fake Alternator server fixture introduced for deterministic unit tests. |
-| Documentation and examples | Partial | [#40](https://github.com/scylladb/alternator-client-python/issues/40) | README and examples should stay aligned with implemented APIs. |
+| Documentation and examples | Supported | [#40](https://github.com/scylladb/alternator-client-python/issues/40) | README, examples, and release-note guidance are aligned with implemented APIs. |
 
 ## Deterministic Test Harness
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,0 +1,74 @@
+# Capability Release Notes
+
+Use this file as the release-note source for the capability roadmap tracked in
+[FEATURE_PARITY.md](../FEATURE_PARITY.md). Keep
+[docs/COMPATIBILITY_AND_RELEASE.md](COMPATIBILITY_AND_RELEASE.md) as the
+authority for compatibility decisions.
+
+## Next Minor Release
+
+### Additive APIs
+
+- Added `Helper` and `AsyncHelper` lifecycle facades for callers that need one
+  owner for clients/resources plus topology diagnostics.
+- Added explicit routing fallback controls with `fallback=...`,
+  `with_default_fallback(...)`, and `without_fallback(...)`.
+- Added topology validation helpers for configured datacenter/rack scopes.
+- Added transport configuration for SDK retries, connect/read timeouts,
+  connection pool size, region placeholder, and SDK config customization.
+- Added TLS client certificate, client key, and key log file settings.
+- Added configurable gzip compression level and callback-based header whitelist
+  additions.
+- Updated key-affinity routing semantics for read-modify-write operations and
+  `BatchWriteItem` preferred-node voting.
+
+### Compatibility Notes
+
+- Request signing remains disabled by default.
+- Alternator request signing continues to use explicit static credentials via
+  `auth=Auth.static_credentials(...)`.
+- Raw SDK credential kwargs remain supported for compatibility, but emit
+  deprecation warnings.
+- The convenience default port remains `8000`; pass `port=...` explicitly if
+  your deployment uses a different port.
+- Existing datacenter and rack constructors keep their compatibility fallback
+  behavior. Use explicit fallback arguments when the routing boundary matters.
+- Deprecated names such as `AlternatorConfig` and `TlsConfig` remain available
+  and continue to warn. Prefer `Config` and `TLS` in new code.
+- Node health, quarantine behavior, decommission handling, and dead-node
+  handling remain planning-only. No default routing behavior changes are part of
+  this release.
+
+### Behavior Notes
+
+- `RMW` key-affinity mode applies only to writes that require a prior item
+  state. `BatchWriteItem` does not use affinity in `RMW` mode.
+- `ANY_WRITE` key-affinity mode selects a preferred node for single-item writes.
+  For `BatchWriteItem`, valid put/delete entries vote for their preferred node.
+  Tied votes, missing partition-key metadata, unsupported key values, no active
+  nodes, or no eligible votes fall back to normal routing.
+- `sdk_config_customizer` can adjust supported SDK config kwargs, but the client
+  still owns endpoint routing and reapplies auth-managed signature settings.
+- TLS key logs contain traffic decryption material and should only be used in
+  protected debugging environments.
+
+### Migration Steps
+
+- Replace `AlternatorConfig` with `Config` and `TlsConfig` with `TLS` in new or
+  updated code.
+- Replace raw SDK credential kwargs with
+  `auth=Auth.static_credentials(access_key_id, secret_access_key)`.
+- Replace implicit topology assumptions with explicit routing fallback when a
+  request must stay inside a cluster, datacenter, or rack boundary.
+- Preload partition-key metadata with `table_pk_map` when key affinity should be
+  active on the first request for a table.
+- Review timeout configuration as per-attempt SDK settings, not whole-operation
+  deadlines.
+
+### Versioning Expectation
+
+The capability batch is compatible additive work and should be released as a
+minor version unless a separate maintainer decision adds an incompatible change.
+Changed defaults, removed deprecated names, removed legacy credential kwargs,
+changed routing fallback defaults, changed auth defaults, or default-enabled node
+health/quarantine behavior require a major release.

--- a/examples/capability_configuration.py
+++ b/examples/capability_configuration.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+Configuration recipes for advanced Alternator client capabilities.
+
+Running this file builds configuration objects only; it does not open network
+connections. Copy the functions into application code as needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from alternator import (
+    TLS,
+    AlternatorConfigBuilder,
+    Auth,
+    ClusterScope,
+    CompressionAlgorithm,
+    Config,
+    DatacenterScope,
+    HeaderWhitelistContext,
+    Helper,
+    KeyRouteAffinityMode,
+    RackScope,
+    RetryMode,
+    TimeoutConfig,
+)
+
+
+def helper_lifecycle_example() -> None:
+    """Use Helper when one object should own clients and topology diagnostics."""
+    config = Config(
+        seed_hosts=["node1.example.com", "node2.example.com"],
+        port=8000,
+    )
+
+    with Helper(config, auth=Auth.disabled()) as helper:
+        client = helper.client()
+        resource = helper.resource()
+
+        helper.update_live_nodes()
+        print("nodes:", helper.get_nodes())
+        print("next node:", helper.next_node())
+
+        client.list_tables()
+        resource.Table("orders").scan(Limit=1)
+
+
+def static_auth() -> Auth:
+    """Use explicit static credentials when Alternator auth is enabled."""
+    return Auth.static_credentials("alternator", "secret")
+
+
+def explicit_routing_fallback_config() -> Config:
+    """Route to a rack first, then its datacenter, then the full cluster."""
+    return Config(
+        seed_hosts=["node1.example.com", "node2.example.com"],
+        port=8000,
+        routing_scope=RackScope(
+            "dc1",
+            "rack1",
+            fallback=DatacenterScope("dc1", fallback=ClusterScope()),
+        ),
+    )
+
+
+def datacenter_only_config() -> Config:
+    """Disable fallback when requests must stay inside one datacenter."""
+    return Config(
+        seed_hosts=["node1.example.com"],
+        port=8000,
+        routing_scope=DatacenterScope("dc1", fallback=None),
+    )
+
+
+def customize_sdk(kwargs: dict[str, Any]) -> None:
+    """Adjust supported SDK config kwargs without taking over endpoint routing."""
+    kwargs["user_agent_extra"] = "orders-service"
+
+
+def transport_config() -> Config:
+    """Configure retries, per-attempt timeouts, pool size, and SDK kwargs."""
+    return (
+        AlternatorConfigBuilder()
+        .with_seeds("node1.example.com", "node2.example.com")
+        .with_port(8000)
+        .with_retries(max_attempts=4, mode=RetryMode.STANDARD)
+        .with_timeouts(
+            discovery_seconds=3.0,
+            connect_seconds=2.0,
+            read_seconds=10.0,
+        )
+        .with_pool_connections(300)
+        .with_aws_region("us-east-1")
+        .with_sdk_config_customizer(customize_sdk)
+        .build()
+    )
+
+
+def mtls_config() -> Config:
+    """Configure HTTPS discovery and SDK calls with client certificates."""
+    tls = TLS(
+        custom_ca_cert_paths=(Path("/etc/alternator/ca.pem"),),
+        client_cert_path=Path("/etc/alternator/client.crt"),
+        client_key_path=Path("/etc/alternator/client.key"),
+        key_log_file_path=Path("/secure/tmp/alternator-tls.keys"),
+    )
+    return Config(
+        seed_hosts=["node1.example.com"],
+        port=8043,
+        scheme="https",
+        tls=tls,
+    )
+
+
+def extra_headers(context: HeaderWhitelistContext) -> set[str]:
+    """Keep service headers that depend on auth and compression settings."""
+    headers = {"X-Service-Trace"}
+    if context.auth_enabled:
+        headers.add("X-Auth-Trace")
+    if context.compression_enabled:
+        headers.add("X-Compression-Trace")
+    return headers
+
+
+def compression_and_header_config() -> Config:
+    """Enable gzip request compression and dynamic header optimization."""
+    return (
+        AlternatorConfigBuilder()
+        .with_seeds("node1.example.com")
+        .with_port(8000)
+        .with_compression(
+            CompressionAlgorithm.GZIP,
+            min_size=1024,
+            gzip_level=6,
+        )
+        .with_header_optimization(
+            whitelist={"X-Request-Id"},
+            whitelist_callback=extra_headers,
+        )
+        .build()
+    )
+
+
+def key_affinity_config() -> Config:
+    """Enable write affinity with preloaded partition-key metadata."""
+    return (
+        AlternatorConfigBuilder()
+        .with_seeds("node1.example.com", "node2.example.com")
+        .with_port(8000)
+        .with_key_affinity(
+            KeyRouteAffinityMode.ANY_WRITE,
+            table_pk_map={"orders": "order_id", "customers": "customer_id"},
+        )
+        .build()
+    )
+
+
+def main() -> None:
+    """Build example configs without connecting to Alternator."""
+    configs = {
+        "routing": explicit_routing_fallback_config(),
+        "datacenter-only": datacenter_only_config(),
+        "transport": transport_config(),
+        "mtls": mtls_config(),
+        "compression-headers": compression_and_header_config(),
+        "key-affinity": key_affinity_config(),
+    }
+    auth = static_auth()
+
+    for name, config in configs.items():
+        print(f"{name}: seeds={list(config.seed_hosts)} port={config.port}")
+    print("static auth enabled:", auth.enabled)
+    print(
+        "example timeout seconds:",
+        TimeoutConfig().discovery_seconds,
+        TimeoutConfig().connect_seconds,
+        TimeoutConfig().read_seconds,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add capability release-note guidance and a configuration recipe example
- document which public client API to use and align README capability details
- make examples part of lint and syntax validation

Closes #40

## Testing
- make lint
- make test-unit
- uv run python examples/capability_configuration.py