### PR TITLE
Use total retry attempts in SDK config

### DIFF
--- a/alternator/config.py
+++ b/alternator/config.py
@@ -284,9 +284,9 @@ class RetryConfig:
     mode: RetryMode = RetryMode.STANDARD
 
     def __post_init__(self) -> None:
-        if self.max_attempts < 0:
+        if self.max_attempts <= 0:
             raise ConfigurationError(
-                f"max_attempts must be >= 0, got {self.max_attempts}"
+                f"max_attempts must be > 0, got {self.max_attempts}"
             )
 
 
@@ -617,7 +617,7 @@ def build_sdk_config_kwargs(config: Config) -> dict[str, Any]:
     """Build SDK config kwargs shared by sync and async clients."""
     kwargs: dict[str, Any] = {
         "retries": {
-            "max_attempts": config.retries.max_attempts,
+            "total_max_attempts": config.retries.max_attempts,
             "mode": config.retries.mode.value,
         },
         "max_pool_connections": config.max_pool_connections,

--- a/tests/unit/test_boto_config.py
+++ b/tests/unit/test_boto_config.py
@@ -3,6 +3,7 @@
 import contextlib
 from pathlib import Path
 
+import pytest
 from botocore import UNSIGNED
 
 from alternator.client import _create_boto_config
@@ -43,8 +44,23 @@ class TestCreateBotoConfig:
         boto_config = _create_boto_config(config, auth_enabled=False)
 
         retries = boto_config._user_provided_options["retries"]
-        assert retries["max_attempts"] == 5
+        assert retries["total_max_attempts"] == 5
         assert retries["mode"] == "adaptive"
+
+    def test_retry_attempts_are_total_attempts_in_created_client(self) -> None:
+        """RetryConfig max_attempts maps to botocore total attempts."""
+        import boto3
+
+        config = self._make_config(retries=RetryConfig(max_attempts=3))
+        boto_config = _create_boto_config(config, auth_enabled=False)
+        client = boto3.client(
+            "dynamodb",
+            endpoint_url="http://localhost:1",
+            config=boto_config,
+            region_name="us-east-1",
+        )
+
+        assert client.meta.config.retries["total_max_attempts"] == 3
 
     def test_pool_connections_propagated(self) -> None:
         """max_pool_connections from Config flows into BotoConfig."""
@@ -126,6 +142,8 @@ class TestCreateAioConfig:
 
     def test_async_config_matches_sync_transport_settings(self) -> None:
         """AioConfig receives retry, timeout, pool, and signature settings."""
+        pytest.importorskip("aiobotocore")
+
         from alternator.async_client import _create_aio_config
 
         config = Config(
@@ -147,7 +165,7 @@ class TestCreateAioConfig:
         aio_config = _create_aio_config(config, auth_enabled=False)
 
         retries = aio_config._user_provided_options["retries"]
-        assert retries["max_attempts"] == 4
+        assert retries["total_max_attempts"] == 4
         assert retries["mode"] == "standard"
         assert aio_config.max_pool_connections == 17
         assert aio_config.connect_timeout == 3.0

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -14,6 +14,7 @@ from alternator.config import (
     KeyRouteAffinityConfig,
     KeyRouteAffinityMode,
     RequestCompressionConfig,
+    RetryConfig,
     TlsConfig,
     TlsSessionCacheConfig,
 )
@@ -429,3 +430,12 @@ class TestKeyRouteAffinityConfig:
         )
         assert config.mode == KeyRouteAffinityMode.RMW
         assert config.table_pk_attributes == {"users": "pk"}
+
+
+class TestRetryConfig:
+    """Tests for RetryConfig validation."""
+
+    def test_zero_max_attempts_raises(self) -> None:
+        """Retry attempts count is a total-attempts value and must be positive."""
+        with pytest.raises(ConfigurationError, match="max_attempts must be > 0"):
+            RetryConfig(max_attempts=0)


### PR DESCRIPTION
## Summary

- map `RetryConfig.max_attempts` to botocore `total_max_attempts`
- reject zero total attempts during config validation
- add a boto3 config regression that verifies botocore resolves the configured value as total attempts

## Tests

- `pytest -q tests/unit/test_boto_config.py tests/unit/test_config.py`
- `ruff check alternator/config.py tests/unit/test_boto_config.py tests/unit/test_config.py`
- `mypy alternator`
- `git diff --check`

Closes #75