### PR TITLE
Add Alternator user-agent replacement API

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ config = (
 | `max_pool_connections` | `int` | `200` | Max connections per host |
 | `timeouts` | `TimeoutConfig` | discovery 5s, connect 5s, read 30s | Discovery and SDK per-attempt timeouts |
 | `aws_region` | `str` | `"us-east-1"` | Region placeholder required by the SDK |
+| `user_agent` | str, callable, or `None` | `alternator-client-python/<version>` | Final User-Agent; `None` omits the wire header |
 | `sdk_config_customizer` | callable | `None` | Callback for safe SDK config kwargs adjustments |
 | `active_refresh_interval_ms` | `int` | `1000` | Node refresh interval when active |
 | `idle_refresh_interval_ms` | `int` | `60000` | Node refresh interval when idle |
@@ -740,27 +741,47 @@ config = Config(
 )
 ```
 
-Use `sdk_config_customizer` for supported SDK config kwargs that are not modeled
-directly:
+By default, Alternator sends `alternator-client-python/<version>` as the final
+wire `User-Agent` header. Pass `None` to omit the header:
 
 ```python
-from alternator import Config
-
-def customize_sdk(kwargs: dict[str, object]) -> None:
-    kwargs["user_agent_extra"] = "my-service"
+from alternator import Config, create_client
 
 config = Config(
-    seed_hosts=["node1"],
+    seed_hosts=["node1", "node2"],
     port=8000,
-    sdk_config_customizer=customize_sdk,
+    user_agent=None,
 )
+client = create_client(config)
 ```
 
-The client still owns the SDK config object and endpoint routing. Auth-managed
-signature settings are reapplied after the customizer. Python botocore does not
-expose direct knobs for max idle connections, max idle connections per host, or
-idle connection timeout; tune `max_pool_connections`, retries, and timeouts
-instead.
+Pass a string to `user_agent` when you need to set a final value:
+
+```python
+config = Config(
+    seed_hosts=["node1", "node2"],
+    port=8000,
+    user_agent="orders-service/1.0",
+)
+client = create_client(config)
+```
+
+Pass a callback when you need to wrap or add to the default
+`alternator-client-python/<version>` identity:
+
+```python
+config = Config(
+    seed_hosts=["node1", "node2"],
+    port=8000,
+    user_agent=lambda default: f"orders-service {default}",
+)
+client = create_client(config)
+```
+
+The client still owns the SDK config object, endpoint routing, and the final
+wire `User-Agent` header. Python botocore does not expose direct knobs for max
+idle connections, max idle connections per host, or idle connection timeout;
+tune `max_pool_connections`, retries, and timeouts instead.
 
 ## Production Recommendations
 

--- a/alternator/__init__.py
+++ b/alternator/__init__.py
@@ -110,6 +110,8 @@ from alternator.config import (
     TimeoutConfig,
     TlsConfig,
     TlsSessionCacheConfig,
+    UserAgent,
+    UserAgentCustomizer,
 )
 from alternator.core.routing_scope import (
     ClusterScope,
@@ -162,6 +164,8 @@ __all__ = [
     "TimeoutConfig",
     "TlsConfig",
     "TlsSessionCacheConfig",
+    "UserAgent",
+    "UserAgentCustomizer",
     # Exceptions
     "AlternatorError",
     "ConfigurationError",

--- a/alternator/async_client.py
+++ b/alternator/async_client.py
@@ -345,6 +345,7 @@ async def _create_async_client_with_manager(
 
     auth_enabled = apply_auth(auth, boto_kwargs)
     boto_config = _create_aio_config(config, auth_enabled=auth_enabled)
+    user_agent = getattr(boto_config, "user_agent", None)
 
     # Create aioboto3 session and client
     # Alternator doesn't use AWS regions, but boto3 requires one;
@@ -375,6 +376,7 @@ async def _create_async_client_with_manager(
             config,
             _create_async_affinity_node_computer(config, pk_cache),
             auth_enabled=auth_enabled,
+            user_agent=user_agent,
         )
 
         # Attach manager for cleanup reference

--- a/alternator/client.py
+++ b/alternator/client.py
@@ -227,6 +227,7 @@ def _create_client_with_manager(
     initial_endpoint = manager.next_node_uri()
     auth_enabled = apply_auth(auth, boto_kwargs)
     boto_config = _create_boto_config(config, auth_enabled=auth_enabled)
+    user_agent = cast("str | None", getattr(boto_config, "user_agent", None))
 
     # Create boto3 client
     # Alternator doesn't use AWS regions, but boto3 requires one;
@@ -246,6 +247,7 @@ def _create_client_with_manager(
         config,
         _create_affinity_node_computer(config, client),
         auth_enabled=auth_enabled,
+        user_agent=user_agent,
     )
 
     # Attach manager for cleanup reference
@@ -415,6 +417,7 @@ def _create_resource_with_manager(
     initial_endpoint = manager.next_node_uri()
     auth_enabled = apply_auth(auth, boto_kwargs)
     boto_config = _create_boto_config(config, auth_enabled=auth_enabled)
+    user_agent = cast("str | None", getattr(boto_config, "user_agent", None))
 
     # Create boto3 resource
     # Alternator doesn't use AWS regions, but boto3 requires one;
@@ -434,6 +437,7 @@ def _create_resource_with_manager(
         config,
         _create_affinity_node_computer(config, resource.meta.client),
         auth_enabled=auth_enabled,
+        user_agent=user_agent,
     )
 
     # Attach manager for cleanup reference

--- a/alternator/config.py
+++ b/alternator/config.py
@@ -11,6 +11,7 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import Any, Literal
 
+from alternator._version import __version__
 from alternator.core.routing_scope import ClusterScope, RoutingScope
 from alternator.exceptions import ConfigurationError
 
@@ -18,6 +19,9 @@ logger = logging.getLogger("alternator")
 
 SDKConfigCustomizer = Callable[[dict[str, Any]], None]
 SDKClientCert = str | tuple[str, str]
+UserAgentCustomizer = Callable[[str], str]
+UserAgent = str | UserAgentCustomizer
+DEFAULT_USER_AGENT = f"alternator-client-python/{__version__}"
 
 
 class CompressionAlgorithm(Enum):
@@ -398,6 +402,7 @@ class Config:
 
     # SDK settings
     aws_region: str = "us-east-1"
+    user_agent: UserAgent | None = DEFAULT_USER_AGENT
     sdk_config_customizer: SDKConfigCustomizer | None = None
 
     def __post_init__(self) -> None:
@@ -467,6 +472,7 @@ class AlternatorConfigBuilder:
         self._node_list_polling = NodeListPollingConfig()
         self._timeouts = TimeoutConfig()
         self._aws_region = "us-east-1"
+        self._user_agent: UserAgent | None = DEFAULT_USER_AGENT
         self._sdk_config_customizer: SDKConfigCustomizer | None = None
 
     def with_seeds(self, *hosts: str) -> AlternatorConfigBuilder:
@@ -614,6 +620,14 @@ class AlternatorConfigBuilder:
         self._aws_region = region_name
         return self
 
+    def with_user_agent(
+        self,
+        user_agent: UserAgent | None,
+    ) -> AlternatorConfigBuilder:
+        """Set a literal or callback-built Alternator User-Agent value."""
+        self._user_agent = user_agent
+        return self
+
     def with_sdk_config_customizer(
         self,
         customizer: SDKConfigCustomizer | None,
@@ -641,6 +655,7 @@ class AlternatorConfigBuilder:
             node_list_polling=self._node_list_polling,
             timeouts=self._timeouts,
             aws_region=self._aws_region,
+            user_agent=self._user_agent,
             sdk_config_customizer=self._sdk_config_customizer,
         )
 
@@ -660,7 +675,23 @@ def build_sdk_config_kwargs(config: Config) -> dict[str, Any]:
         kwargs["client_cert"] = config.tls.sdk_client_cert
     if config.sdk_config_customizer is not None:
         config.sdk_config_customizer(kwargs)
+    if config.user_agent is not None:
+        kwargs["user_agent"] = _resolve_user_agent(config.user_agent)
+    else:
+        kwargs.pop("user_agent", None)
     return kwargs
+
+
+def _resolve_user_agent(user_agent: UserAgent) -> str:
+    """Return the User-Agent produced from the default Alternator identity."""
+    resolved = (
+        user_agent if isinstance(user_agent, str) else user_agent(DEFAULT_USER_AGENT)
+    )
+    if not isinstance(resolved, str) or not resolved:
+        raise ConfigurationError(
+            "user_agent must be a non-empty string or callback returning one"
+        )
+    return resolved
 
 
 def _normalize_response_compression(

--- a/alternator/core/handlers.py
+++ b/alternator/core/handlers.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 from botocore.awsrequest import AWSPreparedRequest, AWSRequest
 from botocore.hooks import BaseEventHooks
 
-from alternator.config import CompressionAlgorithm
+from alternator.config import DEFAULT_USER_AGENT, CompressionAlgorithm
 from alternator.core.compression import (
     create_compression_handler,
     create_response_compression_decode_handler,
@@ -20,6 +20,7 @@ from alternator.core.compression import (
 from alternator.core.headers import (
     compute_header_whitelist,
     create_header_filter_handler,
+    create_user_agent_header_handler,
 )
 from alternator.core.query_plan import LazyQueryPlan
 from alternator.core.request import extract_operation_name, extract_request_params
@@ -52,6 +53,7 @@ def _register_alternator_handlers(
     | None = None,
     *,
     auth_enabled: bool = False,
+    user_agent: str | None = DEFAULT_USER_AGENT,
 ) -> None:
     """
     Register all Alternator event handlers on a boto3/aioboto3 client.
@@ -63,6 +65,7 @@ def _register_alternator_handlers(
         manager: Object with a ``nodes`` property returning a ``NodeList``
         config: Alternator configuration
         compute_affinity_node: Optional function to select a preferred affinity node
+        user_agent: Final Alternator User-Agent header value, or None to remove it
     """
     scheme = config.scheme
     port = config.port
@@ -210,6 +213,9 @@ def _register_alternator_handlers(
         )
         header_filter = create_header_filter_handler(whitelist)
         events.register("before-send.dynamodb.*", header_filter)
+
+    user_agent_handler = create_user_agent_header_handler(user_agent)
+    events.register_last("before-send.dynamodb.*", user_agent_handler)
 
 
 def _stable_seed(value: str) -> int:

--- a/alternator/core/headers.py
+++ b/alternator/core/headers.py
@@ -7,7 +7,10 @@ from typing import TYPE_CHECKING, Any
 
 from botocore.awsrequest import AWSPreparedRequest
 
-from alternator.config import HeaderWhitelistCallback, HeaderWhitelistContext
+from alternator.config import (
+    HeaderWhitelistCallback,
+    HeaderWhitelistContext,
+)
 
 if TYPE_CHECKING:
     from alternator.config import Config
@@ -118,3 +121,25 @@ def create_header_filter_handler(
             del request.headers[key]
 
     return filter_headers
+
+
+def create_user_agent_header_handler(user_agent: str | None) -> Callable[..., None]:
+    """
+    Create a botocore event handler for the final wire User-Agent header.
+
+    Botocore appends its own product token even when Config.user_agent is set.
+    When the Alternator user-agent is unset, remove the SDK-generated header.
+    """
+
+    def set_user_agent(request: AWSPreparedRequest, **kwargs: Any) -> None:  # noqa: ANN401 -- botocore event handler signature
+        """Set or remove the final User-Agent header value."""
+        if not hasattr(request, "headers"):
+            return
+        if user_agent is None:
+            for key in list(request.headers):
+                if key.lower() == "user-agent":
+                    del request.headers[key]
+            return
+        request.headers["User-Agent"] = user_agent
+
+    return set_user_agent

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -16,6 +16,7 @@ and intentionally deferred behavior.
 | Request compression | Supported | [#37](https://github.com/scylladb/alternator-client-python/issues/37) | Gzip request compression supports threshold and compression-level configuration. |
 | Response compression | Supported | [#65](https://github.com/scylladb/alternator-client-python/issues/65) | Gzip and deflate response decoding is disabled by default and enabled with `with_response_compression(...)`. |
 | Header optimization | Supported | [#37](https://github.com/scylladb/alternator-client-python/issues/37) | Required headers are preserved, with static and callback-computed whitelist additions. |
+| User-Agent replacement | Supported | [#61](https://github.com/scylladb/alternator-client-python/issues/61) | Requests do not preserve boto3/botocore user-agent tokens. By default, requests send the Alternator Python client identity; `Config.user_agent=None` removes the wire header; a string sets the final value; a callback can wrap/add to the default identity. |
 | TLS server trust | Supported | Existing API | System CA, custom CA, hostname verification, and trust-all mode exist. |
 | TLS client certificates | Supported | [#38](https://github.com/scylladb/alternator-client-python/issues/38) | mTLS certificate/key paths are loaded into discovery SSL contexts and SDK `client_cert` config. |
 | TLS key log file | Supported | [#38](https://github.com/scylladb/alternator-client-python/issues/38) | Debug-only key log file paths are applied to SSL contexts when supported by the runtime. |

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -16,6 +16,10 @@ authority for compatibility decisions.
 - Added topology validation helpers for configured datacenter/rack scopes.
 - Added transport configuration for SDK retries, connect/read timeouts,
   connection pool size, region placeholder, and SDK config customization.
+- Added Alternator-specific `User-Agent` control with `Config.user_agent`.
+  By default, requests send the Alternator Python client identity; callers can
+  pass `None` to remove the wire header, a string to set a final value, or a
+  callback to wrap/add to the default identity.
 - Added TLS client certificate, client key, and key log file settings.
 - Added configurable gzip compression level and callback-based header whitelist
   additions.

--- a/examples/capability_configuration.py
+++ b/examples/capability_configuration.py
@@ -9,7 +9,6 @@ connections. Copy the functions into application code as needed.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from alternator import (
     TLS,
@@ -74,13 +73,8 @@ def datacenter_only_config() -> Config:
     )
 
 
-def customize_sdk(kwargs: dict[str, Any]) -> None:
-    """Adjust supported SDK config kwargs without taking over endpoint routing."""
-    kwargs["user_agent_extra"] = "orders-service"
-
-
 def transport_config() -> Config:
-    """Configure retries, per-attempt timeouts, pool size, and SDK kwargs."""
+    """Configure retries, per-attempt timeouts, pool size, and User-Agent."""
     return (
         AlternatorConfigBuilder()
         .with_seeds("node1.example.com", "node2.example.com")
@@ -93,7 +87,7 @@ def transport_config() -> Config:
         )
         .with_pool_connections(300)
         .with_aws_region("us-east-1")
-        .with_sdk_config_customizer(customize_sdk)
+        .with_user_agent(lambda default: f"orders-service {default}")
         .build()
     )
 

--- a/tests/integration/test_header_optimization.py
+++ b/tests/integration/test_header_optimization.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
 from alternator import AlternatorConfigBuilder, Auth, close_client, create_client
@@ -22,14 +20,11 @@ pytestmark = [
 
 
 def _user_agent_config(user_agent_label: str) -> object:
-    def customize_sdk(kwargs: dict[str, Any]) -> None:
-        kwargs["user_agent_extra"] = user_agent_label
-
     return (
         AlternatorConfigBuilder()
         .with_seeds(SCYLLA_HOST)
         .with_port(SCYLLA_PORT)
-        .with_sdk_config_customizer(customize_sdk)
+        .with_user_agent(user_agent_label)
         .build()
     )
 
@@ -43,20 +38,17 @@ class TestHeaderOptimization:
             captured = capture_prepared_requests(client)
             client.list_tables()
             request = latest_request(captured)
-            assert "alternator-unfiltered" in (request.header("user-agent") or "")
+            assert request.header("user-agent") == "alternator-unfiltered"
         finally:
             close_client(client)
 
     def test_filters_wire_headers_and_preserves_auth(self) -> None:
-        def customize_sdk(kwargs: dict[str, Any]) -> None:
-            kwargs["user_agent_extra"] = "alternator-filtered"
-
         config = (
             AlternatorConfigBuilder()
             .with_seeds(SCYLLA_HOST)
             .with_port(SCYLLA_PORT)
             .with_header_optimization(whitelist={"X-Keep-Me"})
-            .with_sdk_config_customizer(customize_sdk)
+            .with_user_agent("alternator-filtered")
             .build()
         )
         client = create_client(
@@ -73,7 +65,7 @@ class TestHeaderOptimization:
             assert request.header("x-drop-me") is None
             assert request.header("authorization") is not None
             assert request.header("x-amz-date") is not None
-            assert request.header("user-agent") is None
+            assert request.header("user-agent") == "alternator-filtered"
         finally:
             close_client(client)
 

--- a/tests/integration/test_sdk_config.py
+++ b/tests/integration/test_sdk_config.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
 from alternator import (
@@ -24,9 +22,6 @@ pytestmark = [
 
 
 def _transport_config(user_agent_label: str) -> Config:
-    def customize_sdk(kwargs: dict[str, Any]) -> None:
-        kwargs["user_agent_extra"] = user_agent_label
-
     return Config(
         seed_hosts=[SCYLLA_HOST],
         port=SCYLLA_PORT,
@@ -39,7 +34,7 @@ def _transport_config(user_agent_label: str) -> Config:
             read_seconds=11.0,
         ),
         aws_region="us-west-2",
-        sdk_config_customizer=customize_sdk,
+        user_agent=user_agent_label,
     )
 
 
@@ -56,7 +51,7 @@ class TestSdkConfigPropagation:
             assert sdk_config.connect_timeout == 3.0
             assert sdk_config.read_timeout == 11.0
             assert sdk_config.retries["mode"] == RetryMode.STANDARD.value
-            assert "alternator-sdk-config-sync" in sdk_config.user_agent_extra
+            assert sdk_config.user_agent.startswith("alternator-sdk-config-sync")
             assert "TableNames" in client.list_tables()
         finally:
             close_client(client)
@@ -76,7 +71,7 @@ class TestAsyncSdkConfigPropagation:
             assert sdk_config.connect_timeout == 3.0
             assert sdk_config.read_timeout == 11.0
             assert sdk_config.retries["mode"] == RetryMode.STANDARD.value
-            assert "alternator-sdk-config-async" in sdk_config.user_agent_extra
+            assert sdk_config.user_agent.startswith("alternator-sdk-config-async")
             assert "TableNames" in await client.list_tables()
         finally:
             await close_async_client(client)

--- a/tests/unit/test_boto_config.py
+++ b/tests/unit/test_boto_config.py
@@ -7,7 +7,14 @@ import pytest
 from botocore import UNSIGNED
 
 from alternator.client import _create_boto_config
-from alternator.config import TLS, Config, RetryConfig, RetryMode, TimeoutConfig
+from alternator.config import (
+    DEFAULT_USER_AGENT,
+    TLS,
+    Config,
+    RetryConfig,
+    RetryMode,
+    TimeoutConfig,
+)
 
 
 class TestCreateBotoConfig:
@@ -83,18 +90,98 @@ class TestCreateBotoConfig:
         assert boto_config.connect_timeout == 2.5
         assert boto_config.read_timeout == 7.5
 
+    def test_default_user_agent_propagated(self) -> None:
+        """By default Alternator supplies its own SDK user-agent."""
+        config = self._make_config()
+        boto_config = _create_boto_config(config, auth_enabled=False)
+
+        assert boto_config.user_agent == DEFAULT_USER_AGENT
+        assert boto_config._user_provided_options["user_agent"] == DEFAULT_USER_AGENT
+
+    def test_user_agent_callback_can_append_to_current_value(self) -> None:
+        """Callback can keep the SDK user-agent and add Alternator identity."""
+        current = "Boto3/1.0 Botocore/1.0"
+
+        config = self._make_config(user_agent=lambda default: f"{current} {default}")
+        boto_config = _create_boto_config(config, auth_enabled=False)
+
+        assert boto_config.user_agent == f"Boto3/1.0 Botocore/1.0 {DEFAULT_USER_AGENT}"
+
+    def test_user_agent_callback_can_wrap_default_value(self) -> None:
+        """Callback can place the Alternator identity inside another string."""
+        config = self._make_config(user_agent=lambda default: f"service-a ({default})")
+        boto_config = _create_boto_config(config, auth_enabled=False)
+
+        assert boto_config.user_agent == f"service-a ({DEFAULT_USER_AGENT})"
+
+    def test_user_agent_callback_can_replace_default_value(self) -> None:
+        """Callback can replace the Alternator identity completely."""
+        config = self._make_config(user_agent=lambda _default: "orders-service/1.0")
+        boto_config = _create_boto_config(config, auth_enabled=False)
+
+        assert boto_config.user_agent == "orders-service/1.0"
+
+    def test_user_agent_string_replaces_default_value(self) -> None:
+        """A literal user-agent value replaces the Alternator identity."""
+        config = self._make_config(user_agent="orders-service/1.0")
+        boto_config = _create_boto_config(config, auth_enabled=False)
+
+        assert boto_config.user_agent == "orders-service/1.0"
+
+    def test_user_agent_callback_must_return_non_empty_string(self) -> None:
+        """Invalid user-agent callback results fail during SDK config creation."""
+        config = self._make_config(user_agent=lambda _default: "")
+
+        with pytest.raises(ValueError, match="user_agent"):
+            _create_boto_config(config, auth_enabled=False)
+
+    def test_user_agent_string_must_be_non_empty(self) -> None:
+        """Invalid literal user-agent values fail during SDK config creation."""
+        config = self._make_config(user_agent="")
+
+        with pytest.raises(ValueError, match="user_agent"):
+            _create_boto_config(config, auth_enabled=False)
+
     def test_sdk_config_customizer_can_adjust_safe_fields(self) -> None:
         """SDK config customizer can adjust generated config kwargs."""
 
         def customize(kwargs: dict[str, object]) -> None:
             kwargs["connect_timeout"] = 9.0
-            kwargs["user_agent_extra"] = "alternator-test"
 
         config = self._make_config(sdk_config_customizer=customize)
         boto_config = _create_boto_config(config, auth_enabled=False)
 
         assert boto_config.connect_timeout == 9.0
-        assert boto_config.user_agent_extra == "alternator-test"
+        assert boto_config.user_agent == DEFAULT_USER_AGENT
+
+    def test_user_agent_none_overrides_sdk_config_customizer(self) -> None:
+        """The typed user-agent API removes generic customizer user-agent output."""
+
+        def customize(kwargs: dict[str, object]) -> None:
+            kwargs["user_agent"] = "legacy-customizer/1.0"
+
+        config = self._make_config(
+            sdk_config_customizer=customize,
+            user_agent=None,
+        )
+        boto_config = _create_boto_config(config, auth_enabled=False)
+
+        assert boto_config.user_agent is None
+        assert "user_agent" not in boto_config._user_provided_options
+
+    def test_user_agent_callback_overrides_sdk_config_customizer(self) -> None:
+        """The typed user-agent API wins over the generic SDK customizer."""
+
+        def customize(kwargs: dict[str, object]) -> None:
+            kwargs["user_agent"] = "legacy-customizer/1.0"
+
+        config = self._make_config(
+            sdk_config_customizer=customize,
+            user_agent=lambda default: f"orders-service {default}",
+        )
+        boto_config = _create_boto_config(config, auth_enabled=False)
+
+        assert boto_config.user_agent == f"orders-service {DEFAULT_USER_AGENT}"
 
     def test_sdk_config_customizer_cannot_override_signature(self) -> None:
         """Auth-managed signature settings override customizer changes."""
@@ -175,6 +262,8 @@ class TestCreateAioConfig:
             "/path/to/client.crt",
             "/path/to/client.key",
         )
+        assert aio_config.user_agent == DEFAULT_USER_AGENT
+        assert aio_config._user_provided_options["user_agent"] == DEFAULT_USER_AGENT
 
 
 class TestUnsignedRequestNoAuthHeader:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -93,6 +93,7 @@ class TestAlternatorConfig:
         assert config.node_list_polling.active_interval_ms == 1000
         assert config.node_list_polling.idle_interval_ms == 60000
         assert config.aws_region == "us-east-1"
+        assert config.user_agent.startswith("alternator-client-python/")
         assert config.sdk_config_customizer is None
         assert isinstance(config.routing_scope, ClusterScope)
 
@@ -130,6 +131,8 @@ class TestDeprecatedConfigNames:
         assert alternator.Auth is not None
         assert alternator.Config is Config
         assert alternator.TLS is TLS
+        assert alternator.UserAgent is not None
+        assert alternator.UserAgentCustomizer is not None
 
 
 class TestAlternatorConfigBuilder:
@@ -397,11 +400,48 @@ class TestAlternatorConfigBuilder:
         )
         assert config.aws_region == "us-west-2"
 
+    def test_build_with_user_agent(self) -> None:
+        """Test building config with user-agent callback."""
+
+        def customize(default: str) -> str:
+            return f"service-a {default}"
+
+        config = (
+            AlternatorConfigBuilder()
+            .with_seeds("localhost")
+            .with_port(8000)
+            .with_user_agent(customize)
+            .build()
+        )
+        assert config.user_agent is customize
+
+    def test_build_with_user_agent_string(self) -> None:
+        """Test building config with literal user-agent replacement."""
+        config = (
+            AlternatorConfigBuilder()
+            .with_seeds("localhost")
+            .with_port(8000)
+            .with_user_agent("service-a/1.0")
+            .build()
+        )
+        assert config.user_agent == "service-a/1.0"
+
+    def test_build_with_user_agent_none(self) -> None:
+        """Test building config with explicit user-agent suppression."""
+        config = (
+            AlternatorConfigBuilder()
+            .with_seeds("localhost")
+            .with_port(8000)
+            .with_user_agent(None)
+            .build()
+        )
+        assert config.user_agent is None
+
     def test_build_with_sdk_config_customizer(self) -> None:
         """Test building config with SDK config customizer."""
 
         def customize(kwargs: dict[str, object]) -> None:
-            kwargs["user_agent_extra"] = "test"
+            kwargs["user_agent"] = "test"
 
         config = (
             AlternatorConfigBuilder()

--- a/tests/unit/test_headers.py
+++ b/tests/unit/test_headers.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from alternator.config import (
+    DEFAULT_USER_AGENT,
     CompressionAlgorithm,
     Config,
     HeaderOptimizationConfig,
@@ -19,6 +20,7 @@ from alternator.core.headers import (
     COMPRESSION_HEADERS,
     compute_header_whitelist,
     create_header_filter_handler,
+    create_user_agent_header_handler,
 )
 
 
@@ -229,6 +231,37 @@ class TestHeaderFilterHandler:
         handler(request, operation_name="PutItem", extra="value")
 
 
+class TestUserAgentHeaderHandler:
+    """Tests for create_user_agent_header_handler function."""
+
+    def test_replaces_existing_user_agent(self) -> None:
+        """Test the Alternator user-agent replaces an SDK-generated value."""
+        handler = create_user_agent_header_handler(DEFAULT_USER_AGENT)
+        request = MagicMock()
+        request.headers = {"User-Agent": "Boto3/1.0 Botocore/1.0"}
+
+        handler(request)
+
+        assert request.headers["User-Agent"] == DEFAULT_USER_AGENT
+
+    def test_removes_existing_user_agent_when_unset(self) -> None:
+        """Test an unset Alternator user-agent removes SDK-generated values."""
+        handler = create_user_agent_header_handler(None)
+        request = MagicMock()
+        request.headers = {"User-Agent": "Boto3/1.0 Botocore/1.0"}
+
+        handler(request)
+
+        assert "User-Agent" not in request.headers
+
+    def test_handles_missing_headers_attribute(self) -> None:
+        """Test handler handles request without headers attribute."""
+        handler = create_user_agent_header_handler(DEFAULT_USER_AGENT)
+        request = MagicMock(spec=[])
+
+        handler(request)
+
+
 class TestBaseRequiredHeaders:
     """Tests for BASE_REQUIRED_HEADERS constant."""
 
@@ -433,3 +466,77 @@ class TestHeaderFilterWithHandlerRegistration:
         assert "X-Dynamic-Header" in request.headers
         assert "X-Remove-Me" not in request.headers
         assert "Authorization" in request.headers
+
+    def test_default_user_agent_readded_after_header_filter(self) -> None:
+        """Test default Alternator user-agent is present even with filtering."""
+        config = _make_config()
+        manager = _make_manager()
+        events = MagicMock()
+
+        _register_alternator_handlers(events, manager, config, auth_enabled=False)
+
+        registered_handlers = {
+            call[0][1].__name__: call[0][1] for call in events.register.call_args_list
+        }
+        final_handlers = {
+            call[0][1].__name__: call[0][1]
+            for call in events.register_last.call_args_list
+        }
+
+        request = _make_request(include_auth_headers=False)
+        registered_handlers["filter_headers"](request)
+        assert "User-Agent" not in request.headers
+
+        final_handlers["set_user_agent"](request)
+        assert request.headers["User-Agent"] == DEFAULT_USER_AGENT
+
+    def test_user_agent_remains_absent_after_header_filter_when_unset(self) -> None:
+        """Test final User-Agent is absent when Alternator user-agent is None."""
+        config = _make_config()
+        manager = _make_manager()
+        events = MagicMock()
+
+        _register_alternator_handlers(
+            events,
+            manager,
+            config,
+            auth_enabled=False,
+            user_agent=None,
+        )
+
+        registered_handlers = {
+            call[0][1].__name__: call[0][1] for call in events.register.call_args_list
+        }
+        final_handlers = {
+            call[0][1].__name__: call[0][1]
+            for call in events.register_last.call_args_list
+        }
+
+        request = _make_request(include_auth_headers=False)
+        registered_handlers["filter_headers"](request)
+        assert "User-Agent" not in request.headers
+
+        final_handlers["set_user_agent"](request)
+        assert "User-Agent" not in request.headers
+
+    def test_custom_user_agent_used_by_registered_handler(self) -> None:
+        """Test handler registration uses the supplied Alternator user-agent."""
+        config = _make_config(optimize_headers=False)
+        manager = _make_manager()
+        events = MagicMock()
+
+        _register_alternator_handlers(
+            events,
+            manager,
+            config,
+            user_agent="custom-alternator/2.0",
+        )
+
+        final_handlers = {
+            call[0][1].__name__: call[0][1]
+            for call in events.register_last.call_args_list
+        }
+        request = _make_request(include_auth_headers=False)
+        final_handlers["set_user_agent"](request)
+
+        assert request.headers["User-Agent"] == "custom-alternator/2.0"

--- a/tests/unit/test_request_lifecycle.py
+++ b/tests/unit/test_request_lifecycle.py
@@ -11,7 +11,13 @@ from botocore.awsrequest import AWSPreparedRequest, AWSRequest
 from botocore.config import Config as BotoConfig
 from botocore.exceptions import EndpointConnectionError
 
-from alternator.config import CompressionAlgorithm, Config, RequestCompressionConfig
+from alternator.config import (
+    DEFAULT_USER_AGENT,
+    CompressionAlgorithm,
+    Config,
+    HeaderOptimizationConfig,
+    RequestCompressionConfig,
+)
 from alternator.core.handlers import _register_alternator_handlers
 from alternator.core.live_nodes import NodeList
 
@@ -23,6 +29,12 @@ class _StaticManager:
     @property
     def nodes(self) -> NodeList:
         return self._nodes
+
+
+def _header_text(value: object) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return str(value)
 
 
 def test_signed_request_url_and_compressed_body_are_final_before_signing() -> None:
@@ -79,6 +91,87 @@ def test_signed_request_url_and_compressed_body_are_final_before_signing() -> No
     assert seen["before_sign_body"].startswith(b"\x1f\x8b")
     assert seen["before_sign_headers"]["Content-Encoding"] == "gzip"
     assert seen["authorization"] is not None
+
+
+def test_unset_user_agent_removes_sdk_user_agent_before_send() -> None:
+    """Final request does not include User-Agent when Alternator value is unset."""
+    config = Config(
+        seed_hosts=["seed"],
+        port=8000,
+        header_optimization=HeaderOptimizationConfig(enabled=True),
+    )
+    client = boto3.client(
+        "dynamodb",
+        endpoint_url="http://seed:8000",
+        region_name="us-east-1",
+        config=BotoConfig(
+            signature_version=UNSIGNED,
+            user_agent="Boto3/1.0 Botocore/1.0",
+        ),
+    )
+    _register_alternator_handlers(
+        client.meta.events,
+        _StaticManager(("node-b",)),
+        config,
+        auth_enabled=False,
+        user_agent=None,
+    )
+    seen: dict[str, object] = {}
+
+    def capture_before_send(request: AWSPreparedRequest, **_: object) -> None:
+        seen["user_agent"] = request.headers.get("User-Agent")
+        raise RuntimeError("captured")
+
+    client.meta.events.register_last(
+        "before-send.dynamodb.ListTables", capture_before_send
+    )
+
+    with pytest.raises(RuntimeError, match="captured"):
+        client.list_tables()
+
+    assert seen["user_agent"] is None
+
+
+def test_configured_user_agent_replaces_sdk_user_agent_before_send() -> None:
+    """Final User-Agent contains only the configured Alternator value."""
+    config = Config(
+        seed_hosts=["seed"],
+        port=8000,
+        header_optimization=HeaderOptimizationConfig(enabled=True),
+        user_agent=DEFAULT_USER_AGENT,
+    )
+    client = boto3.client(
+        "dynamodb",
+        endpoint_url="http://seed:8000",
+        region_name="us-east-1",
+        config=BotoConfig(
+            signature_version=UNSIGNED,
+            user_agent="Boto3/1.0 Botocore/1.0",
+        ),
+    )
+    _register_alternator_handlers(
+        client.meta.events,
+        _StaticManager(("node-b",)),
+        config,
+        auth_enabled=False,
+        user_agent=DEFAULT_USER_AGENT,
+    )
+    seen: dict[str, str] = {}
+
+    def capture_before_send(request: AWSPreparedRequest, **_: object) -> None:
+        seen["user_agent"] = _header_text(request.headers.get("User-Agent"))
+        raise RuntimeError("captured")
+
+    client.meta.events.register_last(
+        "before-send.dynamodb.ListTables", capture_before_send
+    )
+
+    with pytest.raises(RuntimeError, match="captured"):
+        client.list_tables()
+
+    assert seen["user_agent"] == DEFAULT_USER_AGENT
+    assert "Boto3" not in seen["user_agent"]
+    assert "Botocore" not in seen["user_agent"]
 
 
 def test_sdk_retries_advance_shared_query_plan(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Summary:
- add `Config.user_agent` / `AlternatorConfigBuilder.with_user_agent(...)` API that accepts a default value, explicit `None`, a replacement string, or a callback
- send `alternator-client-python/<version>` by default, while `user_agent=None` removes the final wire User-Agent header including SDK-generated values
- pass `alternator-client-python/<version>` into the callback form and use the callback result as the final wire User-Agent
- replace final wire User-Agent header for sync, resource, and async clients after header filtering
- update docs, examples, and tests to use user_agent semantics instead of user_agent_extra or sdk_config_customizer

API examples:
```python
from alternator import Config, create_client

config = Config(
    seed_hosts=["node1", "node2"],
    port=8000,
)
client = create_client(config)  # User-Agent: alternator-client-python/<version>
```

```python
config = Config(
    seed_hosts=["node1", "node2"],
    port=8000,
    user_agent=None,
)
client = create_client(config)  # no User-Agent header
```

```python
config = Config(
    seed_hosts=["node1", "node2"],
    port=8000,
    user_agent="orders-service/1.0",
)
client = create_client(config)
```

```python
config = Config(
    seed_hosts=["node1", "node2"],
    port=8000,
    user_agent=lambda default: f"orders-service {default}",
)
client = create_client(config)
```

Tests:
- pytest tests/unit
- pytest tests/unit/test_config.py tests/unit/test_boto_config.py tests/unit/test_headers.py tests/unit/test_request_lifecycle.py
- ruff check alternator/client.py alternator/async_client.py alternator/config.py alternator/core/handlers.py alternator/core/headers.py alternator/__init__.py tests/unit/test_boto_config.py tests/unit/test_config.py tests/unit/test_headers.py tests/unit/test_request_lifecycle.py tests/integration/test_header_optimization.py tests/integration/test_sdk_config.py examples/capability_configuration.py
- git diff --check

Follow-up:
- #89 tracks dropping `sdk_config_customizer` in favor of specialized APIs

Closes #61