### PR TITLE
Add integration parity coverage and build stages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,29 @@
-.PHONY: install test-unit test-integration test lint lint-fix clean scylla-start scylla-stop scylla-kill scylla-rm help
+MAKEFILE_PATH := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+COMPOSE ?= docker compose
+SCYLLA_IMAGE ?= scylladb/scylla:2025.1
+SCYLLA_HOST ?= localhost
+SCYLLA_PORT ?= 9998
+SCYLLA_READY_URL ?= http://$(SCYLLA_HOST):$(SCYLLA_PORT)/localnodes
+DOCKER_CACHE_DIR := $(MAKEFILE_PATH)/.docker-cache
+DOCKER_CACHE_FILE := $(DOCKER_CACHE_DIR)/scylla-image.tar
+CERT_CACHE_DIR := $(MAKEFILE_PATH)/.cert-cache
+CERT_DIR := $(MAKEFILE_PATH)/tests/scylla
+
+.PHONY: install verify build compile compile-test compile-demo test-unit test-integration test-integration-only test-demo test-demo-only test-all test lint lint-fix clean wait-for-alternator scylla-start scylla-stop scylla-kill scylla-rm docker-pull docker-cache-save docker-cache-load cert-cache-save cert-cache-load help
 
 # Default target
 help:
 	@echo "Available targets:"
 	@echo "  install          - Install package in development mode"
+	@echo "  verify           - Run lint, compile, unit tests, and package checks"
+	@echo "  build            - Build package artifacts and validate metadata"
+	@echo "  compile          - Compile package modules"
+	@echo "  compile-test     - Compile test modules"
+	@echo "  compile-demo     - Compile examples"
 	@echo "  test-unit        - Run unit tests"
-	@echo "  test-integration - Run integration tests (requires Scylla)"
+	@echo "  test-integration - Start Scylla, run integration tests, then stop Scylla"
+	@echo "  test-demo        - Start Scylla, run examples, then stop Scylla"
+	@echo "  test-all         - Run unit, integration, and demo tests"
 	@echo "  test             - Run all tests"
 	@echo "  lint             - Run linters (ruff + mypy)"
 	@echo "  lint-fix         - Auto-fix linting issues with ruff"
@@ -19,15 +37,57 @@ help:
 install:
 	uv sync --all-extras
 
+verify: lint compile compile-test compile-demo test-unit build
+
+build:
+	rm -rf build/ dist/ *.egg-info/
+	uvx --from build pyproject-build
+	uvx twine check dist/*
+
+compile:
+	uv run python -m compileall -q alternator/
+
+compile-test:
+	uv run python -m compileall -q tests/
+
+compile-demo:
+	uv run python -m compileall -q examples/
+
 # Run unit tests only (no external dependencies)
 test-unit:
 	uv run pytest tests/unit/ -v --tb=short --timeout=60 \
 		--cov=alternator --cov-report=xml --cov-report=term-missing --cov-fail-under=70
 
-# Run integration tests (requires running Scylla cluster)
+# Run integration tests and manage the local Scylla cluster lifecycle
 test-integration:
+	@set -e; \
+	trap '$(MAKE) scylla-stop' EXIT; \
+	$(MAKE) scylla-start; \
+	$(MAKE) test-integration-only
+
+# Run integration tests against an already-running Scylla cluster
+test-integration-only:
 	uv run pytest tests/integration/ -v --tb=short --timeout=120 \
 		--cov=alternator --cov-report=xml --cov-report=term-missing
+
+test-demo:
+	@set -e; \
+	trap '$(MAKE) scylla-stop' EXIT; \
+	$(MAKE) scylla-start; \
+	$(MAKE) test-demo-only
+
+test-demo-only: compile-demo
+	SCYLLA_HOST=$(SCYLLA_HOST) SCYLLA_PORT=$(SCYLLA_PORT) uv run python examples/sync_demo.py
+	SCYLLA_HOST=$(SCYLLA_HOST) SCYLLA_PORT=$(SCYLLA_PORT) uv run python examples/async_demo.py
+	uv run python examples/capability_configuration.py
+
+test-all:
+	$(MAKE) test-unit
+	@set -e; \
+	trap '$(MAKE) scylla-stop' EXIT; \
+	$(MAKE) scylla-start; \
+	$(MAKE) test-integration-only; \
+	$(MAKE) test-demo-only
 
 # Run all tests
 test:
@@ -38,7 +98,7 @@ test:
 lint:
 	uv run ruff check alternator/ tests/ examples/
 	uv run ruff format --check alternator/ tests/ examples/
-	uv run python -m py_compile examples/*.py
+	$(MAKE) compile-demo
 	uv run mypy alternator/ --strict
 	@# Ensure every noqa/type: ignore has an explanation after it
 	@if grep -rn --include='*.py' -P '#\s*(noqa|type:\s*ignore)(?::\s*\S+)?\s*$$' alternator/ tests/ examples/; then \
@@ -72,25 +132,62 @@ tests/scylla/db.key tests/scylla/db.crt:
 		-days 365 -nodes -subj '/CN=localhost' \
 		-addext 'subjectAltName=IP:172.43.0.2,IP:172.43.0.3,IP:172.43.0.4,DNS:localhost'
 
-# Start Scylla cluster with Docker Compose
-scylla-start: .prepare-cert
-	docker compose up -d
+wait-for-alternator:
 	@echo "Waiting for Scylla cluster to be ready..."
 	@for i in $$(seq 1 60); do \
-		curl -sf http://localhost:9998/localnodes > /dev/null 2>&1 && break; \
+		if curl -sf "$(SCYLLA_READY_URL)" > /dev/null 2>&1; then \
+			echo "Scylla cluster is ready."; \
+			exit 0; \
+		fi; \
 		echo "Waiting for Scylla Alternator... ($$i)"; \
 		sleep 5; \
-	done
-	@echo "Scylla cluster is ready."
+	done; \
+	echo "Timed out waiting for Scylla Alternator at $(SCYLLA_READY_URL)"; \
+	exit 1
+
+# Start Scylla cluster with Docker Compose
+scylla-start: cert-cache-load docker-cache-load
+	$(COMPOSE) up -d
+	$(MAKE) wait-for-alternator
 
 # Stop Scylla cluster
 scylla-stop:
-	docker compose down -v
+	$(COMPOSE) down -v
 
 # Force kill Scylla cluster
 scylla-kill:
-	docker compose kill
+	$(COMPOSE) kill
 
 # Remove Scylla containers and volumes
 scylla-rm:
-	docker compose rm -f -v
+	$(COMPOSE) rm -f -v
+
+docker-pull:
+	docker pull $(SCYLLA_IMAGE)
+
+docker-cache-save: docker-pull
+	mkdir -p $(DOCKER_CACHE_DIR)
+	docker save $(SCYLLA_IMAGE) -o $(DOCKER_CACHE_FILE)
+
+docker-cache-load:
+	@if [ -f "$(DOCKER_CACHE_FILE)" ]; then \
+		echo "Loading Docker image from cache..."; \
+		docker load -i $(DOCKER_CACHE_FILE); \
+	else \
+		echo "Docker image cache not found, pulling $(SCYLLA_IMAGE)..."; \
+		$(MAKE) docker-pull; \
+	fi
+
+cert-cache-save: .prepare-cert
+	mkdir -p $(CERT_CACHE_DIR)
+	cp $(CERT_DIR)/db.key $(CERT_DIR)/db.crt $(CERT_CACHE_DIR)/
+
+cert-cache-load:
+	@if [ -f "$(CERT_CACHE_DIR)/db.key" ] && [ -f "$(CERT_CACHE_DIR)/db.crt" ]; then \
+		echo "Loading certificates from cache..."; \
+		cp "$(CERT_CACHE_DIR)/db.key" "$(CERT_CACHE_DIR)/db.crt" "$(CERT_DIR)/"; \
+		chmod 644 "$(CERT_DIR)/db.key"; \
+	else \
+		echo "Certificate cache not found, generating..."; \
+		$(MAKE) .prepare-cert; \
+	fi

--- a/examples/async_demo.py
+++ b/examples/async_demo.py
@@ -10,6 +10,7 @@ This example shows how to:
 
 import asyncio
 import logging
+import os
 import sys
 
 from botocore.exceptions import ClientError
@@ -28,8 +29,8 @@ async def main() -> None:
     """Run the async demo."""
     # Configure the client
     config = Config(
-        seed_hosts=["localhost"],  # Replace with your Scylla nodes
-        port=8000,
+        seed_hosts=[os.environ.get("SCYLLA_HOST", "localhost")],
+        port=int(os.environ.get("SCYLLA_PORT", "8000")),
         scheme="http",  # Use "https" for TLS
     )
 

--- a/examples/sync_demo.py
+++ b/examples/sync_demo.py
@@ -9,6 +9,7 @@ This example shows how to:
 """
 
 import logging
+import os
 import sys
 
 from botocore.exceptions import ClientError
@@ -26,8 +27,8 @@ def main() -> None:
     """Run the sync demo."""
     # Configure the client
     config = Config(
-        seed_hosts=["localhost"],  # Replace with your Scylla nodes
-        port=8000,
+        seed_hosts=[os.environ.get("SCYLLA_HOST", "localhost")],
+        port=int(os.environ.get("SCYLLA_PORT", "8000")),
         scheme="http",  # Use "https" for TLS
     )
 

--- a/tests/integration/test_header_optimization.py
+++ b/tests/integration/test_header_optimization.py
@@ -1,0 +1,108 @@
+"""Integration tests for prepared-request header filtering."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from alternator import AlternatorConfigBuilder, Auth, close_client, create_client
+from alternator.async_client import close_async_client, create_async_client
+from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
+from tests.integration.wire_capture import (
+    capture_prepared_requests,
+    inject_custom_headers,
+    latest_request,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(SKIP_INTEGRATION, reason="Integration tests disabled"),
+]
+
+
+def _user_agent_config(user_agent_label: str) -> object:
+    def customize_sdk(kwargs: dict[str, Any]) -> None:
+        kwargs["user_agent_extra"] = user_agent_label
+
+    return (
+        AlternatorConfigBuilder()
+        .with_seeds(SCYLLA_HOST)
+        .with_port(SCYLLA_PORT)
+        .with_sdk_config_customizer(customize_sdk)
+        .build()
+    )
+
+
+class TestHeaderOptimization:
+    """Verify sync header filtering on prepared requests."""
+
+    def test_disabled_keeps_user_agent_on_wire(self) -> None:
+        client = create_client(_user_agent_config("alternator-unfiltered"))
+        try:
+            captured = capture_prepared_requests(client)
+            client.list_tables()
+            request = latest_request(captured)
+            assert "alternator-unfiltered" in (request.header("user-agent") or "")
+        finally:
+            close_client(client)
+
+    def test_filters_wire_headers_and_preserves_auth(self) -> None:
+        def customize_sdk(kwargs: dict[str, Any]) -> None:
+            kwargs["user_agent_extra"] = "alternator-filtered"
+
+        config = (
+            AlternatorConfigBuilder()
+            .with_seeds(SCYLLA_HOST)
+            .with_port(SCYLLA_PORT)
+            .with_header_optimization(whitelist={"X-Keep-Me"})
+            .with_sdk_config_customizer(customize_sdk)
+            .build()
+        )
+        client = create_client(
+            config,
+            auth=Auth.static_credentials("alternator", "secret"),
+        )
+        try:
+            inject_custom_headers(client)
+            captured = capture_prepared_requests(client)
+            client.list_tables()
+            request = latest_request(captured)
+
+            assert request.header("x-keep-me") == "keep"
+            assert request.header("x-drop-me") is None
+            assert request.header("authorization") is not None
+            assert request.header("x-amz-date") is not None
+            assert request.header("user-agent") is None
+        finally:
+            close_client(client)
+
+
+class TestAsyncHeaderOptimization:
+    """Verify async header filtering on prepared requests."""
+
+    @pytest.mark.asyncio
+    async def test_filters_wire_headers_and_preserves_auth(self) -> None:
+        config = (
+            AlternatorConfigBuilder()
+            .with_seeds(SCYLLA_HOST)
+            .with_port(SCYLLA_PORT)
+            .with_header_optimization(whitelist={"X-Keep-Me"})
+            .build()
+        )
+        client = await create_async_client(
+            config,
+            auth=Auth.static_credentials("alternator", "secret"),
+        )
+        try:
+            inject_custom_headers(client)
+            captured = capture_prepared_requests(client)
+            await client.list_tables()
+            request = latest_request(captured)
+
+            assert request.header("x-keep-me") == "keep"
+            assert request.header("x-drop-me") is None
+            assert request.header("authorization") is not None
+            assert request.header("x-amz-date") is not None
+        finally:
+            await close_async_client(client)

--- a/tests/integration/test_live_nodes.py
+++ b/tests/integration/test_live_nodes.py
@@ -1,0 +1,75 @@
+"""Integration tests for live-node discovery through public helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from alternator import AlternatorConfigBuilder, Auth, Helper, KeyRouteAffinityMode
+from alternator.async_client import AsyncHelper
+from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(SKIP_INTEGRATION, reason="Integration tests disabled"),
+]
+
+
+def _affinity_config() -> object:
+    return (
+        AlternatorConfigBuilder()
+        .with_seeds(SCYLLA_HOST)
+        .with_port(SCYLLA_PORT)
+        .with_key_affinity(
+            KeyRouteAffinityMode.ANY_WRITE,
+            table_pk_map={"preconfigured_table": "pk"},
+        )
+        .build()
+    )
+
+
+class TestLiveNodeHelperDiagnostics:
+    """Verify sync helper diagnostics and shared-client lifecycle."""
+
+    def test_helper_exposes_nodes_clients_and_partition_keys(self) -> None:
+        with Helper(_affinity_config(), auth=Auth.disabled()) as helper:
+            assert helper.update_live_nodes()
+            nodes = helper.get_nodes()
+            assert nodes
+            assert helper.get_active_nodes() == nodes
+            assert helper.get_quarantined_nodes() == []
+            assert helper.check_rack_datacenter_feature_supported()
+            assert helper.get_partition_key_name("preconfigured_table") == "pk"
+
+            visited = {helper.next_node() for _ in range(len(nodes) * 2)}
+            assert set(nodes).issubset({node for node in visited if node is not None})
+
+            client = helper.client()
+            assert "TableNames" in client.list_tables()
+
+            resource = helper.resource()
+            assert "TableNames" in resource.meta.client.list_tables()
+
+
+class TestAsyncLiveNodeHelperDiagnostics:
+    """Verify async helper diagnostics and shared-client lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_helper_exposes_nodes_clients_and_partition_keys(self) -> None:
+        async with AsyncHelper(_affinity_config(), auth=Auth.disabled()) as helper:
+            assert await helper.update_live_nodes()
+            nodes = helper.get_nodes()
+            assert nodes
+            assert helper.get_active_nodes() == nodes
+            assert helper.get_quarantined_nodes() == []
+            assert await helper.check_rack_datacenter_feature_supported()
+            assert await helper.get_partition_key_name("preconfigured_table") == "pk"
+
+            visited: set[str] = set()
+            for _ in range(len(nodes) * 2):
+                node = await helper.next_node()
+                assert node is not None
+                visited.add(node)
+            assert set(nodes).issubset(visited)
+
+            client = await helper.client()
+            assert "TableNames" in await client.list_tables()

--- a/tests/integration/test_request_compression.py
+++ b/tests/integration/test_request_compression.py
@@ -1,0 +1,162 @@
+"""Integration tests for request compression on prepared requests."""
+
+from __future__ import annotations
+
+import gzip
+import uuid
+from collections.abc import Callable
+
+import pytest
+from botocore.exceptions import ClientError
+
+from alternator import (
+    AlternatorConfigBuilder,
+    Auth,
+    CompressionAlgorithm,
+    close_client,
+    create_client,
+)
+from alternator.async_client import close_async_client, create_async_client
+from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
+from tests.integration.wire_capture import (
+    capture_prepared_requests,
+    inject_custom_headers,
+    latest_request,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(SKIP_INTEGRATION, reason="Integration tests disabled"),
+]
+
+
+def _large_item_payload() -> str:
+    return "wire-compression-payload-" * 500
+
+
+def _gzip_config(min_size: int = 100) -> object:
+    return (
+        AlternatorConfigBuilder()
+        .with_seeds(SCYLLA_HOST)
+        .with_port(SCYLLA_PORT)
+        .with_compression(CompressionAlgorithm.GZIP, min_size=min_size)
+        .build()
+    )
+
+
+class TestRequestCompression:
+    """Verify sync request compression behavior on the wire."""
+
+    def test_small_payload_is_not_gzipped_on_wire(self) -> None:
+        client = create_client(_gzip_config(min_size=10_000))
+        try:
+            captured = capture_prepared_requests(client)
+            client.list_tables()
+            request = latest_request(captured)
+            assert request.header("content-encoding") is None
+        finally:
+            close_client(client)
+
+    def test_large_payload_is_gzipped_on_wire(
+        self,
+        skip_if_scylla_version_below: Callable[..., None],
+    ) -> None:
+        from tests.integration.scylla_version import ScyllaVersion
+
+        skip_if_scylla_version_below(
+            ScyllaVersion(2026, 1, 0), "gzip request compression"
+        )
+
+        client = create_client(_gzip_config())
+        try:
+            captured = capture_prepared_requests(client)
+            with pytest.raises(ClientError):
+                client.put_item(
+                    TableName=f"missing_compression_{uuid.uuid4().hex}",
+                    Item={
+                        "pk": {"S": "compression-test"},
+                        "data": {"S": _large_item_payload()},
+                    },
+                )
+
+            request = latest_request(captured)
+            assert request.header("content-encoding") == "gzip"
+            assert b"wire-compression-payload" in gzip.decompress(request.body)
+        finally:
+            close_client(client)
+
+    def test_headers_and_compression_share_wire_whitelist(
+        self,
+        skip_if_scylla_version_below: Callable[..., None],
+    ) -> None:
+        from tests.integration.scylla_version import ScyllaVersion
+
+        skip_if_scylla_version_below(
+            ScyllaVersion(2026, 1, 0), "gzip request compression"
+        )
+
+        config = (
+            AlternatorConfigBuilder()
+            .with_seeds(SCYLLA_HOST)
+            .with_port(SCYLLA_PORT)
+            .with_compression(CompressionAlgorithm.GZIP, min_size=100)
+            .with_header_optimization(whitelist={"X-Keep-Me"})
+            .build()
+        )
+        client = create_client(
+            config,
+            auth=Auth.static_credentials("alternator", "secret"),
+        )
+        try:
+            inject_custom_headers(client)
+            captured = capture_prepared_requests(client)
+            with pytest.raises(ClientError):
+                client.put_item(
+                    TableName=f"missing_compression_headers_{uuid.uuid4().hex}",
+                    Item={
+                        "pk": {"S": "compression-header-test"},
+                        "data": {"S": _large_item_payload()},
+                    },
+                )
+
+            request = latest_request(captured)
+            assert request.header("content-encoding") == "gzip"
+            assert request.header("content-length") is not None
+            assert request.header("x-keep-me") == "keep"
+            assert request.header("x-drop-me") is None
+            assert request.header("authorization") is not None
+        finally:
+            close_client(client)
+
+
+class TestAsyncRequestCompression:
+    """Verify async request compression behavior on the wire."""
+
+    @pytest.mark.asyncio
+    async def test_large_payload_is_gzipped_on_wire(
+        self,
+        skip_if_scylla_version_below: Callable[..., None],
+    ) -> None:
+        from tests.integration.scylla_version import ScyllaVersion
+
+        skip_if_scylla_version_below(
+            ScyllaVersion(2026, 1, 0), "gzip request compression"
+        )
+
+        client = await create_async_client(_gzip_config())
+        try:
+            captured = capture_prepared_requests(client)
+            with pytest.raises(ClientError):
+                await client.put_item(
+                    TableName=f"missing_async_compression_{uuid.uuid4().hex}",
+                    Item={
+                        "pk": {"S": "async-compression-test"},
+                        "data": {"S": _large_item_payload()},
+                    },
+                )
+
+            request = latest_request(captured)
+            assert request.header("content-encoding") == "gzip"
+            assert b"wire-compression-payload" in gzip.decompress(request.body)
+        finally:
+            await close_async_client(client)

--- a/tests/integration/test_sdk_config.py
+++ b/tests/integration/test_sdk_config.py
@@ -1,0 +1,82 @@
+"""Integration tests for SDK client configuration propagation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from alternator import (
+    Config,
+    RetryConfig,
+    RetryMode,
+    TimeoutConfig,
+    close_client,
+    create_client,
+)
+from alternator.async_client import close_async_client, create_async_client
+from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(SKIP_INTEGRATION, reason="Integration tests disabled"),
+]
+
+
+def _transport_config(user_agent_label: str) -> Config:
+    def customize_sdk(kwargs: dict[str, Any]) -> None:
+        kwargs["user_agent_extra"] = user_agent_label
+
+    return Config(
+        seed_hosts=[SCYLLA_HOST],
+        port=SCYLLA_PORT,
+        scheme="http",
+        retries=RetryConfig(max_attempts=4, mode=RetryMode.STANDARD),
+        max_pool_connections=37,
+        timeouts=TimeoutConfig(
+            discovery_seconds=2.0,
+            connect_seconds=3.0,
+            read_seconds=11.0,
+        ),
+        aws_region="us-west-2",
+        sdk_config_customizer=customize_sdk,
+    )
+
+
+class TestSdkConfigPropagation:
+    """Verify transport, retry, and SDK options reach the real sync client."""
+
+    def test_client_applies_sdk_config_and_still_operates(self) -> None:
+        config = _transport_config("alternator-sdk-config-sync")
+        client = create_client(config)
+        try:
+            sdk_config = client.meta.config
+            assert client.meta.region_name == "us-west-2"
+            assert sdk_config.max_pool_connections == 37
+            assert sdk_config.connect_timeout == 3.0
+            assert sdk_config.read_timeout == 11.0
+            assert sdk_config.retries["mode"] == RetryMode.STANDARD.value
+            assert "alternator-sdk-config-sync" in sdk_config.user_agent_extra
+            assert "TableNames" in client.list_tables()
+        finally:
+            close_client(client)
+
+
+class TestAsyncSdkConfigPropagation:
+    """Verify transport, retry, and SDK options reach the real async client."""
+
+    @pytest.mark.asyncio
+    async def test_client_applies_sdk_config_and_still_operates(self) -> None:
+        config = _transport_config("alternator-sdk-config-async")
+        client = await create_async_client(config)
+        try:
+            sdk_config = client.meta.config
+            assert client.meta.region_name == "us-west-2"
+            assert sdk_config.max_pool_connections == 37
+            assert sdk_config.connect_timeout == 3.0
+            assert sdk_config.read_timeout == 11.0
+            assert sdk_config.retries["mode"] == RetryMode.STANDARD.value
+            assert "alternator-sdk-config-async" in sdk_config.user_agent_extra
+            assert "TableNames" in await client.list_tables()
+        finally:
+            await close_async_client(client)

--- a/tests/integration/wire_capture.py
+++ b/tests/integration/wire_capture.py
@@ -1,0 +1,71 @@
+"""Helpers for inspecting botocore requests immediately before transport send."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CapturedRequest:
+    """Prepared request snapshot captured immediately before transport send."""
+
+    headers: dict[str, str]
+    body: bytes
+
+    def header(self, name: str) -> str | None:
+        """Return a case-insensitive header value."""
+        return self.headers.get(name.lower())
+
+
+def body_as_bytes(body: object) -> bytes:
+    if body is None:
+        return b""
+    if isinstance(body, bytes):
+        return body
+    if isinstance(body, str):
+        return body.encode("utf-8")
+    if isinstance(body, bytearray | memoryview):
+        return bytes(body)
+    return b""
+
+
+def normalize_headers(headers: object) -> dict[str, str]:
+    normalized: dict[str, str] = {}
+    for raw_key, raw_value in dict(headers).items():
+        key = raw_key.decode("utf-8") if isinstance(raw_key, bytes) else str(raw_key)
+        value = (
+            raw_value.decode("utf-8")
+            if isinstance(raw_value, bytes)
+            else str(raw_value)
+        )
+        normalized[key.lower()] = value
+    return normalized
+
+
+def capture_prepared_requests(client: Any) -> list[CapturedRequest]:  # noqa: ANN401 -- SDK clients are dynamically typed
+    captured: list[CapturedRequest] = []
+
+    def capture(request: Any, **kwargs: Any) -> None:  # noqa: ANN401 -- botocore event handler signature
+        captured.append(
+            CapturedRequest(
+                headers=normalize_headers(request.headers),
+                body=body_as_bytes(getattr(request, "body", None)),
+            )
+        )
+
+    client.meta.events.register_last("before-send.dynamodb.*", capture)
+    return captured
+
+
+def inject_custom_headers(client: Any) -> None:  # noqa: ANN401 -- SDK clients are dynamically typed
+    def add_headers(request: Any, **kwargs: Any) -> None:  # noqa: ANN401 -- botocore event handler signature
+        request.headers["X-Keep-Me"] = "keep"
+        request.headers["X-Drop-Me"] = "drop"
+
+    client.meta.events.register_first("before-send.dynamodb.*", add_headers)
+
+
+def latest_request(captured: list[CapturedRequest]) -> CapturedRequest:
+    assert captured, "expected at least one prepared request to be captured"
+    return captured[-1]


### PR DESCRIPTION
## Summary
- add integration coverage for helper diagnostics, SDK config propagation, and prepared-request header/compression behavior
- expand Makefile stages for verify/build/compile/test/demo, cluster readiness, and docker/cert cache helpers
- let CI run integration tests through the Makefile lifecycle target
- make sync and async demos honor SCYLLA_HOST and SCYLLA_PORT for local test runs

## Validation
- make verify
- make test-integration
- make test-demo