### PR TITLE
Align Python query plan with cross-language vectors

### DIFF
--- a/alternator/core/query_plan.py
+++ b/alternator/core/query_plan.py
@@ -16,8 +16,8 @@ class LazyQueryPlan(Iterator[str]):
     ordering across all clients.
 
     Truly lazy: each call to ``__next__`` picks a random node from the
-    remaining pool via incremental Fisher-Yates (seeded for determinism)
-    and swaps it into place.  No upfront shuffle is performed.
+    remaining pool, removes it by replacing it with the last remaining node,
+    and then truncates the pool. No upfront shuffle is performed.
 
     Yields raw node addresses (e.g. ``"192.168.1.1"``).
 
@@ -31,21 +31,17 @@ class LazyQueryPlan(Iterator[str]):
     ) -> None:
         self._nodes = list(nodes)
         self._rng = DeterministicRand(seed)
-        self._index = 0
 
     def __next__(self) -> str:
-        if self._index >= len(self._nodes):
+        if not self._nodes:
             raise StopIteration
 
-        # Incremental Fisher-Yates: pick a random node from the remaining
-        # pool [_index, len) and swap it to the current position.
-        remaining = len(self._nodes) - self._index
-        pick = self._index + self._rng.intn(remaining)
-        self._nodes[self._index], self._nodes[pick] = (
-            self._nodes[pick],
-            self._nodes[self._index],
-        )
+        # Go/Java-compatible pick-and-remove: pick from the current pool,
+        # return that node, then fill its slot with the last remaining node.
+        pick = self._rng.intn(len(self._nodes))
+        node = self._nodes[pick]
+        last = self._nodes.pop()
+        if pick < len(self._nodes):
+            self._nodes[pick] = last
 
-        node = self._nodes[self._index]
-        self._index += 1
         return node

--- a/tests/unit/test_hashing.py
+++ b/tests/unit/test_hashing.py
@@ -103,6 +103,16 @@ class TestHashAttributeValueBinaryVectors:
 class TestTypeCollisionPrevention:
     """Tests that same content with different types produce different hashes."""
 
+    def test_string_number_binary_12345_vectors_are_distinct(self) -> None:
+        string_hash = hash_attribute_value("S", "12345")
+        number_hash = hash_attribute_value("N", "12345")
+        binary_hash = hash_attribute_value("B", b"12345")
+
+        assert string_hash == -6122888897254035317
+        assert number_hash == -3190731486301745196
+        assert binary_hash == -3752463870508600385
+        assert len({string_hash, number_hash, binary_hash}) == 3
+
     def test_string_vs_number_42(self) -> None:
         string_hash = hash_attribute_value("S", "42")
         number_hash = hash_attribute_value("N", "42")

--- a/tests/unit/test_query_plan.py
+++ b/tests/unit/test_query_plan.py
@@ -125,9 +125,13 @@ class TestLazyQueryPlanDistribution:
         assert set(plan) == {"a", "b", "c"}
 
 
-# Sorted node list matching the spec: node1..node10 sorted lexicographically
-_SPEC_NODES = [f"node{i}.example.com:8043" for i in range(1, 11)]
-_SPEC_NODES.sort()
+# Raw spec fixture order from the cross-language LazyQueryPlan vectors.
+_RAW_SPEC_NODES = [f"node{i}.example.com:8043" for i in range(1, 11)]
+
+# Production nodes are sorted lexicographically before LazyQueryPlan sees them.
+_SORTED_SPEC_NODES = sorted(_RAW_SPEC_NODES)
+
+_SIX_ACTIVE_NODES = [f"node{i}.example.com:8043" for i in range(1, 7)]
 
 MAX_INT64 = (1 << 63) - 1
 
@@ -143,20 +147,49 @@ class TestDeterministicVectors:
     @pytest.mark.parametrize(
         "seed, expected_first_6",
         [
-            (42, ["node5", "node9", "node6", "node4", "node1", "node3"]),
-            (123, ["node5", "node10", "node1", "node2", "node9", "node4"]),
-            (999, ["node4", "node5", "node10", "node3", "node2", "node7"]),
-            (0, ["node4", "node10", "node3", "node7", "node9", "node6"]),
-            (-1, ["node10", "node5", "node2", "node1", "node9", "node6"]),
-            (12345, ["node3", "node5", "node2", "node9", "node1", "node10"]),
-            (MAX_INT64, ["node10", "node7", "node9", "node3", "node5", "node8"]),
+            (42, ["node6", "node9", "node5", "node2", "node7", "node1"]),
+            (123, ["node6", "node1", "node4", "node3", "node10", "node5"]),
+            (999, ["node5", "node10", "node4", "node1", "node2", "node3"]),
+            (0, ["node5", "node1", "node2", "node10", "node6", "node8"]),
+            (-1, ["node2", "node5", "node1", "node3", "node6", "node10"]),
+            (12345, ["node4", "node5", "node1", "node7", "node6", "node8"]),
+            (MAX_INT64, ["node2", "node7", "node8", "node1", "node10", "node4"]),
         ],
         ids=["seed42", "seed123", "seed999", "seed0", "seed-1", "seed12345", "seedMAX"],
     )
-    def test_spec_vector(self, seed: int, expected_first_6: list[str]) -> None:
-        """Verify shuffle matches the deterministic spec vectors."""
-        plan = LazyQueryPlan(nodes=_SPEC_NODES, seed=seed)
+    def test_raw_spec_vector(self, seed: int, expected_first_6: list[str]) -> None:
+        """Verify raw pick-and-remove vectors from the cross-language spec."""
+        plan = LazyQueryPlan(nodes=_RAW_SPEC_NODES, seed=seed)
         actual = [_node_short(next(plan)) for _ in range(6)]
         assert actual == expected_first_6, (
             f"seed={seed}: expected {expected_first_6}, got {actual}"
         )
+
+    @pytest.mark.parametrize(
+        "seed, expected_first_6",
+        [
+            (42, ["node5", "node8", "node4", "node10", "node6", "node1"]),
+            (123, ["node5", "node1", "node3", "node2", "node9", "node4"]),
+            (999, ["node4", "node9", "node3", "node1", "node10", "node2"]),
+            (0, ["node4", "node1", "node10", "node9", "node5", "node7"]),
+            (-1, ["node10", "node4", "node1", "node2", "node5", "node9"]),
+            (12345, ["node3", "node4", "node1", "node6", "node5", "node7"]),
+            (MAX_INT64, ["node10", "node6", "node7", "node1", "node9", "node3"]),
+        ],
+        ids=["seed42", "seed123", "seed999", "seed0", "seed-1", "seed12345", "seedMAX"],
+    )
+    def test_sorted_affinity_vector(
+        self, seed: int, expected_first_6: list[str]
+    ) -> None:
+        """Verify vectors for production's lexicographically sorted node order."""
+        plan = LazyQueryPlan(nodes=_SORTED_SPEC_NODES, seed=seed)
+        actual = [_node_short(next(plan)) for _ in range(6)]
+        assert actual == expected_first_6, (
+            f"seed={seed}: expected {expected_first_6}, got {actual}"
+        )
+
+    def test_six_active_nodes_vector(self) -> None:
+        """Verify the 6-active-node vector where natural and lexicographic order match."""
+        plan = LazyQueryPlan(nodes=_SIX_ACTIVE_NODES, seed=42)
+        actual = [_node_short(next(plan)) for _ in range(6)]
+        assert actual == ["node6", "node3", "node1", "node4", "node2", "node5"]


### PR DESCRIPTION
## Summary
- switch `LazyQueryPlan` to the Go/Java-compatible pick-and-remove node selection algorithm
- add raw and lexicographically sorted cross-language query-plan vectors
- add explicit `S`/`N`/`B` `12345` hasher vectors to guard type-collision behavior

## Tests
- `pytest -q tests/unit/test_query_plan.py tests/unit/test_deterministic_rand.py tests/unit/test_hashing.py tests/unit/test_hashing_properties.py`
- `ruff check alternator/core/query_plan.py tests/unit/test_query_plan.py tests/unit/test_hashing.py`
- `mypy alternator/core/query_plan.py alternator/core/hashing.py`
- `git diff --check`

Refs scylladb/alternator-client-java#56 and scylladb/alternator-client-java#32.
