### PR TITLE
Configure Renovate dependency policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "dependencyDashboard": true,
+  "minimumReleaseAge": "90 days",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
+  "internalChecksFilter": "strict",
+  "prCreation": "not-pending"
+}


### PR DESCRIPTION
## Summary
- add Renovate configuration using the GitHub Actions digest pinning helper preset
- require updates to be at least 90 days old before Renovate creates PRs
- require release timestamps for the age gate and use strict internal filtering

## Testing
- python -m json.tool renovate.json
- npx --yes --package renovate renovate-config-validator renovate.json
- git diff --check