### PR TITLE
Close underlying boto client session

### DIFF
--- a/alternator/client.py
+++ b/alternator/client.py
@@ -471,6 +471,19 @@ def close_client(client: DynamoDBClient | DynamoDBServiceResource) -> None:
     # Clear PK cache reference
     if hasattr(client, PK_CACHE_ATTR):
         setattr(client, PK_CACHE_ATTR, None)
+    meta = getattr(client, "meta", None)
+    service_client = getattr(meta, "client", None)
+    if service_client is not None and hasattr(service_client, PK_CACHE_ATTR):
+        setattr(service_client, PK_CACHE_ATTR, None)
+
+    sdk_close = getattr(client, "close", None)
+    if callable(sdk_close):
+        sdk_close()
+        return
+
+    service_client_close = getattr(service_client, "close", None)
+    if callable(service_client_close):
+        service_client_close()
 
 
 class Helper:

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import Mock
 from urllib.parse import urlsplit
 
 import pytest
@@ -177,6 +179,34 @@ def test_create_client_uses_configured_aws_region(
         assert client.meta.region_name == "us-west-2"
     finally:
         close_client(client)
+
+
+def test_close_client_closes_underlying_boto_client() -> None:
+    """close_client releases the botocore HTTP session for clients."""
+    manager = SimpleNamespace(stop=Mock())
+    client = SimpleNamespace(close=Mock())
+    setattr(client, MANAGER_ATTR, manager)
+    setattr(client, MANAGER_OWNS_ATTR, True)
+
+    close_client(client)  # type: ignore[arg-type] -- lightweight boto client stub
+    close_client(client)  # type: ignore[arg-type] -- idempotency check
+
+    assert manager.stop.call_count == 1
+    assert client.close.call_count == 2
+
+
+def test_close_resource_closes_underlying_boto_client() -> None:
+    """close_client releases the botocore HTTP session for resources."""
+    manager = SimpleNamespace(stop=Mock())
+    service_client = SimpleNamespace(close=Mock())
+    resource = SimpleNamespace(meta=SimpleNamespace(client=service_client))
+    setattr(resource, MANAGER_ATTR, manager)
+    setattr(resource, MANAGER_OWNS_ATTR, True)
+
+    close_client(resource)  # type: ignore[arg-type] -- lightweight resource stub
+
+    manager.stop.assert_called_once_with()
+    service_client.close.assert_called_once_with()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- make `close_client` close the underlying boto3 client when passed a client
- make `close_client` close `resource.meta.client` when passed a DynamoDB resource
- clear the partition-key cache reference on both resource and service-client paths
- add lightweight lifecycle regressions for client and resource close behavior

## Tests

- `pytest -q tests/unit/test_helper.py tests/unit/test_client_alias.py`
- `ruff check alternator/client.py tests/unit/test_helper.py`
- `mypy alternator`
- `git diff --check`

Closes #76