### PR TITLE
Support HTTP response compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A Python library that provides client-side load balancing for [ScyllaDB Alternat
 - **Node Discovery**: Automatically discovers cluster topology via the `/localnodes` endpoint
 - **Topology Awareness**: Route requests to specific datacenters or racks
 - **Key Affinity Routing**: Optimizes LWT (Lightweight Transaction) operations by routing requests for the same partition key to the same node
-- **Request Compression**: Optional gzip compression to reduce bandwidth
+- **Request Compression**: Optional gzip request compression to reduce bandwidth
+- **Response Compression**: Optional gzip/deflate response decompression
 - **Header Optimization**: Filters unnecessary headers to reduce request overhead
 - **TLS Support**: Full TLS/SSL support with custom CA certificates
 - **Async Support**: Full async/await support via aioboto3
@@ -173,6 +174,7 @@ from alternator import (
     AlternatorConfigBuilder,
     CompressionAlgorithm,
     KeyRouteAffinityMode,
+    ResponseCompression,
     TLS,
 )
 
@@ -183,6 +185,7 @@ config = (
     .with_https(TLS.system_default())
     .with_datacenter("us-east-1")
     .with_compression(CompressionAlgorithm.GZIP, min_size=1024)
+    .with_response_compression(ResponseCompression.GZIP)
     .with_key_affinity(KeyRouteAffinityMode.RMW)
     .with_refresh_intervals(active_ms=1000, idle_ms=60000)
     .build()
@@ -200,6 +203,7 @@ config = (
 | `compression` | `CompressionAlgorithm` | `NONE` | Request compression |
 | `min_compression_size_bytes` | `int` | `1024` | Minimum body size to compress |
 | `gzip_level` | `int` | `9` | gzip compression level, `0` through `9` |
+| `response_compression` | `Sequence[ResponseCompression]` | empty | Accepted response compression encodings |
 | `optimize_headers` | `bool` | `False` | Enable header filtering |
 | `headers_whitelist` | `frozenset[str]` | `None` | Additional headers to keep |
 | `header_whitelist_callback` | callable | `None` | Callback for dynamic header whitelist additions |
@@ -435,14 +439,18 @@ temporary locations, delete them after debugging, and never commit them. Key log
 support depends on Python/OpenSSL exposing `SSLContext.keylog_filename`; runtimes
 without that attribute ignore `key_log_file_path`.
 
-## Request Compression
+## Request And Response Compression
 
 Enable gzip compression for large request bodies:
 
-> **Note:** Gzip request compression requires **ScyllaDB 2026.1.0 or later**. Earlier versions do not support the `Content-Encoding: gzip` header. Response compression (`Accept-Encoding: gzip`) is not yet supported by Alternator.
+> **Note:** Gzip request compression requires **ScyllaDB 2026.1.0 or later**. HTTP response compression requires an Alternator build that includes ScyllaDB core response-compression support from `scylladb/scylladb#27454`.
 
 ```python
-from alternator import AlternatorConfigBuilder, CompressionAlgorithm
+from alternator import (
+    AlternatorConfigBuilder,
+    CompressionAlgorithm,
+    ResponseCompression,
+)
 
 config = (
     AlternatorConfigBuilder()
@@ -453,6 +461,10 @@ config = (
         min_size=1024,  # Only compress bodies >= 1KB
         gzip_level=6,   # Python gzip level 0-9; default is 9
     )
+    .with_response_compression(
+        ResponseCompression.GZIP,
+        ResponseCompression.DEFLATE,
+    )
     .build()
 )
 ```
@@ -462,6 +474,12 @@ Compression uses Python's `gzip.compress` implementation. Levels `0` through
 higher levels spend more CPU and usually produce smaller bodies. The client only
 sends compressed bodies when the compressed payload is smaller than the original
 payload.
+
+Response compression is disabled by default. When enabled, the client sends
+`Accept-Encoding` with the configured encodings and decodes `Content-Encoding:
+gzip` or `Content-Encoding: deflate` responses before boto3/aioboto3 parses the
+DynamoDB JSON body. Use `.without_response_compression()` to disable it again in
+builder chains.
 
 ## Header Optimization
 
@@ -760,7 +778,8 @@ Async clients created by `create_async_client` / `AsyncAlternatorClient` are saf
 
 ## Known Limitations
 
-- **Request Compression**: Gzip compression requires ScyllaDB 2026.1.0+. Response compression is not yet supported by Alternator.
+- **Request Compression**: Gzip request compression requires ScyllaDB 2026.1.0+.
+- **Response Compression**: Response gzip/deflate decoding requires an Alternator build that includes `scylladb/scylladb#27454` and must be enabled explicitly with `with_response_compression(...)`.
 - **Gzip Compression Levels**: Python's gzip module supports levels `0` through `9`; this client does not expose alternative compression algorithms or custom compressor objects.
 - **TLS Session Cache Settings**: The `cache_size` and `timeout_seconds` parameters in `TlsSessionCacheConfig` are not currently used by Python's `ssl` module. Only the `enabled` flag controls session ticket behavior.
 - **TLS Key Logs**: Key log file support depends on Python/OpenSSL runtime support for `SSLContext.keylog_filename` and should only be used in protected debugging environments.

--- a/alternator/__init__.py
+++ b/alternator/__init__.py
@@ -73,6 +73,7 @@ Vector Search (ScyllaDB Extension)
 Notes
 -----
 - Gzip compression requires ScyllaDB 2026.1.0 or later
+- Response compression supports gzip and deflate when the server supports it
 - For async support, install with: ``pip install alternator[async]``
 - Vector search is a ScyllaDB Alternator extension not available on AWS DynamoDB
 """
@@ -102,6 +103,7 @@ from alternator.config import (
     KeyRouteAffinityMode,
     NodeListPollingConfig,
     RequestCompressionConfig,
+    ResponseCompression,
     RetryConfig,
     RetryMode,
     SDKConfigCustomizer,
@@ -150,6 +152,7 @@ __all__ = [
     "HeaderWhitelistCallback",
     "HeaderWhitelistContext",
     "RequestCompressionConfig",
+    "ResponseCompression",
     "KeyRouteAffinityConfig",
     "KeyRouteAffinityMode",
     "NodeListPollingConfig",

--- a/alternator/config.py
+++ b/alternator/config.py
@@ -27,6 +27,13 @@ class CompressionAlgorithm(Enum):
     GZIP = auto()
 
 
+class ResponseCompression(Enum):
+    """HTTP response compression encoding accepted by the client."""
+
+    GZIP = "gzip"
+    DEFLATE = "deflate"
+
+
 class KeyRouteAffinityMode(Enum):
     """Mode for key-based routing affinity (LWT optimization)."""
 
@@ -361,6 +368,9 @@ class Config:
         default_factory=RequestCompressionConfig
     )
 
+    # Response compression settings
+    response_compression: Sequence[ResponseCompression] = field(default_factory=tuple)
+
     # Header optimization
     header_optimization: HeaderOptimizationConfig = field(
         default_factory=HeaderOptimizationConfig
@@ -406,6 +416,11 @@ class Config:
             )
         if not self.aws_region:
             raise ConfigurationError("aws_region must not be empty")
+        object.__setattr__(
+            self,
+            "response_compression",
+            _normalize_response_compression(self.response_compression),
+        )
 
 
 @dataclass(frozen=True)
@@ -443,6 +458,7 @@ class AlternatorConfigBuilder:
         self._scheme: Literal["http", "https"] = "http"
         self._routing_scope: RoutingScope | None = None
         self._request_compression = RequestCompressionConfig()
+        self._response_compression: tuple[ResponseCompression, ...] = ()
         self._header_optimization = HeaderOptimizationConfig()
         self._tls = TLS.system_default()
         self._key_affinity = KeyRouteAffinityConfig()
@@ -508,6 +524,21 @@ class AlternatorConfigBuilder:
             min_size_bytes=min_size,
             gzip_level=gzip_level,
         )
+        return self
+
+    def with_response_compression(
+        self,
+        encoding: ResponseCompression,
+        *additional_encodings: ResponseCompression,
+    ) -> AlternatorConfigBuilder:
+        """Enable response compression for the accepted encodings."""
+        encodings = (encoding, *additional_encodings)
+        self._response_compression = _normalize_response_compression(encodings)
+        return self
+
+    def without_response_compression(self) -> AlternatorConfigBuilder:
+        """Disable response compression."""
+        self._response_compression = ()
         return self
 
     def with_header_optimization(
@@ -601,6 +632,7 @@ class AlternatorConfigBuilder:
             scheme=self._scheme,
             routing_scope=self._routing_scope or ClusterScope(),
             request_compression=self._request_compression,
+            response_compression=self._response_compression,
             header_optimization=self._header_optimization,
             tls=self._tls,
             key_affinity=self._key_affinity,
@@ -629,3 +661,16 @@ def build_sdk_config_kwargs(config: Config) -> dict[str, Any]:
     if config.sdk_config_customizer is not None:
         config.sdk_config_customizer(kwargs)
     return kwargs
+
+
+def _normalize_response_compression(
+    encodings: Sequence[ResponseCompression],
+) -> tuple[ResponseCompression, ...]:
+    """Validate and freeze response compression encodings."""
+    normalized = tuple(encodings)
+    for encoding in normalized:
+        if not isinstance(encoding, ResponseCompression):
+            raise ConfigurationError(
+                f"unsupported response compression encoding: {encoding!r}"
+            )
+    return normalized

--- a/alternator/core/compression.py
+++ b/alternator/core/compression.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import contextlib
 import gzip
-from collections.abc import Callable
+import zlib
+from collections.abc import Callable, Sequence
 from typing import Any, cast
 
 from botocore.awsrequest import AWSPreparedRequest, AWSRequest
+
+from alternator.config import ResponseCompression
 
 
 def create_compression_handler(
@@ -71,3 +75,138 @@ def _set_request_body(request: AWSPreparedRequest | AWSRequest, body: bytes) -> 
         mutable_request.data = body
         return
     mutable_request.body = body
+
+
+def create_response_compression_request_handler(
+    encodings: Sequence[ResponseCompression],
+) -> Callable[..., None]:
+    """Create a handler that requests compressed HTTP responses."""
+    accept_encoding = _response_accept_encoding(encodings)
+
+    def request_response_compression(
+        request: AWSPreparedRequest | AWSRequest,
+        **kwargs: Any,  # noqa: ANN401 -- botocore event handler signature
+    ) -> None:
+        if not accept_encoding:
+            return
+        headers = getattr(request, "headers", None)
+        if headers is None:
+            return
+
+        current = _get_header(headers, "Accept-Encoding")
+        if (
+            current is None
+            or current.strip() == ""
+            or current.strip().lower() == "identity"
+        ):
+            headers["Accept-Encoding"] = accept_encoding
+
+    return request_response_compression
+
+
+def create_response_compression_decode_handler() -> Callable[..., None]:
+    """Create a handler that decodes compressed HTTP responses before parsing."""
+
+    def decode_response_compression(
+        response_dict: dict[str, Any],
+        **kwargs: Any,  # noqa: ANN401 -- botocore event handler signature
+    ) -> None:
+        headers = response_dict.get("headers")
+        encoding = _get_header(headers, "Content-Encoding")
+        if encoding is None:
+            return
+
+        normalized_encoding = encoding.strip().lower()
+        if normalized_encoding == ResponseCompression.GZIP.value:
+            response_dict["body"] = _decode_gzip_response(response_dict.get("body"))
+        elif normalized_encoding == ResponseCompression.DEFLATE.value:
+            response_dict["body"] = _decode_deflate_response(response_dict.get("body"))
+        else:
+            return
+
+        _delete_header(headers, "Content-Encoding")
+        _delete_header(headers, "Content-Length")
+
+    return decode_response_compression
+
+
+def _response_accept_encoding(
+    encodings: Sequence[ResponseCompression],
+) -> str:
+    seen: set[ResponseCompression] = set()
+    parts: list[str] = []
+    for encoding in encodings:
+        if encoding in seen:
+            continue
+        seen.add(encoding)
+        parts.append(encoding.value)
+    return ", ".join(parts)
+
+
+def _decode_gzip_response(body: object) -> bytes:
+    try:
+        return gzip.decompress(_response_body_as_bytes(body))
+    except Exception as exc:
+        raise ValueError(f"decode gzip response: {exc}") from exc
+
+
+def _decode_deflate_response(body: object) -> bytes:
+    try:
+        return zlib.decompress(_response_body_as_bytes(body))
+    except Exception as exc:
+        raise ValueError(f"decode deflate response: {exc}") from exc
+
+
+def _response_body_as_bytes(body: object) -> bytes:
+    if isinstance(body, bytes):
+        return body
+    if isinstance(body, str):
+        return body.encode("utf-8")
+    if isinstance(body, bytearray | memoryview):
+        return bytes(body)
+    raise TypeError(f"unsupported response body type {type(body).__name__}")
+
+
+def _get_header(headers: object, name: str) -> str | None:
+    if headers is None:
+        return None
+
+    getter = getattr(headers, "get", None)
+    if callable(getter):
+        for key in (name, name.lower(), name.title()):
+            value = getter(key)
+            if value is not None:
+                return _header_value_to_str(value)
+
+    for header_key, value in _header_items(headers):
+        if _header_value_to_str(header_key).lower() == name.lower():
+            return _header_value_to_str(value)
+    return None
+
+
+def _delete_header(headers: object, name: str) -> None:
+    if headers is None:
+        return
+
+    mutable_headers = cast(Any, headers)
+    for key in (name, name.lower(), name.title()):
+        with contextlib.suppress(KeyError, TypeError, AttributeError):
+            del mutable_headers[key]
+
+    for header_key, _ in _header_items(headers):
+        if _header_value_to_str(header_key).lower() == name.lower():
+            with contextlib.suppress(KeyError, TypeError, AttributeError):
+                del mutable_headers[header_key]
+
+
+def _header_items(headers: object) -> list[tuple[object, object]]:
+    try:
+        return list(dict(cast(Any, headers)).items())
+    except (TypeError, ValueError):
+        return []
+
+
+def _header_value_to_str(value: object) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return str(value)

--- a/alternator/core/handlers.py
+++ b/alternator/core/handlers.py
@@ -12,7 +12,11 @@ from botocore.awsrequest import AWSPreparedRequest, AWSRequest
 from botocore.hooks import BaseEventHooks
 
 from alternator.config import CompressionAlgorithm
-from alternator.core.compression import create_compression_handler
+from alternator.core.compression import (
+    create_compression_handler,
+    create_response_compression_decode_handler,
+    create_response_compression_request_handler,
+)
 from alternator.core.headers import (
     compute_header_whitelist,
     create_header_filter_handler,
@@ -185,6 +189,15 @@ def _register_alternator_handlers(
             gzip_level=config.request_compression.gzip_level,
         )
         events.register("request-created.dynamodb.*", compress_handler)
+
+    # Register response compression handlers if enabled
+    if config.response_compression:
+        accept_encoding_handler = create_response_compression_request_handler(
+            config.response_compression,
+        )
+        decode_response_handler = create_response_compression_decode_handler()
+        events.register("before-send.dynamodb.*", accept_encoding_handler)
+        events.register("before-parse.dynamodb.*", decode_response_handler)
 
     # Register header filter if optimization enabled
     if config.header_optimization.enabled:

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -14,6 +14,7 @@ and intentionally deferred behavior.
 | Request query plans | Supported | Existing API | Requests use stable seeded node ordering for retries. |
 | Auth | Supported | Existing API | Disabled by default; explicit static credentials enable signing. |
 | Request compression | Supported | [#37](https://github.com/scylladb/alternator-client-python/issues/37) | Gzip request compression supports threshold and compression-level configuration. |
+| Response compression | Supported | [#65](https://github.com/scylladb/alternator-client-python/issues/65) | Gzip and deflate response decoding is disabled by default and enabled with `with_response_compression(...)`. |
 | Header optimization | Supported | [#37](https://github.com/scylladb/alternator-client-python/issues/37) | Required headers are preserved, with static and callback-computed whitelist additions. |
 | TLS server trust | Supported | Existing API | System CA, custom CA, hostname verification, and trust-all mode exist. |
 | TLS client certificates | Supported | [#38](https://github.com/scylladb/alternator-client-python/issues/38) | mTLS certificate/key paths are loaded into discovery SSL contexts and SDK `client_cert` config. |

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -19,6 +19,7 @@ authority for compatibility decisions.
 - Added TLS client certificate, client key, and key log file settings.
 - Added configurable gzip compression level and callback-based header whitelist
   additions.
+- Added opt-in gzip and deflate response compression decoding.
 - Updated key-affinity routing semantics for read-modify-write operations and
   `BatchWriteItem` preferred-node voting.
 

--- a/tests/integration/test_response_compression.py
+++ b/tests/integration/test_response_compression.py
@@ -1,0 +1,107 @@
+"""Integration tests for HTTP response compression."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+
+from alternator import (
+    AlternatorConfigBuilder,
+    Config,
+    ResponseCompression,
+    close_client,
+    create_client,
+)
+from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
+from tests.integration.wire_capture import (
+    capture_prepared_requests,
+    capture_raw_responses,
+    latest_request,
+    latest_response,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(SKIP_INTEGRATION, reason="Integration tests disabled"),
+]
+
+
+def _large_response_payload() -> str:
+    return "response-compression-payload-" * 4096
+
+
+def _response_compression_config(encoding: ResponseCompression) -> Config:
+    return (
+        AlternatorConfigBuilder()
+        .with_seeds(SCYLLA_HOST)
+        .with_port(SCYLLA_PORT)
+        .with_response_compression(encoding)
+        .build()
+    )
+
+
+def _create_table(client: Any, table_name: str) -> None:  # noqa: ANN401 -- SDK clients are dynamically typed
+    client.create_table(
+        TableName=table_name,
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    client.get_waiter("table_exists").wait(TableName=table_name)
+
+
+def _delete_table(client: Any, table_name: str) -> None:  # noqa: ANN401 -- SDK clients are dynamically typed
+    client.delete_table(TableName=table_name)
+    client.get_waiter("table_not_exists").wait(TableName=table_name)
+
+
+class TestResponseCompression:
+    """Verify response compression behavior on the wire."""
+
+    @pytest.mark.parametrize(
+        "encoding",
+        [ResponseCompression.GZIP, ResponseCompression.DEFLATE],
+    )
+    def test_large_get_item_response_is_decoded(
+        self,
+        encoding: ResponseCompression,
+    ) -> None:
+        table_name = f"response_compression_{encoding.value}_{uuid.uuid4().hex}"
+        client = create_client(_response_compression_config(encoding))
+        try:
+            captured_requests = capture_prepared_requests(client)
+            captured_responses = capture_raw_responses(client, "GetItem")
+
+            _create_table(client, table_name)
+            try:
+                client.put_item(
+                    TableName=table_name,
+                    Item={
+                        "pk": {"S": "response-compression-key"},
+                        "data": {"S": _large_response_payload()},
+                    },
+                )
+
+                response = client.get_item(
+                    TableName=table_name,
+                    Key={"pk": {"S": "response-compression-key"}},
+                )
+
+                request = latest_request(captured_requests)
+                assert request.header("accept-encoding") == encoding.value
+
+                raw_response = latest_response(captured_responses)
+                if raw_response.header("content-encoding") is None:
+                    pytest.skip(
+                        "running Alternator did not return compressed responses; "
+                        "requires a build with scylladb/scylladb#27454 enabled"
+                    )
+
+                assert raw_response.header("content-encoding") == encoding.value
+                assert response["Item"]["data"]["S"] == _large_response_payload()
+            finally:
+                _delete_table(client, table_name)
+        finally:
+            close_client(client)

--- a/tests/integration/wire_capture.py
+++ b/tests/integration/wire_capture.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 
 @dataclass(frozen=True)
@@ -12,6 +12,17 @@ class CapturedRequest:
 
     headers: dict[str, str]
     body: bytes
+
+    def header(self, name: str) -> str | None:
+        """Return a case-insensitive header value."""
+        return self.headers.get(name.lower())
+
+
+@dataclass(frozen=True)
+class CapturedResponse:
+    """Raw response snapshot captured before botocore parsing."""
+
+    headers: dict[str, str]
 
     def header(self, name: str) -> str | None:
         """Return a case-insensitive header value."""
@@ -32,7 +43,7 @@ def body_as_bytes(body: object) -> bytes:
 
 def normalize_headers(headers: object) -> dict[str, str]:
     normalized: dict[str, str] = {}
-    for raw_key, raw_value in dict(headers).items():
+    for raw_key, raw_value in dict(cast(Any, headers)).items():
         key = raw_key.decode("utf-8") if isinstance(raw_key, bytes) else str(raw_key)
         value = (
             raw_value.decode("utf-8")
@@ -58,6 +69,24 @@ def capture_prepared_requests(client: Any) -> list[CapturedRequest]:  # noqa: AN
     return captured
 
 
+def capture_raw_responses(client: Any, operation_name: str) -> list[CapturedResponse]:  # noqa: ANN401 -- SDK clients are dynamically typed
+    captured: list[CapturedResponse] = []
+
+    def capture(
+        operation_model: Any,  # noqa: ANN401 -- botocore operation model
+        response_dict: dict[str, Any],
+        **kwargs: Any,  # noqa: ANN401 -- botocore event handler signature
+    ) -> None:
+        if getattr(operation_model, "name", None) != operation_name:
+            return
+        captured.append(
+            CapturedResponse(headers=normalize_headers(response_dict["headers"]))
+        )
+
+    client.meta.events.register_first("before-parse.dynamodb.*", capture)
+    return captured
+
+
 def inject_custom_headers(client: Any) -> None:  # noqa: ANN401 -- SDK clients are dynamically typed
     def add_headers(request: Any, **kwargs: Any) -> None:  # noqa: ANN401 -- botocore event handler signature
         request.headers["X-Keep-Me"] = "keep"
@@ -68,4 +97,9 @@ def inject_custom_headers(client: Any) -> None:  # noqa: ANN401 -- SDK clients a
 
 def latest_request(captured: list[CapturedRequest]) -> CapturedRequest:
     assert captured, "expected at least one prepared request to be captured"
+    return captured[-1]
+
+
+def latest_response(captured: list[CapturedResponse]) -> CapturedResponse:
+    assert captured, "expected at least one raw response to be captured"
     return captured[-1]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -14,6 +14,7 @@ from alternator.config import (
     KeyRouteAffinityConfig,
     KeyRouteAffinityMode,
     RequestCompressionConfig,
+    ResponseCompression,
     RetryConfig,
     TlsConfig,
     TlsSessionCacheConfig,
@@ -85,6 +86,7 @@ class TestAlternatorConfig:
         assert config.request_compression.algorithm == CompressionAlgorithm.NONE
         assert config.request_compression.min_size_bytes == 1024
         assert config.request_compression.gzip_level == 9
+        assert config.response_compression == ()
         assert config.header_optimization.enabled is False
         assert config.header_optimization.whitelist is None
         assert config.header_optimization.whitelist_callback is None
@@ -215,6 +217,57 @@ class TestAlternatorConfigBuilder:
         assert config.request_compression.algorithm == CompressionAlgorithm.GZIP
         assert config.request_compression.min_size_bytes == 2048
         assert config.request_compression.gzip_level == 1
+
+    def test_build_with_response_compression(self) -> None:
+        """Test building config with response compression."""
+        config = (
+            AlternatorConfigBuilder()
+            .with_seeds("localhost")
+            .with_port(8000)
+            .with_response_compression(
+                ResponseCompression.GZIP,
+                ResponseCompression.DEFLATE,
+            )
+            .build()
+        )
+        assert config.response_compression == (
+            ResponseCompression.GZIP,
+            ResponseCompression.DEFLATE,
+        )
+
+    def test_without_response_compression(self) -> None:
+        """Test disabling response compression."""
+        config = (
+            AlternatorConfigBuilder()
+            .with_seeds("localhost")
+            .with_port(8000)
+            .with_response_compression(ResponseCompression.GZIP)
+            .without_response_compression()
+            .build()
+        )
+        assert config.response_compression == ()
+
+    def test_with_response_compression_rejects_invalid_encoding(self) -> None:
+        """Test enabling response compression rejects invalid encodings."""
+        with pytest.raises(
+            ConfigurationError,
+            match="unsupported response compression encoding",
+        ):
+            AlternatorConfigBuilder().with_response_compression(
+                None,  # type: ignore[arg-type] -- validate runtime input
+            )
+
+    def test_invalid_response_compression_raises(self) -> None:
+        """Test invalid response compression encodings raise."""
+        with pytest.raises(
+            ConfigurationError,
+            match="unsupported response compression encoding",
+        ):
+            Config(
+                seed_hosts=["localhost"],
+                port=8000,
+                response_compression=("br",),  # type: ignore[arg-type] -- validate runtime input
+            )
 
     @pytest.mark.parametrize("gzip_level", [-1, 10])
     def test_invalid_compression_level_raises(self, gzip_level: int) -> None:

--- a/tests/unit/test_response_compression.py
+++ b/tests/unit/test_response_compression.py
@@ -1,0 +1,155 @@
+"""Tests for HTTP response compression handlers."""
+
+from __future__ import annotations
+
+import gzip
+import zlib
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from alternator.config import ResponseCompression
+from alternator.core.compression import (
+    create_response_compression_decode_handler,
+    create_response_compression_request_handler,
+)
+
+
+class TestResponseCompressionRequestHandler:
+    """Tests for adding Accept-Encoding to outgoing requests."""
+
+    def test_sets_accept_encoding_when_missing(self) -> None:
+        handler = create_response_compression_request_handler(
+            (ResponseCompression.GZIP, ResponseCompression.DEFLATE),
+        )
+        request = MagicMock()
+        request.headers = {}
+
+        handler(request)
+
+        assert request.headers["Accept-Encoding"] == "gzip, deflate"
+
+    def test_replaces_identity_accept_encoding(self) -> None:
+        handler = create_response_compression_request_handler(
+            (ResponseCompression.DEFLATE,),
+        )
+        request = MagicMock()
+        request.headers = {"Accept-Encoding": "identity"}
+
+        handler(request)
+
+        assert request.headers["Accept-Encoding"] == "deflate"
+
+    def test_preserves_custom_accept_encoding(self) -> None:
+        handler = create_response_compression_request_handler(
+            (ResponseCompression.GZIP,),
+        )
+        request = MagicMock()
+        request.headers = {"Accept-Encoding": "br"}
+
+        handler(request)
+
+        assert request.headers["Accept-Encoding"] == "br"
+
+    def test_deduplicates_encodings_in_order(self) -> None:
+        handler = create_response_compression_request_handler(
+            (
+                ResponseCompression.GZIP,
+                ResponseCompression.DEFLATE,
+                ResponseCompression.GZIP,
+            ),
+        )
+        request = MagicMock()
+        request.headers = {}
+
+        handler(request)
+
+        assert request.headers["Accept-Encoding"] == "gzip, deflate"
+
+
+class TestResponseCompressionDecodeHandler:
+    """Tests for decoding compressed HTTP responses before SDK parsing."""
+
+    def test_decodes_gzip_response(self) -> None:
+        body = b'{"TableNames":["a"]}'
+        response_dict = {
+            "headers": {
+                "Content-Encoding": "gzip",
+                "Content-Length": "99",
+            },
+            "body": gzip.compress(body),
+        }
+        handler = create_response_compression_decode_handler()
+
+        handler(response_dict=response_dict)
+
+        assert response_dict["body"] == body
+        assert "Content-Encoding" not in response_dict["headers"]
+        assert "Content-Length" not in response_dict["headers"]
+
+    def test_decodes_deflate_response(self) -> None:
+        body = b'{"TableNames":["a"]}'
+        response_dict = {
+            "headers": {
+                "content-encoding": "deflate",
+                "content-length": "99",
+            },
+            "body": zlib.compress(body),
+        }
+        handler = create_response_compression_decode_handler()
+
+        handler(response_dict=response_dict)
+
+        assert response_dict["body"] == body
+        assert "content-encoding" not in response_dict["headers"]
+        assert "content-length" not in response_dict["headers"]
+
+    def test_leaves_uncompressed_response_unchanged(self) -> None:
+        response_dict = {
+            "headers": {"Content-Length": "20"},
+            "body": b'{"TableNames":["a"]}',
+        }
+        handler = create_response_compression_decode_handler()
+
+        handler(response_dict=response_dict)
+
+        assert response_dict == {
+            "headers": {"Content-Length": "20"},
+            "body": b'{"TableNames":["a"]}',
+        }
+
+    def test_ignores_unsupported_content_encoding(self) -> None:
+        body = b"compressed"
+        response_dict: dict[str, Any] = {
+            "headers": {"Content-Encoding": "br"},
+            "body": body,
+        }
+        handler = create_response_compression_decode_handler()
+
+        handler(response_dict=response_dict)
+
+        assert response_dict["body"] == body
+        assert response_dict["headers"]["Content-Encoding"] == "br"
+
+    def test_invalid_gzip_response_raises(self) -> None:
+        handler = create_response_compression_decode_handler()
+
+        with pytest.raises(ValueError, match="decode gzip response"):
+            handler(
+                response_dict={
+                    "headers": {"Content-Encoding": "gzip"},
+                    "body": b"not-gzip",
+                }
+            )
+
+    def test_invalid_deflate_response_raises(self) -> None:
+        handler = create_response_compression_decode_handler()
+
+        with pytest.raises(ValueError, match="decode deflate response"):
+            handler(
+                response_dict={
+                    "headers": {"Content-Encoding": "deflate"},
+                    "body": b"not-deflate",
+                }
+            )


### PR DESCRIPTION
## Summary
- Add opt-in `ResponseCompression` API with gzip and deflate encodings, plus builder methods to enable or disable response compression.
- Send `Accept-Encoding` for configured encodings and decode gzip/deflate response bodies before boto3/aioboto3 parses DynamoDB JSON.
- Add unit and integration coverage, and document supported response encodings.

Closes #65

## Tests
- `make lint`
- `make test-unit`
- `make test-integration`

Note: the default CI Scylla image is `scylladb/scylla:2025.1`; the new response-compression integration cases skip there unless the server returns compressed responses.