### PR TITLE
Fix signed request mutation timing

### DIFF
--- a/alternator/core/compression.py
+++ b/alternator/core/compression.py
@@ -27,7 +27,10 @@ def create_compression_handler(
         Event handler function for botocore
     """
 
-    def compress_request(request: AWSPreparedRequest | AWSRequest, **kwargs: Any) -> None:  # noqa: ANN401 -- botocore event handler signature
+    def compress_request(
+        request: AWSPreparedRequest | AWSRequest,
+        **kwargs: Any,  # noqa: ANN401 -- botocore event handler signature
+    ) -> None:
         """Compress request body if it exceeds threshold."""
         raw_body = request.body
         if raw_body is None:

--- a/alternator/core/compression.py
+++ b/alternator/core/compression.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import gzip
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
-from botocore.awsrequest import AWSPreparedRequest
+from botocore.awsrequest import AWSPreparedRequest, AWSRequest
 
 
 def create_compression_handler(
@@ -27,7 +27,7 @@ def create_compression_handler(
         Event handler function for botocore
     """
 
-    def compress_request(request: AWSPreparedRequest, **kwargs: Any) -> None:  # noqa: ANN401 -- botocore event handler signature
+    def compress_request(request: AWSPreparedRequest | AWSRequest, **kwargs: Any) -> None:  # noqa: ANN401 -- botocore event handler signature
         """Compress request body if it exceeds threshold."""
         raw_body = request.body
         if raw_body is None:
@@ -51,8 +51,20 @@ def create_compression_handler(
             return
 
         # Update request with compressed body
-        request.body = compressed
+        _set_request_body(request, compressed)
         request.headers["Content-Encoding"] = "gzip"
         request.headers["Content-Length"] = str(len(compressed))
 
     return compress_request
+
+
+def _set_request_body(request: AWSPreparedRequest | AWSRequest, body: bytes) -> None:
+    """Set request body for both prepared and pre-signing request objects."""
+    mutable_request = cast(Any, request)
+    if isinstance(request, AWSPreparedRequest):
+        mutable_request.body = body
+        return
+    if isinstance(request, AWSRequest):
+        mutable_request.data = body
+        return
+    mutable_request.body = body

--- a/alternator/core/handlers.py
+++ b/alternator/core/handlers.py
@@ -92,7 +92,10 @@ def _register_alternator_handlers(
             yield f"{scheme}://{node}:{port}"
 
     # Register event handler to update endpoint per-request
-    def update_endpoint(request: AWSPreparedRequest | AWSRequest, **kwargs: Any) -> None:  # noqa: ANN401 -- botocore event handler signature
+    def update_endpoint(
+        request: AWSPreparedRequest | AWSRequest,
+        **kwargs: Any,  # noqa: ANN401 -- botocore event handler signature
+    ) -> None:
         """Update request URL based on routing strategy."""
         # Get or create query plan
         plan: Iterator[str] | None = getattr(request, _QUERY_PLAN_ATTR, None)

--- a/alternator/core/handlers.py
+++ b/alternator/core/handlers.py
@@ -8,7 +8,7 @@ from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from urllib.parse import urlparse
 
-from botocore.awsrequest import AWSPreparedRequest
+from botocore.awsrequest import AWSPreparedRequest, AWSRequest
 from botocore.hooks import BaseEventHooks
 
 from alternator.config import CompressionAlgorithm
@@ -92,7 +92,7 @@ def _register_alternator_handlers(
             yield f"{scheme}://{node}:{port}"
 
     # Register event handler to update endpoint per-request
-    def update_endpoint(request: AWSPreparedRequest, **kwargs: Any) -> None:  # noqa: ANN401 -- botocore event handler signature
+    def update_endpoint(request: AWSPreparedRequest | AWSRequest, **kwargs: Any) -> None:  # noqa: ANN401 -- botocore event handler signature
         """Update request URL based on routing strategy."""
         # Get or create query plan
         plan: Iterator[str] | None = getattr(request, _QUERY_PLAN_ATTR, None)
@@ -123,12 +123,27 @@ def _register_alternator_handlers(
         # Get next node from plan
         new_uri = next(plan)
 
-        parsed = urlparse(request.url)
-        request.url = f"{new_uri}{parsed.path}"
-        if parsed.query:
-            request.url += f"?{parsed.query}"
+        request_url = (
+            request.url.decode("utf-8")
+            if isinstance(request.url, bytes)
+            else request.url
+        )
+        parsed = urlparse(request_url)
+        path = (
+            parsed.path.decode("utf-8")
+            if isinstance(parsed.path, bytes)
+            else parsed.path
+        )
+        query = (
+            parsed.query.decode("utf-8")
+            if isinstance(parsed.query, bytes)
+            else parsed.query
+        )
+        request.url = f"{new_uri}{path}"
+        if query:
+            request.url += f"?{query}"
 
-    events.register("before-send.dynamodb.*", update_endpoint)
+    events.register("request-created.dynamodb.*", update_endpoint)
 
     # Register compression handler if enabled
     if config.request_compression.algorithm == CompressionAlgorithm.GZIP:
@@ -136,7 +151,7 @@ def _register_alternator_handlers(
             config.request_compression.min_size_bytes,
             gzip_level=config.request_compression.gzip_level,
         )
-        events.register("before-send.dynamodb.*", compress_handler)
+        events.register("request-created.dynamodb.*", compress_handler)
 
     # Register header filter if optimization enabled
     if config.header_optimization.enabled:

--- a/alternator/core/request.py
+++ b/alternator/core/request.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from botocore.awsrequest import AWSPreparedRequest
+from botocore.awsrequest import AWSPreparedRequest, AWSRequest
 
 _PARSED_PARAMS_ATTR = "_alternator_parsed_params"
 
 
-def extract_operation_name(request: AWSPreparedRequest) -> str:
+def extract_operation_name(request: AWSPreparedRequest | AWSRequest) -> str:
     """
     Extract operation name from the X-Amz-Target header.
 
@@ -26,7 +26,7 @@ def extract_operation_name(request: AWSPreparedRequest) -> str:
     return target.split(".")[-1] if "." in target else ""
 
 
-def extract_request_params(request: AWSPreparedRequest) -> dict[str, Any]:
+def extract_request_params(request: AWSPreparedRequest | AWSRequest) -> dict[str, Any]:
     """
     Parse the request body to extract parameters.
 

--- a/tests/unit/test_request_lifecycle.py
+++ b/tests/unit/test_request_lifecycle.py
@@ -1,0 +1,77 @@
+"""Tests for Alternator request mutation timing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import boto3
+import pytest
+from botocore.awsrequest import AWSPreparedRequest, AWSRequest
+from botocore.config import Config as BotoConfig
+
+from alternator.config import CompressionAlgorithm, Config, RequestCompressionConfig
+from alternator.core.handlers import _register_alternator_handlers
+from alternator.core.live_nodes import NodeList
+
+
+class _StaticManager:
+    def __init__(self, nodes: tuple[str, ...]) -> None:
+        self._nodes = NodeList(nodes=nodes, scope_name="cluster")
+
+    @property
+    def nodes(self) -> NodeList:
+        return self._nodes
+
+
+def test_signed_request_url_and_compressed_body_are_final_before_signing() -> None:
+    """Endpoint and body mutations happen before SigV4 signing."""
+    config = Config(
+        seed_hosts=["seed"],
+        port=8000,
+        request_compression=RequestCompressionConfig(
+            algorithm=CompressionAlgorithm.GZIP,
+            min_size_bytes=10,
+        ),
+    )
+    client = boto3.client(
+        "dynamodb",
+        endpoint_url="http://seed:8000",
+        region_name="us-east-1",
+        aws_access_key_id="alternator",
+        aws_secret_access_key="secret",
+        config=BotoConfig(retries={"max_attempts": 0, "mode": "standard"}),
+    )
+    _register_alternator_handlers(
+        client.meta.events,
+        _StaticManager(("node-b",)),
+        config,
+        auth_enabled=True,
+    )
+    seen: dict[str, Any] = {}
+
+    def capture_before_sign(request: AWSRequest, **_: object) -> None:
+        seen["before_sign_url"] = request.url
+        seen["before_sign_body"] = request.body
+        seen["before_sign_headers"] = dict(request.headers)
+
+    def capture_before_send(request: AWSPreparedRequest, **_: object) -> None:
+        seen["before_send_url"] = request.url
+        seen["before_send_body"] = request.body
+        seen["authorization"] = request.headers.get("Authorization")
+        raise RuntimeError("captured")
+
+    client.meta.events.register("before-sign.dynamodb.PutItem", capture_before_sign)
+    client.meta.events.register_last("before-send.dynamodb.PutItem", capture_before_send)
+
+    with pytest.raises(RuntimeError, match="captured"):
+        client.put_item(
+            TableName="tbl",
+            Item={"pk": {"S": "k"}, "data": {"S": "x" * 5000}},
+        )
+
+    assert seen["before_sign_url"] == "http://node-b:8000/"
+    assert seen["before_send_url"] == seen["before_sign_url"]
+    assert seen["before_sign_body"] == seen["before_send_body"]
+    assert seen["before_sign_body"].startswith(b"\x1f\x8b")
+    assert seen["before_sign_headers"]["Content-Encoding"] == "gzip"
+    assert seen["authorization"] is not None

--- a/tests/unit/test_request_lifecycle.py
+++ b/tests/unit/test_request_lifecycle.py
@@ -61,7 +61,9 @@ def test_signed_request_url_and_compressed_body_are_final_before_signing() -> No
         raise RuntimeError("captured")
 
     client.meta.events.register("before-sign.dynamodb.PutItem", capture_before_sign)
-    client.meta.events.register_last("before-send.dynamodb.PutItem", capture_before_send)
+    client.meta.events.register_last(
+        "before-send.dynamodb.PutItem", capture_before_send
+    )
 
     with pytest.raises(RuntimeError, match="captured"):
         client.put_item(


### PR DESCRIPTION
## Summary

- move Alternator endpoint routing to `request-created` so SigV4 signs the final node URL
- move request compression to `request-created` so SigV4 signs the final compressed body and headers
- update request parsing/compression helpers to support both `AWSRequest` and `AWSPreparedRequest`
- add a real boto3 regression test that captures `before-sign` and `before-send` for a signed compressed request

## Tests

- `pytest -q tests/unit/test_request_lifecycle.py tests/unit/test_compression.py tests/unit/test_request.py`
- `ruff check alternator/core/compression.py alternator/core/handlers.py alternator/core/request.py tests/unit/test_request_lifecycle.py`
- `mypy alternator`
- `git diff --check`

Closes #71