### PR TITLE
Honor custom-only TLS trust roots

### DIFF
--- a/alternator/core/tls.py
+++ b/alternator/core/tls.py
@@ -19,26 +19,24 @@ def create_ssl_context(tls_config: TLS) -> ssl.SSLContext:
     Returns:
         Configured SSL context
     """
-    context = ssl.create_default_context()
     if tls_config.trust_all_certificates:
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         # INSECURE - for development only
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
     else:
+        if tls_config.trust_system_ca_certs:
+            context = ssl.create_default_context()
+        else:
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            context.verify_mode = ssl.CERT_REQUIRED
+
         # Configure hostname verification
         context.check_hostname = tls_config.verify_hostname
 
     if not tls_config.trust_all_certificates and tls_config.custom_ca_cert_paths:
         for cert_path in tls_config.custom_ca_cert_paths:
             context.load_verify_locations(str(cert_path))
-
-    # If not using system CA and custom certs provided, don't load system certs
-    if (
-        not tls_config.trust_all_certificates
-        and not tls_config.trust_system_ca_certs
-        and tls_config.custom_ca_cert_paths
-    ):
-        context.verify_mode = ssl.CERT_REQUIRED
 
     if tls_config.client_cert_path is not None:
         context.load_cert_chain(

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -114,6 +114,24 @@ class TestCreateSslContext:
         else:
             pytest.skip("No system CA file available for testing")
 
+    def test_no_system_ca_does_not_load_default_context(self) -> None:
+        """Disabling system CAs avoids ssl.create_default_context."""
+        cert_path = Path("/custom/ca.pem")
+
+        with (
+            patch("ssl.create_default_context") as mock_create_default_context,
+            patch("ssl.SSLContext.load_verify_locations") as mock_load_verify,
+        ):
+            tls_config = TLS(
+                custom_ca_cert_paths=[cert_path],
+                trust_system_ca_certs=False,
+            )
+            ctx = create_ssl_context(tls_config)
+
+        mock_create_default_context.assert_not_called()
+        mock_load_verify.assert_called_once_with(str(cert_path))
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+
     def test_client_cert_chain_is_loaded(self, tmp_path: Path) -> None:
         """Test TLS client certificate paths load into the SSL context."""
         cert_path = tmp_path / "client.crt"


### PR DESCRIPTION
## Summary

- avoid `ssl.create_default_context()` when `trust_system_ca_certs=False`
- create an empty client TLS context for custom-CA-only trust and load configured CA files explicitly
- keep system-default and trust-all behavior unchanged
- add a regression that verifies the default context is not created in custom-CA-only mode

## Tests

- `pytest -q tests/unit/test_tls.py tests/unit/test_http.py`
- `ruff check alternator/core/tls.py tests/unit/test_tls.py`
- `mypy alternator`
- `git diff --check`

Closes #73