### PR TITLE
Fix cluster-wide localnodes discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,11 @@ config = Config(
 )
 ```
 
+`ClusterScope` queries every configured seed host and combines the returned
+`/localnodes` results. Because ScyllaDB's optionless `/localnodes` endpoint
+returns nodes from the contacted seed's local datacenter, pass at least one seed
+from each datacenter when cluster-wide routing should span multiple datacenters.
+
 Default constructors keep compatibility fallback behavior:
 
 - `DatacenterScope("dc1")` uses `DatacenterScope` -> `ClusterScope`

--- a/alternator/core/live_nodes.py
+++ b/alternator/core/live_nodes.py
@@ -213,6 +213,12 @@ def _uses_topology_filter(scope: RoutingScope) -> bool:
     return isinstance(scope, DatacenterScope | RackScope)
 
 
+def _uses_cluster_scope(scope: RoutingScope) -> bool:
+    from alternator.core.routing_scope import ClusterScope
+
+    return isinstance(scope, ClusterScope)
+
+
 def _validate_topology_scope_values(scope: RoutingScope) -> None:
     from alternator.core.routing_scope import DatacenterScope, RackScope
 
@@ -366,6 +372,12 @@ class SyncLiveNodesManager:
         scope: RoutingScope | None = self._config.routing_scope
 
         while scope is not None:
+            if _uses_cluster_scope(scope):
+                if self._refresh_cluster_scope_nodes(scope):
+                    return True
+                scope = scope.fallback
+                continue
+
             for seed in self._config.seed_hosts:
                 url = self._core.build_localnodes_url(scope, seed)
                 try:
@@ -378,6 +390,27 @@ class SyncLiveNodesManager:
 
         self._core.log_all_scopes_failed()
         return False
+
+    def _refresh_cluster_scope_nodes(self, scope: RoutingScope) -> bool:
+        """Fetch cluster scope by aggregating local node lists from every seed."""
+        discovered: list[str] = []
+        seen: set[str] = set()
+
+        for seed in self._config.seed_hosts:
+            url = self._core.build_localnodes_url(scope, seed)
+            try:
+                nodes = self._http_fetch(url)
+            except Exception as e:
+                self._core.log_fetch_error(scope, e)
+                continue
+
+            for node in nodes:
+                if node in seen:
+                    continue
+                seen.add(node)
+                discovered.append(node)
+
+        return self._core.process_fetch_result(discovered, scope)
 
     def _fetch_scope_nodes(self, scope: RoutingScope) -> list[str]:
         """Fetch nodes for one scope without updating current routing state."""
@@ -533,6 +566,12 @@ class AsyncLiveNodesManager:
         scope: RoutingScope | None = self._config.routing_scope
 
         while scope is not None:
+            if _uses_cluster_scope(scope):
+                if await self._refresh_cluster_scope_nodes(scope):
+                    return True
+                scope = scope.fallback
+                continue
+
             for seed in self._config.seed_hosts:
                 url = self._core.build_localnodes_url(scope, seed)
                 try:
@@ -545,6 +584,27 @@ class AsyncLiveNodesManager:
 
         self._core.log_all_scopes_failed()
         return False
+
+    async def _refresh_cluster_scope_nodes(self, scope: RoutingScope) -> bool:
+        """Fetch cluster scope by aggregating local node lists from every seed."""
+        discovered: list[str] = []
+        seen: set[str] = set()
+
+        for seed in self._config.seed_hosts:
+            url = self._core.build_localnodes_url(scope, seed)
+            try:
+                nodes = await self._http_fetch(url)
+            except Exception as e:
+                self._core.log_fetch_error(scope, e)
+                continue
+
+            for node in nodes:
+                if node in seen:
+                    continue
+                seen.add(node)
+                discovered.append(node)
+
+        return self._core.process_fetch_result(discovered, scope)
 
     async def _fetch_scope_nodes(self, scope: RoutingScope) -> list[str]:
         """Fetch nodes for one scope without updating current routing state."""

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -9,7 +9,7 @@ and intentionally deferred behavior.
 | DynamoDB resource | Supported | Existing API | `create_resource` and `AlternatorResource` wrap boto3 resource usage. |
 | Async DynamoDB client | Supported | Existing API | `create_async_client` and `AsyncAlternatorClient` use aioboto3. |
 | Host-only seeds with one shared port | Supported | Existing API | Seeds must not include ports; one port applies to all nodes. |
-| Node discovery | Supported | Existing API | `/localnodes` refresh updates the live node list. |
+| Node discovery | Supported | Existing API | `/localnodes` refresh updates the live node list. `ClusterScope` combines results from all configured seeds so multi-DC users can seed each datacenter. |
 | Routing scopes | Supported | [#35](https://github.com/scylladb/alternator-client-python/issues/35) | Cluster, datacenter, and rack scopes support explicit fallback chains and scoped validation helpers. |
 | Request query plans | Supported | Existing API | Requests use stable seeded node ordering for retries. |
 | Auth | Supported | Existing API | Disabled by default; explicit static credentials enable signing. |

--- a/tests/unit/test_async_manager.py
+++ b/tests/unit/test_async_manager.py
@@ -99,6 +99,57 @@ class TestAsyncLiveNodesManager:
         assert "dc=" not in call_urls[1]
 
     @pytest.mark.asyncio
+    async def test_cluster_scope_aggregates_all_seed_localnodes(self) -> None:
+        """Cluster scope unions local-DC node lists returned by each seed."""
+        call_urls: list[str] = []
+
+        async def mock_fetch(url: str) -> list[str]:
+            call_urls.append(url)
+            if "seed-dc1" in url:
+                return ["dc1-node1", "dc1-node2"]
+            if "seed-dc2" in url:
+                return ["dc2-node1", "dc2-node2"]
+            return []
+
+        config = Config(
+            seed_hosts=["seed-dc1", "seed-dc2"],
+            port=8000,
+            routing_scope=ClusterScope(),
+        )
+        manager = AsyncLiveNodesManager(config, mock_fetch)
+
+        assert await manager.refresh_nodes() is True
+        assert call_urls == [
+            "http://seed-dc1:8000/localnodes",
+            "http://seed-dc2:8000/localnodes",
+        ]
+        assert manager.nodes.nodes == (
+            "dc1-node1",
+            "dc1-node2",
+            "dc2-node1",
+            "dc2-node2",
+        )
+
+    @pytest.mark.asyncio
+    async def test_cluster_scope_aggregates_reachable_seed_localnodes(self) -> None:
+        """Cluster scope keeps usable seed results when another seed fails."""
+
+        async def mock_fetch(url: str) -> list[str]:
+            if "seed-dc1" in url:
+                raise OSError("seed unavailable")
+            return ["dc2-node1", "dc2-node2"]
+
+        config = Config(
+            seed_hosts=["seed-dc1", "seed-dc2"],
+            port=8000,
+            routing_scope=ClusterScope(),
+        )
+        manager = AsyncLiveNodesManager(config, mock_fetch)
+
+        assert await manager.refresh_nodes() is True
+        assert manager.nodes.nodes == ("dc2-node1", "dc2-node2")
+
+    @pytest.mark.asyncio
     async def test_url_construction(self, config: Config) -> None:
         """Test build_localnodes_url constructs correct URL."""
         manager = AsyncLiveNodesManager(config, lambda _: [])

--- a/tests/unit/test_sync_manager.py
+++ b/tests/unit/test_sync_manager.py
@@ -7,7 +7,7 @@ import pytest
 
 from alternator.config import Config
 from alternator.core.live_nodes import NoNodesAvailableError, SyncLiveNodesManager
-from alternator.core.routing_scope import DatacenterScope, RackScope
+from alternator.core.routing_scope import ClusterScope, DatacenterScope, RackScope
 from alternator.exceptions import ConfigurationError
 
 
@@ -96,6 +96,55 @@ class TestSyncLiveNodesManager:
         assert len(calls) == 2  # DC scope then cluster scope
         assert "dc=dc1" in calls[0]
         assert "dc=" not in calls[1]
+
+    def test_cluster_scope_aggregates_all_seed_localnodes(self) -> None:
+        """Cluster scope unions local-DC node lists returned by each seed."""
+        config = Config(
+            seed_hosts=["seed-dc1", "seed-dc2"],
+            port=8000,
+            routing_scope=ClusterScope(),
+        )
+        calls: list[str] = []
+
+        def mock_fetch(url: str) -> Sequence[str]:
+            calls.append(url)
+            if "seed-dc1" in url:
+                return ["dc1-node1", "dc1-node2"]
+            if "seed-dc2" in url:
+                return ["dc2-node1", "dc2-node2"]
+            return []
+
+        manager = SyncLiveNodesManager(config, mock_fetch)
+
+        assert manager.refresh_nodes() is True
+        assert calls == [
+            "http://seed-dc1:8000/localnodes",
+            "http://seed-dc2:8000/localnodes",
+        ]
+        assert manager.nodes.nodes == (
+            "dc1-node1",
+            "dc1-node2",
+            "dc2-node1",
+            "dc2-node2",
+        )
+
+    def test_cluster_scope_aggregates_reachable_seed_localnodes(self) -> None:
+        """Cluster scope keeps usable seed results when another seed fails."""
+        config = Config(
+            seed_hosts=["seed-dc1", "seed-dc2"],
+            port=8000,
+            routing_scope=ClusterScope(),
+        )
+
+        def mock_fetch(url: str) -> Sequence[str]:
+            if "seed-dc1" in url:
+                raise OSError("seed unavailable")
+            return ["dc2-node1", "dc2-node2"]
+
+        manager = SyncLiveNodesManager(config, mock_fetch)
+
+        assert manager.refresh_nodes() is True
+        assert manager.nodes.nodes == ("dc2-node1", "dc2-node2")
 
     def test_url_construction(self, config: Config) -> None:
         """Test URL is constructed correctly."""


### PR DESCRIPTION
Summary:
- aggregate ClusterScope /localnodes results from every configured seed instead of stopping at the first local-DC response
- keep datacenter/rack fallback behavior unchanged
- document that multi-DC cluster-wide routing needs at least one seed per datacenter

Fixes #66

Validation:
- make verify