### PR TITLE
Enforce type annotations with Ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER_CACHE_FILE := $(DOCKER_CACHE_DIR)/scylla-image.tar
 CERT_CACHE_DIR := $(MAKEFILE_PATH)/.cert-cache
 CERT_DIR := $(MAKEFILE_PATH)/tests/scylla
 
-.PHONY: install verify build compile compile-test compile-demo test-unit test-integration test-integration-only test-demo test-demo-only test-all test lint lint-fix clean wait-for-alternator scylla-start scylla-stop scylla-kill scylla-rm docker-pull docker-cache-save docker-cache-load cert-cache-save cert-cache-load help
+.PHONY: install verify build compile compile-test compile-demo test-unit test-integration test-integration-only test-demo test-demo-only test-all test lint lint-types lint-fix clean wait-for-alternator scylla-start scylla-stop scylla-kill scylla-rm docker-pull docker-cache-save docker-cache-load cert-cache-save cert-cache-load help
 
 # Default target
 help:
@@ -26,6 +26,7 @@ help:
 	@echo "  test-all         - Run unit, integration, and demo tests"
 	@echo "  test             - Run all tests"
 	@echo "  lint             - Run linters (ruff + mypy)"
+	@echo "  lint-types       - Enforce type annotations with ruff"
 	@echo "  lint-fix         - Auto-fix linting issues with ruff"
 	@echo "  clean            - Remove build artifacts"
 	@echo "  scylla-start     - Start 3-node Scylla cluster via Docker"
@@ -95,7 +96,7 @@ test:
 		--cov=alternator --cov-report=xml --cov-report=term-missing
 
 # Run linters
-lint:
+lint: lint-types
 	uv run ruff check alternator/ tests/ examples/
 	uv run ruff format --check alternator/ tests/ examples/
 	$(MAKE) compile-demo
@@ -105,6 +106,9 @@ lint:
 		echo "ERROR: Found noqa/type: ignore comments without explanations. Add ' -- reason' after each."; \
 		exit 1; \
 	fi
+
+lint-types:
+	uv run ruff check --select ANN alternator/ tests/ examples/
 
 # Auto-fix linting issues
 lint-fix:


### PR DESCRIPTION
## Summary
- Add a dedicated `make lint-types` target for Ruff `ANN` annotation checks.
- Run `lint-types` as part of `make lint`, so CI explicitly enforces type annotations before the full lint suite.

## Testing
- `make verify`