### PR TITLE
Clarify ClusterScope seed requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,9 @@ config = Config(
 
 `ClusterScope` queries every configured seed host and combines the returned
 `/localnodes` results. Because ScyllaDB's optionless `/localnodes` endpoint
-returns nodes from the contacted seed's local datacenter, pass at least one seed
-from each datacenter when cluster-wide routing should span multiple datacenters.
+returns nodes from the contacted seed's local datacenter, cluster-wide routing
+spans multiple datacenters only when the configuration includes at least one
+reachable seed from each datacenter.
 
 Default constructors keep compatibility fallback behavior:
 

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -9,7 +9,7 @@ and intentionally deferred behavior.
 | DynamoDB resource | Supported | Existing API | `create_resource` and `AlternatorResource` wrap boto3 resource usage. |
 | Async DynamoDB client | Supported | Existing API | `create_async_client` and `AsyncAlternatorClient` use aioboto3. |
 | Host-only seeds with one shared port | Supported | Existing API | Seeds must not include ports; one port applies to all nodes. |
-| Node discovery | Supported | Existing API | `/localnodes` refresh updates the live node list. `ClusterScope` combines results from all configured seeds so multi-DC users can seed each datacenter. |
+| Node discovery | Supported | Existing API | `/localnodes` refresh updates the live node list. `ClusterScope` combines results from all configured seeds, so multi-DC routing requires at least one reachable seed from each datacenter. |
 | Routing scopes | Supported | [#35](https://github.com/scylladb/alternator-client-python/issues/35) | Cluster, datacenter, and rack scopes support explicit fallback chains and scoped validation helpers. |
 | Request query plans | Supported | Existing API | Requests use stable seeded node ordering for retries. |
 | Auth | Supported | Existing API | Disabled by default; explicit static credentials enable signing. |


### PR DESCRIPTION
Summary:
- clarify that multi-DC ClusterScope routing needs at least one reachable seed from each datacenter
- update the capability matrix with the same constraint

Validation:
- git diff --check