### PR TITLE
Align routing fallback defaults

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -59,8 +59,8 @@ and recorded in
   explicitly changes it.
 - Keep deprecated names such as `AlternatorConfig` and `TlsConfig` working while
   capability changes land.
-- Treat routing fallback changes as compatibility-sensitive and document a
-  migration path before changing constructor behavior.
+- Align routing fallback defaults: datacenter and rack constructors stay
+  constrained unless fallback is configured explicitly.
 - Keep node health default behavior unchanged; any future node health behavior
   should start opt-in, and default-enabled behavior requires a major release.
 - Use a minor release for additive compatible APIs, and reserve major releases

--- a/README.md
+++ b/README.md
@@ -280,14 +280,14 @@ config = Config(
     routing_scope=ClusterScope(),
 )
 
-# Route to nodes in a specific datacenter, then fall back to cluster
+# Route only to nodes in a specific datacenter
 config = Config(
     seed_hosts=["node1"],
     port=8000,
     routing_scope=DatacenterScope(datacenter="us-east-1"),
 )
 
-# Route to nodes in a specific rack, then fall back to datacenter and cluster
+# Route only to nodes in a specific rack
 config = Config(
     seed_hosts=["node1"],
     port=8000,
@@ -301,26 +301,30 @@ returns nodes from the contacted seed's local datacenter, cluster-wide routing
 spans multiple datacenters only when the configuration includes at least one
 reachable seed from each datacenter.
 
-Default constructors keep compatibility fallback behavior:
+Default constructors stay constrained to their requested scope:
 
-- `DatacenterScope("dc1")` uses `DatacenterScope` -> `ClusterScope`
-- `RackScope("dc1", "rack1")` uses `RackScope` -> `DatacenterScope` -> `ClusterScope`
+- `DatacenterScope("dc1")` tries only datacenter `dc1`
+- `RackScope("dc1", "rack1")` tries only rack `rack1` in datacenter `dc1`
 
-Use the named `fallback` argument for explicit routing constraints:
+Use the named `fallback` argument when a broader fallback chain is desired:
 
 ```python
 from alternator import ClusterScope, DatacenterScope, RackScope
 
 cluster_only = ClusterScope()
-datacenter_only = DatacenterScope("dc1", fallback=None)
+datacenter_only = DatacenterScope("dc1")
 datacenter_then_cluster = DatacenterScope("dc1", fallback=ClusterScope())
-rack_only = RackScope("dc1", "rack1", fallback=None)
+rack_only = RackScope("dc1", "rack1")
 rack_then_datacenter = RackScope(
     "dc1",
     "rack1",
     fallback=DatacenterScope("dc1", fallback=None),
 )
-rack_then_datacenter_then_cluster = RackScope.with_default_fallback("dc1", "rack1")
+rack_then_datacenter_then_cluster = RackScope(
+    "dc1",
+    "rack1",
+    fallback=DatacenterScope("dc1", fallback=ClusterScope()),
+)
 ```
 
 `Helper.check_rack_and_datacenter_set_correctly()` validates the configured

--- a/alternator/core/query_plan.py
+++ b/alternator/core/query_plan.py
@@ -36,7 +36,7 @@ class LazyQueryPlan(Iterator[str]):
         if not self._nodes:
             raise StopIteration
 
-        # Go/Java-compatible pick-and-remove: pick from the current pool,
+        # Cross-client-compatible pick-and-remove: pick from the current pool,
         # return that node, then fill its slot with the last remaining node.
         pick = self._rng.intn(len(self._nodes))
         node = self._nodes[pick]

--- a/alternator/core/routing_scope.py
+++ b/alternator/core/routing_scope.py
@@ -6,8 +6,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from urllib.parse import quote
 
-_DEFAULT_FALLBACK = object()
-
 
 class RoutingScope(ABC):
     """Base class for topology-aware routing scopes."""
@@ -66,26 +64,20 @@ class DatacenterScope(RoutingScope):
     def __init__(
         self,
         datacenter: str,
-        _fallback: RoutingScope | None | object = _DEFAULT_FALLBACK,
         *,
-        fallback: RoutingScope | None | object = _DEFAULT_FALLBACK,
+        fallback: RoutingScope | None = None,
     ) -> None:
         """Create a datacenter scope.
 
-        Omitting fallback preserves the historical datacenter-to-cluster
-        fallback. Passing ``fallback=None`` disables fallback explicitly.
+        Omitting fallback keeps routing constrained to the datacenter. Use
+        ``fallback=...`` to broaden routing when this scope returns no nodes.
         """
         object.__setattr__(self, "datacenter", datacenter)
         object.__setattr__(
             self,
             "_fallback",
-            _resolve_datacenter_fallback(_fallback, fallback),
+            _validate_fallback(fallback),
         )
-
-    @classmethod
-    def with_default_fallback(cls, datacenter: str) -> DatacenterScope:
-        """Create a datacenter scope that falls back to cluster scope."""
-        return cls(datacenter, fallback=ClusterScope())
 
     @classmethod
     def without_fallback(cls, datacenter: str) -> DatacenterScope:
@@ -120,30 +112,20 @@ class RackScope(RoutingScope):
         self,
         datacenter: str,
         rack: str,
-        _fallback: RoutingScope | None | object = _DEFAULT_FALLBACK,
         *,
-        fallback: RoutingScope | None | object = _DEFAULT_FALLBACK,
+        fallback: RoutingScope | None = None,
     ) -> None:
         """Create a rack scope.
 
-        Omitting fallback preserves the historical rack-to-datacenter-to-cluster
-        fallback. Passing ``fallback=None`` disables fallback explicitly.
+        Omitting fallback keeps routing constrained to the rack. Use
+        ``fallback=...`` to broaden routing when this scope returns no nodes.
         """
         object.__setattr__(self, "datacenter", datacenter)
         object.__setattr__(self, "rack", rack)
         object.__setattr__(
             self,
             "_fallback",
-            _resolve_rack_fallback(datacenter, _fallback, fallback),
-        )
-
-    @classmethod
-    def with_default_fallback(cls, datacenter: str, rack: str) -> RackScope:
-        """Create a rack scope that falls back to datacenter and then cluster."""
-        return cls(
-            datacenter,
-            rack,
-            fallback=DatacenterScope.with_default_fallback(datacenter),
+            _validate_fallback(fallback),
         )
 
     @classmethod
@@ -165,29 +147,6 @@ class RackScope(RoutingScope):
 
     def get_localnodes_query(self) -> str:
         return f"dc={quote(self.datacenter, safe='')}&rack={quote(self.rack, safe='')}"
-
-
-def _resolve_datacenter_fallback(
-    legacy_fallback: RoutingScope | None | object,
-    fallback: RoutingScope | None | object,
-) -> RoutingScope | None:
-    if fallback is not _DEFAULT_FALLBACK:
-        return _validate_fallback(fallback)
-    if legacy_fallback is not _DEFAULT_FALLBACK and legacy_fallback is not None:
-        return _validate_fallback(legacy_fallback)
-    return ClusterScope()
-
-
-def _resolve_rack_fallback(
-    datacenter: str,
-    legacy_fallback: RoutingScope | None | object,
-    fallback: RoutingScope | None | object,
-) -> RoutingScope | None:
-    if fallback is not _DEFAULT_FALLBACK:
-        return _validate_fallback(fallback)
-    if legacy_fallback is not _DEFAULT_FALLBACK and legacy_fallback is not None:
-        return _validate_fallback(legacy_fallback)
-    return DatacenterScope.with_default_fallback(datacenter)
 
 
 def _validate_fallback(fallback: RoutingScope | None | object) -> RoutingScope | None:

--- a/docs/COMPATIBILITY_AND_RELEASE.md
+++ b/docs/COMPATIBILITY_AND_RELEASE.md
@@ -43,18 +43,16 @@ kwargs in the same release as the capability work.
 
 ### Routing Scope Fallback
 
-Keep existing fallback behavior for default routing-scope constructors:
+Default routing-scope constructors stay constrained to their requested scope:
 
-- `DatacenterScope("dc1")` falls back to `ClusterScope()`.
-- `RackScope("dc1", "rack1")` falls back to `DatacenterScope("dc1")` and then
-  `ClusterScope()`.
+- `DatacenterScope("dc1")` has no fallback.
+- `RackScope("dc1", "rack1")` has no fallback.
 
-New code should prefer explicit fallback configuration with `fallback=...`,
-`with_default_fallback(...)`, or `without_fallback(...)`.
+Callers that need broader routing should configure it explicitly with
+`fallback=...`.
 
-Changing default fallback behavior requires a warning period and a major
-release. Release notes must include migration examples for callers that need
-cluster fallback, datacenter fallback, or no fallback.
+This is a default behavior change. Release notes must include migration examples
+for callers that need cluster fallback or datacenter fallback.
 
 ### Node Health
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -5,14 +5,14 @@ Use this file as the release-note source for the capability roadmap tracked in
 [docs/COMPATIBILITY_AND_RELEASE.md](COMPATIBILITY_AND_RELEASE.md) as the
 authority for compatibility decisions.
 
-## Next Minor Release
+## Next Major Release
 
 ### Additive APIs
 
 - Added `Helper` and `AsyncHelper` lifecycle facades for callers that need one
   owner for clients/resources plus topology diagnostics.
-- Added explicit routing fallback controls with `fallback=...`,
-  `with_default_fallback(...)`, and `without_fallback(...)`.
+- Added explicit routing fallback controls with `fallback=...` and
+  `without_fallback(...)`.
 - Added topology validation helpers for configured datacenter/rack scopes.
 - Added transport configuration for SDK retries, connect/read timeouts,
   connection pool size, region placeholder, and SDK config customization.
@@ -31,13 +31,12 @@ authority for compatibility decisions.
   deprecation warnings.
 - The convenience default port remains `8000`; pass `port=...` explicitly if
   your deployment uses a different port.
-- Existing datacenter and rack constructors keep their compatibility fallback
-  behavior. Use explicit fallback arguments when the routing boundary matters.
+- Datacenter and rack constructors now stay constrained by default. Use
+  `fallback=...` when broader routing is desired.
 - Deprecated names such as `AlternatorConfig` and `TlsConfig` remain available
   and continue to warn. Prefer `Config` and `TLS` in new code.
 - Node health, quarantine behavior, decommission handling, and dead-node
-  handling remain planning-only. No default routing behavior changes are part of
-  this release.
+  handling remain planning-only.
 
 ### Behavior Notes
 
@@ -58,8 +57,8 @@ authority for compatibility decisions.
   updated code.
 - Replace raw SDK credential kwargs with
   `auth=Auth.static_credentials(access_key_id, secret_access_key)`.
-- Replace implicit topology assumptions with explicit routing fallback when a
-  request must stay inside a cluster, datacenter, or rack boundary.
+- Replace implicit topology fallback assumptions with explicit `fallback=...`
+  when requests may broaden from rack to datacenter or cluster scope.
 - Preload partition-key metadata with `table_pk_map` when key affinity should be
   active on the first request for a table.
 - Review timeout configuration as per-attempt SDK settings, not whole-operation

--- a/tests/integration/test_sync_client.py
+++ b/tests/integration/test_sync_client.py
@@ -489,8 +489,7 @@ class TestRoutingScopes:
     def test_datacenter_scope_works(self) -> None:
         """Test datacenter-scoped routing.
 
-        Note: This test may fall back to cluster scope if the specified
-        datacenter doesn't exist. It verifies the fallback mechanism works.
+        The default Scylla docker-compose uses 'datacenter1'.
         """
         from alternator import DatacenterScope
 
@@ -506,31 +505,31 @@ class TestRoutingScopes:
         assert isinstance(config.routing_scope, DatacenterScope)
 
         with AlternatorClient(config) as client:
-            # Should work (may fall back to cluster scope)
             response = client.list_tables()
             assert "TableNames" in response
 
     def test_rack_scope_works(self) -> None:
         """Test rack-scoped routing.
 
-        Note: This test may fall back to datacenter or cluster scope
-        if the specified rack doesn't exist.
+        This test uses an explicit fallback chain because the local fixture may
+        not expose rack1.
         """
-        from alternator import RackScope
+        from alternator import ClusterScope, DatacenterScope, RackScope
 
-        config = (
-            AlternatorConfigBuilder()
-            .with_seeds(SCYLLA_HOST)
-            .with_port(SCYLLA_PORT)
-            .with_rack("datacenter1", "rack1")  # Common default names
-            .build()
+        config = Config(
+            seed_hosts=[SCYLLA_HOST],
+            port=SCYLLA_PORT,
+            routing_scope=RackScope(
+                "datacenter1",
+                "rack1",
+                fallback=DatacenterScope("datacenter1", fallback=ClusterScope()),
+            ),
         )
 
         # Verify the config has the correct scope
         assert isinstance(config.routing_scope, RackScope)
 
         with AlternatorClient(config) as client:
-            # Should work (may fall back to broader scope)
             response = client.list_tables()
             assert "TableNames" in response
 

--- a/tests/integration/test_wrong_dc_rack.py
+++ b/tests/integration/test_wrong_dc_rack.py
@@ -1,7 +1,7 @@
 """Integration tests for wrong DC/rack error handling and fallback.
 
 These tests verify that the client gracefully handles incorrect datacenter
-and rack configurations by falling back to broader scopes.
+and rack configurations when broader fallback scopes are configured.
 
 These tests require a running Scylla cluster with Alternator enabled.
 Start a local cluster with: make scylla-start
@@ -12,6 +12,7 @@ import pytest
 from alternator import (
     AlternatorClient,
     AlternatorConfigBuilder,
+    ClusterScope,
     Config,
     DatacenterScope,
     Helper,
@@ -31,34 +32,32 @@ class TestWrongDatacenter:
     """Test wrong datacenter detection and fallback."""
 
     def test_wrong_datacenter_falls_back_to_cluster(self) -> None:
-        """When a non-existent datacenter is specified, client falls back to cluster scope.
+        """Explicit fallback lets a non-existent datacenter use cluster scope.
 
         The /localnodes?dc=nonexistent endpoint returns empty results,
         causing the manager to fall back to ClusterScope.
         """
-        config = (
-            AlternatorConfigBuilder()
-            .with_seeds(SCYLLA_HOST)
-            .with_port(SCYLLA_PORT)
-            .with_datacenter("nonexistent_dc_12345")
-            .build()
+        config = Config(
+            seed_hosts=[SCYLLA_HOST],
+            port=SCYLLA_PORT,
+            routing_scope=DatacenterScope(
+                "nonexistent_dc_12345", fallback=ClusterScope()
+            ),
         )
 
         assert isinstance(config.routing_scope, DatacenterScope)
 
-        # Should still work — falls back to cluster scope
+        # Should still work because fallback to cluster scope is explicit.
         with AlternatorClient(config) as client:
             response = client.list_tables()
             assert "TableNames" in response
 
     def test_wrong_datacenter_still_handles_operations(self) -> None:
         """After fallback, all operations should work normally."""
-        config = (
-            AlternatorConfigBuilder()
-            .with_seeds(SCYLLA_HOST)
-            .with_port(SCYLLA_PORT)
-            .with_datacenter("bad_dc")
-            .build()
+        config = Config(
+            seed_hosts=[SCYLLA_HOST],
+            port=SCYLLA_PORT,
+            routing_scope=DatacenterScope("bad_dc", fallback=ClusterScope()),
         )
 
         with AlternatorClient(config) as client:
@@ -68,11 +67,11 @@ class TestWrongDatacenter:
                 assert "TableNames" in response
 
     def test_wrong_datacenter_without_fallback_fails(self) -> None:
-        """Explicit datacenter-only routing fails when that datacenter is absent."""
+        """Default datacenter-only routing fails when that datacenter is absent."""
         config = Config(
             seed_hosts=[SCYLLA_HOST],
             port=SCYLLA_PORT,
-            routing_scope=DatacenterScope("bad_dc", fallback=None),
+            routing_scope=DatacenterScope("bad_dc"),
         )
 
         with pytest.raises(NoNodesAvailableError), AlternatorClient(config):
@@ -83,33 +82,37 @@ class TestWrongRack:
     """Test wrong rack detection and fallback."""
 
     def test_wrong_rack_falls_back_to_datacenter(self) -> None:
-        """When a non-existent rack is specified, client falls back to datacenter scope.
+        """Explicit fallback lets a non-existent rack use broader scopes.
 
         Fallback chain: Rack → Datacenter → Cluster
         """
-        config = (
-            AlternatorConfigBuilder()
-            .with_seeds(SCYLLA_HOST)
-            .with_port(SCYLLA_PORT)
-            .with_rack("datacenter1", "nonexistent_rack_12345")
-            .build()
+        config = Config(
+            seed_hosts=[SCYLLA_HOST],
+            port=SCYLLA_PORT,
+            routing_scope=RackScope(
+                "datacenter1",
+                "nonexistent_rack_12345",
+                fallback=DatacenterScope("datacenter1", fallback=ClusterScope()),
+            ),
         )
 
         assert isinstance(config.routing_scope, RackScope)
 
-        # Should still work — falls back through datacenter to cluster
+        # Should still work because fallback through datacenter to cluster is explicit.
         with AlternatorClient(config) as client:
             response = client.list_tables()
             assert "TableNames" in response
 
     def test_wrong_rack_and_datacenter_falls_back_to_cluster(self) -> None:
-        """When both rack and datacenter are wrong, falls back to cluster scope."""
-        config = (
-            AlternatorConfigBuilder()
-            .with_seeds(SCYLLA_HOST)
-            .with_port(SCYLLA_PORT)
-            .with_rack("bad_dc", "bad_rack")
-            .build()
+        """Explicit fallback lets wrong rack and datacenter use cluster scope."""
+        config = Config(
+            seed_hosts=[SCYLLA_HOST],
+            port=SCYLLA_PORT,
+            routing_scope=RackScope(
+                "bad_dc",
+                "bad_rack",
+                fallback=DatacenterScope("bad_dc", fallback=ClusterScope()),
+            ),
         )
 
         assert isinstance(config.routing_scope, RackScope)
@@ -120,12 +123,14 @@ class TestWrongRack:
 
     def test_wrong_rack_still_handles_operations(self) -> None:
         """After rack fallback, all operations should work normally."""
-        config = (
-            AlternatorConfigBuilder()
-            .with_seeds(SCYLLA_HOST)
-            .with_port(SCYLLA_PORT)
-            .with_rack("datacenter1", "bad_rack")
-            .build()
+        config = Config(
+            seed_hosts=[SCYLLA_HOST],
+            port=SCYLLA_PORT,
+            routing_scope=RackScope(
+                "datacenter1",
+                "bad_rack",
+                fallback=DatacenterScope("datacenter1", fallback=ClusterScope()),
+            ),
         )
 
         with AlternatorClient(config) as client:

--- a/tests/unit/test_async_manager.py
+++ b/tests/unit/test_async_manager.py
@@ -73,7 +73,7 @@ class TestAsyncLiveNodesManager:
 
     @pytest.mark.asyncio
     async def test_fallback_chain_on_empty(self) -> None:
-        """Test fallback to broader scope when narrow scope returns empty."""
+        """Test explicit fallback to broader scope when narrow scope returns empty."""
         call_urls: list[str] = []
 
         async def mock_fetch(url: str) -> list[str]:
@@ -86,7 +86,7 @@ class TestAsyncLiveNodesManager:
         config = Config(
             seed_hosts=["192.168.1.1"],
             port=8000,
-            routing_scope=DatacenterScope(datacenter="dc1"),
+            routing_scope=DatacenterScope("dc1", fallback=ClusterScope()),
         )
 
         manager = AsyncLiveNodesManager(config, mock_fetch)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -188,6 +188,7 @@ class TestAlternatorConfigBuilder:
         )
         assert isinstance(config.routing_scope, DatacenterScope)
         assert config.routing_scope.datacenter == "us-east-1"
+        assert config.routing_scope.fallback is None
 
     def test_build_with_compression(self) -> None:
         """Test building config with compression."""

--- a/tests/unit/test_routing_scope.py
+++ b/tests/unit/test_routing_scope.py
@@ -51,16 +51,15 @@ class TestDatacenterScope:
         scope = DatacenterScope(datacenter="us-east-1")
         assert scope.get_localnodes_query() == "dc=us-east-1"
 
-    def test_default_fallback_to_cluster(self) -> None:
-        """Test default fallback is ClusterScope."""
+    def test_default_has_no_fallback(self) -> None:
+        """Default datacenter routing stays constrained."""
         scope = DatacenterScope(datacenter="us-east-1")
-        fallback = scope.fallback
-        assert isinstance(fallback, ClusterScope)
+        assert scope.fallback is None
 
     def test_custom_fallback(self) -> None:
         """Test custom fallback scope."""
         custom_fallback = ClusterScope()
-        scope = DatacenterScope(datacenter="us-east-1", _fallback=custom_fallback)
+        scope = DatacenterScope(datacenter="us-east-1", fallback=custom_fallback)
         assert scope.fallback is custom_fallback
 
     def test_explicit_no_fallback(self) -> None:
@@ -68,18 +67,13 @@ class TestDatacenterScope:
         scope = DatacenterScope(datacenter="us-east-1", fallback=None)
         assert scope.fallback is None
 
-    def test_legacy_none_fallback_keeps_default(self) -> None:
-        """The legacy positional fallback=None keeps default fallback behavior."""
-        scope = DatacenterScope("us-east-1", None)
-        assert isinstance(scope.fallback, ClusterScope)
-
-    def test_with_default_fallback(self) -> None:
-        """Compatibility constructor creates datacenter-to-cluster fallback."""
-        scope = DatacenterScope.with_default_fallback("us-east-1")
+    def test_explicit_cluster_fallback(self) -> None:
+        """Explicit fallback creates datacenter-to-cluster fallback."""
+        scope = DatacenterScope("us-east-1", fallback=ClusterScope())
         assert isinstance(scope.fallback, ClusterScope)
 
     def test_without_fallback(self) -> None:
-        """Named constructor creates datacenter-only fallback."""
+        """Named constructor creates datacenter-only routing."""
         scope = DatacenterScope.without_fallback("us-east-1")
         assert scope.fallback is None
 
@@ -102,17 +96,15 @@ class TestRackScope:
         scope = RackScope(datacenter="us-east-1", rack="rack1")
         assert scope.get_localnodes_query() == "dc=us-east-1&rack=rack1"
 
-    def test_default_fallback_to_datacenter(self) -> None:
-        """Test default fallback is DatacenterScope."""
+    def test_default_has_no_fallback(self) -> None:
+        """Default rack routing stays constrained."""
         scope = RackScope(datacenter="us-east-1", rack="rack1")
-        fallback = scope.fallback
-        assert isinstance(fallback, DatacenterScope)
-        assert fallback.datacenter == "us-east-1"
+        assert scope.fallback is None
 
     def test_custom_fallback(self) -> None:
         """Test custom fallback scope."""
         custom_fallback = ClusterScope()
-        scope = RackScope(datacenter="dc1", rack="r1", _fallback=custom_fallback)
+        scope = RackScope(datacenter="dc1", rack="r1", fallback=custom_fallback)
         assert scope.fallback is custom_fallback
 
     def test_explicit_no_fallback(self) -> None:
@@ -120,20 +112,19 @@ class TestRackScope:
         scope = RackScope(datacenter="dc1", rack="r1", fallback=None)
         assert scope.fallback is None
 
-    def test_legacy_none_fallback_keeps_default(self) -> None:
-        """The legacy positional fallback=None keeps default fallback behavior."""
-        scope = RackScope("dc1", "r1", None)
-        assert isinstance(scope.fallback, DatacenterScope)
-
-    def test_with_default_fallback(self) -> None:
-        """Compatibility constructor creates rack-to-datacenter-to-cluster fallback."""
-        scope = RackScope.with_default_fallback("dc1", "r1")
+    def test_explicit_datacenter_cluster_fallback(self) -> None:
+        """Explicit fallback creates rack-to-datacenter-to-cluster fallback."""
+        scope = RackScope(
+            "dc1",
+            "r1",
+            fallback=DatacenterScope("dc1", fallback=ClusterScope()),
+        )
         fallback = scope.fallback
         assert isinstance(fallback, DatacenterScope)
         assert isinstance(fallback.fallback, ClusterScope)
 
     def test_without_fallback(self) -> None:
-        """Named constructor creates rack-only fallback."""
+        """Named constructor creates rack-only routing."""
         scope = RackScope.without_fallback("dc1", "r1")
         assert scope.fallback is None
 
@@ -142,8 +133,12 @@ class TestFallbackChain:
     """Tests for routing scope fallback chains."""
 
     def test_rack_fallback_chain(self) -> None:
-        """Test full fallback chain: Rack -> Datacenter -> Cluster."""
-        rack_scope = RackScope(datacenter="us-east-1", rack="rack1")
+        """Test explicit full fallback chain: Rack -> Datacenter -> Cluster."""
+        rack_scope = RackScope(
+            "us-east-1",
+            "rack1",
+            fallback=DatacenterScope("us-east-1", fallback=ClusterScope()),
+        )
 
         # Rack -> Datacenter
         dc_scope = rack_scope.fallback
@@ -158,8 +153,8 @@ class TestFallbackChain:
         assert cluster_scope.fallback is None
 
     def test_datacenter_fallback_chain(self) -> None:
-        """Test fallback chain: Datacenter -> Cluster."""
-        dc_scope = DatacenterScope(datacenter="eu-west-1")
+        """Test explicit fallback chain: Datacenter -> Cluster."""
+        dc_scope = DatacenterScope("eu-west-1", fallback=ClusterScope())
 
         # Datacenter -> Cluster
         cluster_scope = dc_scope.fallback
@@ -177,10 +172,18 @@ class TestFallbackChain:
     def test_scope_chain_includes_cluster(self) -> None:
         """Detect whether a scope chain can fall back to cluster scope."""
         assert scope_chain_includes_cluster(ClusterScope())
-        assert scope_chain_includes_cluster(DatacenterScope("dc1"))
-        assert scope_chain_includes_cluster(RackScope("dc1", "r1"))
-        assert not scope_chain_includes_cluster(DatacenterScope("dc1", fallback=None))
-        assert not scope_chain_includes_cluster(RackScope("dc1", "r1", fallback=None))
+        assert scope_chain_includes_cluster(
+            DatacenterScope("dc1", fallback=ClusterScope())
+        )
+        assert scope_chain_includes_cluster(
+            RackScope(
+                "dc1",
+                "r1",
+                fallback=DatacenterScope("dc1", fallback=ClusterScope()),
+            )
+        )
+        assert not scope_chain_includes_cluster(DatacenterScope("dc1"))
+        assert not scope_chain_includes_cluster(RackScope("dc1", "r1"))
 
     def test_all_supported_fallback_shapes(self) -> None:
         """Represent every supported explicit fallback shape."""

--- a/tests/unit/test_sync_manager.py
+++ b/tests/unit/test_sync_manager.py
@@ -73,11 +73,11 @@ class TestSyncLiveNodesManager:
             manager.next_node_uri()
 
     def test_fallback_chain_on_empty(self, config: Config) -> None:
-        """Test fallback chain is used when scope returns empty."""
+        """Test explicit fallback chain is used when scope returns empty."""
         dc_config = Config(
             seed_hosts=["192.168.1.1"],
             port=8000,
-            routing_scope=DatacenterScope(datacenter="dc1"),
+            routing_scope=DatacenterScope("dc1", fallback=ClusterScope()),
         )
 
         calls: list[str] = []


### PR DESCRIPTION
## Summary
- Keep `DatacenterScope(...)` and `RackScope(...)` constrained unless `fallback=...` is set.
- Remove `with_default_fallback` and require explicit fallback chains through `fallback=...`.
- Remove positional fallback constructor handling and update tests/examples to use the named argument.
- Add `DIFF.md` as an issue-planning backlog for Python/Go client discrepancies.
- Update release/compatibility docs and integration coverage for the new default behavior.

## Tests
- `make lint`
- `python -m pytest tests/unit/`