### PR TITLE
Advance query plan across SDK retries

### DIFF
--- a/alternator/core/handlers.py
+++ b/alternator/core/handlers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import random
 from collections.abc import Callable, Iterator
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 from urllib.parse import urlparse
 
 from botocore.awsrequest import AWSPreparedRequest, AWSRequest
@@ -98,33 +98,24 @@ def _register_alternator_handlers(
     ) -> None:
         """Update request URL based on routing strategy."""
         # Get or create query plan
-        plan: Iterator[str] | None = getattr(request, _QUERY_PLAN_ATTR, None)
-        if plan is None:
-            nodes = manager.nodes
-            if not nodes:
-                raise NoNodesAvailableError(
-                    "No nodes available",
-                    scope_name=scope_name,
-                )
+        context = getattr(request, "context", None)
+        plan: Iterator[str] | None
+        if isinstance(context, dict):
+            plan = context.get(_QUERY_PLAN_ATTR)
+        else:
+            plan = getattr(request, _QUERY_PLAN_ATTR, None)
 
-            # First attempt: create plan with optional affinity preferred node
-            preferred_node = None
-            if compute_affinity_node is not None:
-                # Check operation name first (cheap header read) before
-                # parsing the JSON body (expensive)
-                operation_name = extract_operation_name(request)
-                if operation_name in _affinity_operations:
-                    params = extract_request_params(request)
-                    preferred_node = compute_affinity_node(
-                        operation_name,
-                        params,
-                        nodes,
-                    )
-            plan = create_query_plan(nodes, preferred_node)
-            setattr(request, _QUERY_PLAN_ATTR, plan)
+        if plan is None:
+            plan = _create_request_query_plan(request)
+            _store_query_plan(request, plan)
 
         # Get next node from plan
-        new_uri = next(plan)
+        try:
+            new_uri = next(plan)
+        except StopIteration:
+            plan = _create_request_query_plan(request, preferred_node=None)
+            _store_query_plan(request, plan)
+            new_uri = next(plan)
 
         request_url = (
             request.url.decode("utf-8")
@@ -145,6 +136,45 @@ def _register_alternator_handlers(
         request.url = f"{new_uri}{path}"
         if query:
             request.url += f"?{query}"
+
+    def _create_request_query_plan(
+        request: AWSRequest | AWSPreparedRequest,
+        preferred_node: str | None | object = _PREFERRED_NODE_UNSET,
+    ) -> Iterator[str]:
+        nodes = manager.nodes
+        if not nodes:
+            raise NoNodesAvailableError(
+                "No nodes available",
+                scope_name=scope_name,
+            )
+
+        selected_preferred_node: str | None
+        if preferred_node is _PREFERRED_NODE_UNSET:
+            selected_preferred_node = None
+            if compute_affinity_node is not None:
+                # Check operation name first (cheap header read) before
+                # parsing the JSON body (expensive)
+                operation_name = extract_operation_name(request)
+                if operation_name in _affinity_operations:
+                    params = extract_request_params(request)
+                    selected_preferred_node = compute_affinity_node(
+                        operation_name,
+                        params,
+                        nodes,
+                    )
+        else:
+            selected_preferred_node = cast("str | None", preferred_node)
+        return create_query_plan(nodes, selected_preferred_node)
+
+    def _store_query_plan(
+        request: AWSRequest | AWSPreparedRequest,
+        plan: Iterator[str],
+    ) -> None:
+        context = getattr(request, "context", None)
+        if isinstance(context, dict):
+            context[_QUERY_PLAN_ATTR] = plan
+            return
+        setattr(request, _QUERY_PLAN_ATTR, plan)
 
     events.register("request-created.dynamodb.*", update_endpoint)
 
@@ -172,3 +202,6 @@ def _register_alternator_handlers(
 def _stable_seed(value: str) -> int:
     digest = hashlib.blake2b(value.encode("utf-8"), digest_size=8).digest()
     return int.from_bytes(digest, "big")
+
+
+_PREFERRED_NODE_UNSET = object()

--- a/tests/unit/test_request_lifecycle.py
+++ b/tests/unit/test_request_lifecycle.py
@@ -121,7 +121,9 @@ def test_sdk_retries_advance_shared_query_plan(monkeypatch: pytest.MonkeyPatch) 
     def retry_without_sleep(attempts: int, **_: object) -> int | None:
         return 0 if attempts < 3 else None
 
-    client.meta.events.register_last("before-send.dynamodb.PutItem", capture_before_send)
+    client.meta.events.register_last(
+        "before-send.dynamodb.PutItem", capture_before_send
+    )
     client.meta.events.register_first(
         "needs-retry.dynamodb.PutItem",
         retry_without_sleep,

--- a/tests/unit/test_request_lifecycle.py
+++ b/tests/unit/test_request_lifecycle.py
@@ -118,8 +118,8 @@ def test_sdk_retries_advance_shared_query_plan(monkeypatch: pytest.MonkeyPatch) 
     def fail_send(request: AWSPreparedRequest) -> None:
         raise EndpointConnectionError(endpoint_url=request.url)
 
-    def retry_without_sleep(attempts: int, **_: object) -> int | bool:
-        return 0 if attempts < 3 else False
+    def retry_without_sleep(attempts: int, **_: object) -> int | None:
+        return 0 if attempts < 3 else None
 
     client.meta.events.register_last("before-send.dynamodb.PutItem", capture_before_send)
     client.meta.events.register_first(

--- a/tests/unit/test_request_lifecycle.py
+++ b/tests/unit/test_request_lifecycle.py
@@ -6,8 +6,10 @@ from typing import Any
 
 import boto3
 import pytest
+from botocore import UNSIGNED
 from botocore.awsrequest import AWSPreparedRequest, AWSRequest
 from botocore.config import Config as BotoConfig
+from botocore.exceptions import EndpointConnectionError
 
 from alternator.config import CompressionAlgorithm, Config, RequestCompressionConfig
 from alternator.core.handlers import _register_alternator_handlers
@@ -77,3 +79,57 @@ def test_signed_request_url_and_compressed_body_are_final_before_signing() -> No
     assert seen["before_sign_body"].startswith(b"\x1f\x8b")
     assert seen["before_sign_headers"]["Content-Encoding"] == "gzip"
     assert seen["authorization"] is not None
+
+
+def test_sdk_retries_advance_shared_query_plan(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retries for one SDK call walk the node plan across fresh requests."""
+    config = Config(seed_hosts=["seed"], port=8000)
+    client = boto3.client(
+        "dynamodb",
+        endpoint_url="http://seed:8000",
+        region_name="us-east-1",
+        config=BotoConfig(
+            signature_version=UNSIGNED,
+            retries={"max_attempts": 2, "mode": "standard"},
+        ),
+    )
+
+    def preferred_node(
+        operation_name: str,
+        params: dict[str, Any],
+        nodes: NodeList,
+    ) -> str | None:
+        assert operation_name == "PutItem"
+        assert nodes.nodes == ("node-a", "node-b", "node-c")
+        return "node-b"
+
+    _register_alternator_handlers(
+        client.meta.events,
+        _StaticManager(("node-a", "node-b", "node-c")),
+        config,
+        preferred_node,
+        auth_enabled=False,
+    )
+    urls: list[str] = []
+
+    def capture_before_send(request: AWSPreparedRequest, **_: object) -> None:
+        urls.append(request.url)
+
+    def fail_send(request: AWSPreparedRequest) -> None:
+        raise EndpointConnectionError(endpoint_url=request.url)
+
+    def retry_without_sleep(attempts: int, **_: object) -> int | bool:
+        return 0 if attempts < 3 else False
+
+    client.meta.events.register_last("before-send.dynamodb.PutItem", capture_before_send)
+    client.meta.events.register_first(
+        "needs-retry.dynamodb.PutItem",
+        retry_without_sleep,
+    )
+    monkeypatch.setattr(client._endpoint.http_session, "send", fail_send)
+
+    with pytest.raises(EndpointConnectionError):
+        client.put_item(TableName="tbl", Item={"pk": {"S": "k"}})
+
+    assert urls[0] == "http://node-b:8000/"
+    assert set(urls[1:]) == {"http://node-a:8000/", "http://node-c:8000/"}


### PR DESCRIPTION
## Summary

- store the per-call Alternator query plan in botocore request context so retries reuse and advance the same iterator
- restart exhausted plans without reusing the preferred affinity node first
- add a boto3 retry regression that forces transport failures and verifies a single SDK call advances from the preferred node to the remaining nodes

This PR depends on the request-created lifecycle change from #78. It targets `main` so the repository's CI workflow runs on the PR; after #78 lands, this branch can be rebased to leave only the retry-specific diff.

## Tests

- `pytest -q tests/unit/test_request_lifecycle.py tests/unit/test_query_plan.py`
- `make lint`
- `git diff --check`

Closes #72