### PR TITLE
Make client API boto3-like

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,13 @@ pip install alternator-client[async]
 
 ### Which API Should I Use?
 
-Use `alternator.client(...)` for the common synchronous case where a context
-manager can own the SDK client and background node refresh.
+Use `alternator.client("dynamodb", ...)` for the common synchronous case where
+a context manager can own the SDK client and background node refresh.
 
-Use `create_client` / `close_client` when the SDK client must be created in one
-place and closed elsewhere. Use `create_resource` / `close_resource` for the
-boto3 table-oriented resource interface.
+Use `alternator.resource("dynamodb", ...)` for the boto3 table-oriented
+resource interface.
 
-Use `Helper` or `AsyncHelper` when one object should own client/resource
+Use `Session` or `AsyncSession` when one object should own client/resource
 lifecycle and expose topology diagnostics such as node refresh, node inspection,
 routing validation, and partition-key cache inspection.
 
@@ -54,6 +53,7 @@ port.
 import alternator
 
 with alternator.client(
+    "dynamodb",
     seeds=["192.168.1.1", "192.168.1.2"],
     port=8000,
 ) as client:
@@ -62,7 +62,8 @@ with alternator.client(
 ```
 
 ```python
-from alternator import Config, AlternatorClient
+import alternator
+from alternator import Config
 
 # Configure the client
 config = Config(
@@ -70,8 +71,7 @@ config = Config(
     port=8000,
 )
 
-# Use as a context manager (recommended)
-with AlternatorClient(config) as client:
+with alternator.client("dynamodb", cluster_config=config) as client:
     # Use like a normal boto3 DynamoDB client
     response = client.list_tables()
     print(response["TableNames"])
@@ -91,7 +91,7 @@ with AlternatorClient(config) as client:
 ```python
 import asyncio
 from alternator import Config
-from alternator.async_client import AsyncAlternatorClient
+from alternator.async_client import AsyncSession
 
 async def main():
     config = Config(
@@ -99,7 +99,9 @@ async def main():
         port=8000,
     )
 
-    async with AsyncAlternatorClient(config) as client:
+    async with AsyncSession(config) as session:
+        client = await session.client("dynamodb")
+
         # Use like a normal aioboto3 DynamoDB client
         response = await client.list_tables()
         print(response["TableNames"])
@@ -107,45 +109,44 @@ async def main():
 asyncio.run(main())
 ```
 
-### Helper Facade
+### Session Facade
 
-Use `Helper` when you need explicit lifecycle control or diagnostics in addition
+Use `Session` when you need explicit lifecycle control or diagnostics in addition
 to standard boto3 clients and resources.
 
 ```python
-from alternator import Config, Helper
+from alternator import Config, Session
 
 config = Config(seed_hosts=["192.168.1.1", "192.168.1.2"], port=8000)
 
-with Helper(config) as helper:
-    client = helper.client()
-    resource = helper.resource()
+with Session(config) as session:
+    client = session.client("dynamodb")
+    resource = session.resource("dynamodb")
 
-    helper.update_live_nodes()
-    print(helper.get_nodes())
-    print(helper.next_node())
+    session.refresh_nodes()
+    print(session.nodes)
 
     client.list_tables()
     resource.Table("my_table").get_item(Key={"pk": "user123"})
 ```
 
-Async code can use `AsyncHelper`:
+Async code can use `AsyncSession`:
 
 ```python
 from alternator import Config
-from alternator.async_client import AsyncHelper
+from alternator.async_client import AsyncSession
 
 config = Config(seed_hosts=["192.168.1.1"], port=8000)
 
-async with AsyncHelper(config) as helper:
-    client = await helper.client()
-    await helper.update_live_nodes()
-    print(helper.get_nodes())
+async with AsyncSession(config) as session:
+    client = await session.client("dynamodb")
+    await session.refresh_nodes()
+    print(session.nodes)
     await client.list_tables()
 ```
 
-`get_active_nodes()` currently returns the live-node list, and
-`get_quarantined_nodes()` returns an empty list because node health and
+`active_nodes` currently returns the live-node list, and
+`quarantined_nodes` returns an empty list because node health and
 quarantine behavior are intentionally deferred.
 
 ## Configuration
@@ -224,17 +225,23 @@ supports static credentials only; AWS SDK environment, profile, and provider-cha
 credentials are not used for Alternator auth.
 
 ```python
-from alternator import Auth, AlternatorClient, Config
+import alternator
+from alternator import Auth, Config
 
 config = Config(seed_hosts=["node1"], port=8000)
 
 # Default: unsigned requests
-with AlternatorClient(config, auth=Auth.disabled()) as client:
+with alternator.client(
+    "dynamodb",
+    cluster_config=config,
+    auth=Auth.disabled(),
+) as client:
     client.list_tables()
 
 # Signed requests with static Alternator credentials
-with AlternatorClient(
-    config,
+with alternator.client(
+    "dynamodb",
+    cluster_config=config,
     auth=Auth.static_credentials("alternator", "secret"),
 ) as client:
     client.list_tables()
@@ -254,6 +261,7 @@ import boto3
 import alternator
 
 with alternator.client(
+    "dynamodb",
     seeds=["node1.example.com", "node2.example.com"],
     port=8000,
 ) as alternator_client:
@@ -331,10 +339,10 @@ rack_then_datacenter_then_cluster = RackScope(
 )
 ```
 
-`Helper.check_rack_and_datacenter_set_correctly()` validates the configured
+`Session.validate_scope()` validates the configured
 scope by querying `/localnodes` with the configured datacenter and rack filters
 without replacing the helper's current live-node list.
-`AsyncHelper` exposes the same validation methods as awaitable methods.
+`AsyncSession` exposes the same validation methods as awaitable methods.
 
 ## Key Affinity (LWT Optimization)
 
@@ -514,8 +522,8 @@ headers exposed in `context.required_headers`.
 ## Error Handling
 
 ```python
+import alternator
 from alternator import (
-    AlternatorClient,
     Config,
     AlternatorError,
     NoNodesAvailableError,
@@ -528,7 +536,7 @@ except ConfigurationError as e:
     print(f"Invalid configuration: {e}")
 
 try:
-    with AlternatorClient(config) as client:
+    with alternator.client("dynamodb", cluster_config=config) as client:
         client.list_tables()
 except NoNodesAvailableError as e:
     print(f"No nodes available: {e}")
@@ -556,32 +564,32 @@ Log levels:
 
 ## DynamoDB Resource Interface
 
-For table-oriented operations, use `AlternatorResource` which wraps boto3's DynamoDB resource:
+For table-oriented operations, use `alternator.resource("dynamodb", ...)` which wraps boto3's DynamoDB resource:
 
 ```python
-from alternator import Config, AlternatorResource
+import alternator
+from alternator import Config
 
 config = Config(seed_hosts=["192.168.1.1"], port=8000)
 
-with AlternatorResource(config) as resource:
+with alternator.resource("dynamodb", cluster_config=config) as resource:
     table = resource.Table("my_table")
     table.put_item(Item={"pk": "user123", "data": "hello"})
     response = table.get_item(Key={"pk": "user123"})
 ```
 
-You can also use the factory function:
+You can also use `Session` when one object should own both lifecycle and
+diagnostics:
 
 ```python
-from alternator import create_resource, close_resource, Config
+from alternator import Config, Session
 
 config = Config(seed_hosts=["node1"], port=8000)
-resource = create_resource(config)
 
-try:
+with Session(config) as session:
+    resource = session.resource("dynamodb")
     table = resource.Table("my_table")
     table.scan()
-finally:
-    close_resource(resource)
 ```
 
 ## Vector Search (ScyllaDB Extension)
@@ -686,30 +694,32 @@ for item in result["Items"]:
 If you prefer not to use context managers:
 
 ```python
-from alternator import create_client, close_client, Config
+from alternator import Config, Session
 
 config = Config(seed_hosts=["node1"], port=8000)
-client = create_client(config)
 
+session = Session(config)
 try:
+    client = session.client("dynamodb")
     client.list_tables()
 finally:
-    close_client(client)  # Stop background refresh thread
+    session.stop()  # Stop background refresh thread and close created clients
 ```
 
 Async equivalent:
 
 ```python
 from alternator import Config
-from alternator.async_client import create_async_client, close_async_client
+from alternator.async_client import AsyncSession
 
 config = Config(seed_hosts=["node1"], port=8000)
-client = await create_async_client(config)
 
+session = AsyncSession(config)
 try:
+    client = await session.client("dynamodb")
     await client.list_tables()
 finally:
-    await close_async_client(client)
+    await session.stop()
 ```
 
 ## Transport Configuration
@@ -744,14 +754,16 @@ By default, Alternator sends `alternator-client-python/<version>` as the final
 wire `User-Agent` header. Pass `None` to omit the header:
 
 ```python
-from alternator import Config, create_client
+import alternator
+from alternator import Config
 
 config = Config(
     seed_hosts=["node1", "node2"],
     port=8000,
     user_agent=None,
 )
-client = create_client(config)
+with alternator.client("dynamodb", cluster_config=config) as client:
+    client.list_tables()
 ```
 
 Pass a string to `user_agent` when you need to set a final value:
@@ -762,7 +774,8 @@ config = Config(
     port=8000,
     user_agent="orders-service/1.0",
 )
-client = create_client(config)
+with alternator.client("dynamodb", cluster_config=config) as client:
+    client.list_tables()
 ```
 
 Pass a callback when you need to wrap or add to the default
@@ -774,7 +787,8 @@ config = Config(
     port=8000,
     user_agent=lambda default: f"orders-service {default}",
 )
-client = create_client(config)
+with alternator.client("dynamodb", cluster_config=config) as client:
+    client.list_tables()
 ```
 
 The client still owns the SDK config object, endpoint routing, and the final
@@ -796,9 +810,9 @@ instead.
 
 ## Thread Safety
 
-Sync clients created by `create_client` / `AlternatorClient` are thread-safe: the underlying node selection, round-robin counter, and node list updates are all protected by locks. You can safely share a single client across multiple threads.
+Sync clients created by `alternator.client("dynamodb", ...)` or `Session.client("dynamodb")` are thread-safe: the underlying node selection, round-robin counter, and node list updates are all protected by locks. You can safely share a single client across multiple threads.
 
-Async clients created by `create_async_client` / `AsyncAlternatorClient` are safe to use from multiple concurrent coroutines within the same event loop. Do not share an async client across different event loops.
+Async clients created by `AsyncSession.client("dynamodb")` are safe to use from multiple concurrent coroutines within the same event loop. Do not share an async client across different event loops.
 
 ## Known Limitations
 
@@ -810,7 +824,7 @@ Async clients created by `create_async_client` / `AsyncAlternatorClient` are saf
 - **mTLS Integration Fixtures**: The local Scylla fixture in this repository does not require client certificate authentication, so automated tests cover configuration propagation and SSL context setup rather than a full mutual-TLS handshake.
 - **Async Key Affinity**: For async clients, partition key auto-discovery happens asynchronously. The first request for an unknown table will use round-robin routing while discovery runs in the background. Subsequent requests will use affinity. Preloading via `table_pk_map` avoids this initial miss.
 - **Batch Operations**: `BatchWriteItem` key affinity in `ANY_WRITE` mode uses preferred-node voting across eligible put/delete entries. Ties, missing partition-key metadata, unsupported key values, no active nodes, or no eligible votes fall back to normal routing. Batches are not split by affinity target.
-- **Node Health**: Node health, quarantine behavior, decommission handling, and dead-node handling are planning-only. `get_quarantined_nodes()` returns an empty list until a future implementation is explicitly added.
+- **Node Health**: Node health, quarantine behavior, decommission handling, and dead-node handling are planning-only. `Session.quarantined_nodes` returns an empty list until a future implementation is explicitly added.
 
 ## Examples
 

--- a/alternator/__init__.py
+++ b/alternator/__init__.py
@@ -8,14 +8,13 @@ Quick Start
 -----------
 Synchronous usage::
 
-    from alternator import Config, AlternatorClient
+    import alternator
 
-    config = Config(
-        seed_hosts=["192.168.1.1", "192.168.1.2"],
+    with alternator.client(
+        "dynamodb",
+        seeds=["192.168.1.1", "192.168.1.2"],
         port=8000,
-    )
-
-    with AlternatorClient(config) as client:
+    ) as client:
         response = client.list_tables()
         client.put_item(
             TableName="my_table",
@@ -25,11 +24,12 @@ Synchronous usage::
 Asynchronous usage::
 
     from alternator import Config
-    from alternator.async_client import AsyncAlternatorClient
+    from alternator.async_client import AsyncSession
 
     config = Config(seed_hosts=["192.168.1.1"], port=8000)
 
-    async with AsyncAlternatorClient(config) as client:
+    async with AsyncSession(config) as session:
+        client = await session.client("dynamodb")
         response = await client.list_tables()
 
 Configuration
@@ -50,9 +50,10 @@ for a fluent builder pattern::
 
 Key Classes
 -----------
-- ``AlternatorClient``: Sync context manager for load-balanced connections
-- ``Helper``: Sync lifecycle and diagnostics facade
-- ``AsyncHelper``: Async lifecycle and diagnostics facade
+- ``client("dynamodb", ...)``: Sync context manager for load-balanced connections
+- ``resource("dynamodb", ...)``: Sync context manager for DynamoDB resources
+- ``Session``: Sync lifecycle and diagnostics facade
+- ``AsyncSession``: Async lifecycle and diagnostics facade
 - ``AsyncAlternatorClient``: Async context manager for load-balanced connections
 - ``Config``: Main configuration dataclass
 - ``Auth``: Explicit disabled/static-credentials auth settings
@@ -82,12 +83,13 @@ from alternator._version import __version__
 from alternator.client import (
     AlternatorClient,
     AlternatorResource,
-    Helper,
+    Session,
     client,
     close_client,
     close_resource,
     create_client,
     create_resource,
+    resource,
 )
 from alternator.config import (
     TLS,
@@ -131,14 +133,15 @@ __all__ = [
     # Sync Client
     "AlternatorClient",
     "AlternatorResource",
-    "Helper",
+    "Session",
     "client",
     "close_client",
     "close_resource",
     "create_client",
     "create_resource",
+    "resource",
     # Async Client (requires [async] extra)
-    "AsyncHelper",
+    "AsyncSession",
     "AsyncAlternatorClient",
     "close_async_client",
     "create_async_client",
@@ -181,7 +184,7 @@ __all__ = [
 def __getattr__(name: str) -> object:
     """Lazy import async client components to avoid requiring async dependencies."""
     if name in (
-        "AsyncHelper",
+        "AsyncSession",
         "AsyncAlternatorClient",
         "close_async_client",
         "create_async_client",

--- a/alternator/async_client.py
+++ b/alternator/async_client.py
@@ -6,9 +6,9 @@ import asyncio
 import contextlib
 import inspect
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from alternator._constants import (
     MANAGER_ATTR,
@@ -20,6 +20,11 @@ from alternator._http import (
     AsyncNodeFetcher,
     create_async_http_fetcher,
     create_ssl_context,
+)
+from alternator.client import (
+    DEFAULT_PORT,
+    _config_from_client_args,
+    _validate_service_name,
 )
 from alternator.config import KeyRouteAffinityMode, build_sdk_config_kwargs
 from alternator.core.auth import apply_auth
@@ -469,28 +474,36 @@ async def close_async_client(client: AsyncDynamoDBClient) -> None:
         await client.__aexit__(None, None, None)
 
 
-class AsyncHelper:
+class AsyncSession:
     """
-    Async facade for Alternator client lifecycle and diagnostics.
+    Async session for Alternator client lifecycle and diagnostics.
 
-    The helper owns one async live-node manager and can create standard
+    The session owns one async live-node manager and can create standard
     aioboto3 DynamoDB clients that share that discovery state.
     """
 
     def __init__(
         self,
-        config: Config,
+        cluster_config: Config | None = None,
         *,
+        seeds: Sequence[str] | None = None,
+        port: int = DEFAULT_PORT,
+        scheme: Literal["http", "https"] = "http",
         auth: Auth | None = None,
         **boto_kwargs: Any,  # noqa: ANN401 -- aioboto3 kwargs are untyped
     ) -> None:
-        self._config = config
+        self._config = _config_from_client_args(
+            cluster_config,
+            seeds=seeds,
+            port=port,
+            scheme=scheme,
+        )
         self._auth = auth
         self._boto_kwargs = dict(boto_kwargs)
         self._manager: AsyncLiveNodesManager | None = None
         self._clients: list[AsyncDynamoDBClient] = []
 
-    async def __aenter__(self) -> AsyncHelper:
+    async def __aenter__(self) -> AsyncSession:
         await self.start()
         return self
 
@@ -504,28 +517,32 @@ class AsyncHelper:
 
     @property
     def config(self) -> Config:
-        """Return this helper's configuration."""
+        """Return this session's configuration."""
         return self._config
 
     def update(
         self,
-        config: Config | None = None,
+        cluster_config: Config | None = None,
         *,
         auth: Auth | None | object = _AUTH_UNSET,
         **boto_kwargs: Any,  # noqa: ANN401 -- aioboto3 kwargs are untyped
-    ) -> AsyncHelper:
-        """Return a new async helper with updated config, auth, or boto kwargs."""
+    ) -> AsyncSession:
+        """Return a new async session with updated config, auth, or boto kwargs."""
         next_auth = self._auth if auth is _AUTH_UNSET else cast("Auth | None", auth)
         next_kwargs = {**self._boto_kwargs, **boto_kwargs}
-        return type(self)(config or self._config, auth=next_auth, **next_kwargs)
+        return type(self)(
+            cluster_config or self._config,
+            auth=next_auth,
+            **next_kwargs,
+        )
 
-    async def start(self) -> AsyncHelper:
+    async def start(self) -> AsyncSession:
         """Start background node discovery."""
         await (await self._ensure_manager()).start()
         return self
 
     async def stop(self) -> None:
-        """Stop background node discovery and close helper-created clients."""
+        """Stop background node discovery and close session-created clients."""
         for created_client in list(self._clients):
             with contextlib.suppress(Exception):
                 await close_async_client(created_client)
@@ -537,9 +554,11 @@ class AsyncHelper:
 
     async def client(
         self,
+        service_name: str,
         **boto_kwargs: Any,  # noqa: ANN401 -- aioboto3 kwargs are untyped
     ) -> AsyncDynamoDBClient:
-        """Create a standard aioboto3 DynamoDB client using this helper."""
+        """Create a standard aioboto3 DynamoDB client using this session."""
+        _validate_service_name(service_name)
         manager = await self._ensure_manager()
         await manager.start()
         client = await _create_async_client_with_manager(
@@ -552,29 +571,28 @@ class AsyncHelper:
         self._clients.append(client)
         return client
 
-    async def update_live_nodes(self) -> bool:
+    async def refresh_nodes(self) -> bool:
         """Refresh the live-node list immediately."""
         return await (await self._ensure_manager()).refresh_nodes()
 
-    async def next_node(self) -> str | None:
-        """Return the next live node selected for diagnostics."""
-        return (await self._ensure_manager()).next_node()
-
-    def get_nodes(self) -> list[str]:
+    @property
+    def nodes(self) -> list[str]:
         """Return the current live-node hostnames."""
         if self._manager is None:
             return []
         return list(self._manager.nodes.nodes)
 
-    def get_active_nodes(self) -> list[str]:
+    @property
+    def active_nodes(self) -> list[str]:
         """Return active nodes; currently this is the live-node list."""
-        return self.get_nodes()
+        return self.nodes
 
-    def get_quarantined_nodes(self) -> list[str]:
+    @property
+    def quarantined_nodes(self) -> list[str]:
         """Return quarantined nodes; node quarantine is not implemented."""
         return []
 
-    async def check_rack_and_datacenter_set_correctly(self) -> bool:
+    async def validate_scope(self) -> bool:
         """Validate configured rack/datacenter scope without changing state."""
         manager = self._manager
         if manager is not None:
@@ -586,7 +604,7 @@ class AsyncHelper:
         finally:
             await _close_async_manager(manager)
 
-    async def check_rack_datacenter_feature_supported(self) -> bool:
+    async def supports_topology_filters(self) -> bool:
         """Report whether scoped rack/datacenter discovery appears supported."""
         manager = self._manager
         if manager is not None:
@@ -598,7 +616,7 @@ class AsyncHelper:
         finally:
             await _close_async_manager(manager)
 
-    async def get_partition_key_name(self, table_name: str) -> str | None:
+    async def partition_key_for(self, table_name: str) -> str | None:
         """Return a known partition key name for diagnostics."""
         configured = self._config.key_affinity.table_pk_attributes.get(table_name)
         if configured is not None:

--- a/alternator/client.py
+++ b/alternator/client.py
@@ -337,9 +337,45 @@ def _validate_host_only_seeds(seed_hosts: Sequence[str]) -> None:
         )
 
 
-def client(
-    seeds: Sequence[str] | Config | None = None,
+def _validate_service_name(service_name: str) -> None:
+    """Validate the boto3-style service name accepted by this client."""
+    if service_name != "dynamodb":
+        raise ConfigurationError(
+            f"alternator only supports the 'dynamodb' service, got {service_name!r}"
+        )
+
+
+def _config_from_client_args(
+    cluster_config: Config | None,
     *,
+    seeds: Sequence[str] | None,
+    port: int,
+    scheme: Literal["http", "https"],
+) -> Config:
+    """Build or validate an Alternator config from boto3-style factory args."""
+    if cluster_config is not None:
+        if seeds is not None or port != DEFAULT_PORT or scheme != "http":
+            raise ConfigurationError(
+                "Do not combine cluster_config with seeds, port, or scheme"
+            )
+        config = cluster_config
+    else:
+        if seeds is None:
+            raise ConfigurationError(
+                "seeds is required when cluster_config is not provided"
+            )
+        _validate_host_only_seeds(seeds)
+        config = Config(seed_hosts=tuple(seeds), port=port, scheme=scheme)
+
+    _validate_host_only_seeds(config.seed_hosts)
+    return config
+
+
+def client(
+    service_name: str,
+    *,
+    cluster_config: Config | None = None,
+    seeds: Sequence[str] | None = None,
     port: int = DEFAULT_PORT,
     scheme: Literal["http", "https"] = "http",
     auth: Auth | None = None,
@@ -348,23 +384,44 @@ def client(
     """
     Create a context-manager friendly Alternator client.
 
-    This is a convenience alias for the common case. Seeds are host names or
-    IP addresses only; provide the shared Alternator port with ``port``.
+    Mirrors ``boto3.client("dynamodb", ...)`` while adding Alternator cluster
+    discovery options. Seeds are host names or IP addresses only; provide the
+    shared Alternator port with ``port``.
     """
-    if isinstance(seeds, Config):
-        if port != DEFAULT_PORT or scheme != "http":
-            raise ConfigurationError(
-                "Do not combine a Config object with port or scheme overrides"
-            )
-        config = seeds
-    else:
-        if seeds is None:
-            raise ConfigurationError("seeds is required when Config is not provided")
-        _validate_host_only_seeds(seeds)
-        config = Config(seed_hosts=tuple(seeds), port=port, scheme=scheme)
-
-    _validate_host_only_seeds(config.seed_hosts)
+    _validate_service_name(service_name)
+    config = _config_from_client_args(
+        cluster_config,
+        seeds=seeds,
+        port=port,
+        scheme=scheme,
+    )
     return AlternatorClient(config, auth=auth, **boto_kwargs)
+
+
+def resource(
+    service_name: str,
+    *,
+    cluster_config: Config | None = None,
+    seeds: Sequence[str] | None = None,
+    port: int = DEFAULT_PORT,
+    scheme: Literal["http", "https"] = "http",
+    auth: Auth | None = None,
+    **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
+) -> AlternatorResource:
+    """
+    Create a context-manager friendly Alternator resource.
+
+    Mirrors ``boto3.resource("dynamodb", ...)`` for callers that use boto3's
+    high-level DynamoDB table API.
+    """
+    _validate_service_name(service_name)
+    config = _config_from_client_args(
+        cluster_config,
+        seeds=seeds,
+        port=port,
+        scheme=scheme,
+    )
+    return AlternatorResource(config, auth=auth, **boto_kwargs)
 
 
 def create_resource(
@@ -490,29 +547,37 @@ def close_client(client: DynamoDBClient | DynamoDBServiceResource) -> None:
         service_client_close()
 
 
-class Helper:
+class Session:
     """
-    Public facade for Alternator client lifecycle and diagnostics.
+    Public session for Alternator client lifecycle and diagnostics.
 
-    The helper owns one live-node manager and can create standard boto3
+    The session owns one live-node manager and can create standard boto3
     DynamoDB clients and resources that share that discovery state.
     """
 
     def __init__(
         self,
-        config: Config,
+        cluster_config: Config | None = None,
         *,
+        seeds: Sequence[str] | None = None,
+        port: int = DEFAULT_PORT,
+        scheme: Literal["http", "https"] = "http",
         auth: Auth | None = None,
         **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
     ) -> None:
-        self._config = config
+        self._config = _config_from_client_args(
+            cluster_config,
+            seeds=seeds,
+            port=port,
+            scheme=scheme,
+        )
         self._auth = auth
         self._boto_kwargs = dict(boto_kwargs)
         self._manager: SyncLiveNodesManager | None = None
         self._manager_finalizer: Any | None = None
         self._clients: list[DynamoDBClient | DynamoDBServiceResource] = []
 
-    def __enter__(self) -> Helper:
+    def __enter__(self) -> Session:
         self.start()
         return self
 
@@ -526,28 +591,32 @@ class Helper:
 
     @property
     def config(self) -> Config:
-        """Return this helper's configuration."""
+        """Return this session's configuration."""
         return self._config
 
     def update(
         self,
-        config: Config | None = None,
+        cluster_config: Config | None = None,
         *,
         auth: Auth | None | object = _AUTH_UNSET,
         **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
-    ) -> Helper:
-        """Return a new helper with updated config, auth, or boto kwargs."""
+    ) -> Session:
+        """Return a new session with updated config, auth, or boto kwargs."""
         next_auth = self._auth if auth is _AUTH_UNSET else cast("Auth | None", auth)
         next_kwargs = {**self._boto_kwargs, **boto_kwargs}
-        return type(self)(config or self._config, auth=next_auth, **next_kwargs)
+        return type(self)(
+            cluster_config or self._config,
+            auth=next_auth,
+            **next_kwargs,
+        )
 
-    def start(self) -> Helper:
+    def start(self) -> Session:
         """Start background node discovery."""
         self._ensure_manager().start()
         return self
 
     def stop(self) -> None:
-        """Stop background node discovery and detach helper-created clients."""
+        """Stop background node discovery and detach session-created clients."""
         for created_client in list(self._clients):
             with contextlib.suppress(Exception):
                 close_client(created_client)
@@ -564,9 +633,11 @@ class Helper:
 
     def client(
         self,
+        service_name: str,
         **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
     ) -> DynamoDBClient:
-        """Create a standard boto3 DynamoDB client using this helper."""
+        """Create a standard boto3 DynamoDB client using this session."""
+        _validate_service_name(service_name)
         manager = self._ensure_manager()
         manager.start()
         client = _create_client_with_manager(
@@ -581,9 +652,11 @@ class Helper:
 
     def resource(
         self,
+        service_name: str,
         **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
     ) -> DynamoDBServiceResource:
-        """Create a standard boto3 DynamoDB resource using this helper."""
+        """Create a standard boto3 DynamoDB resource using this session."""
+        _validate_service_name(service_name)
         manager = self._ensure_manager()
         manager.start()
         resource = _create_resource_with_manager(
@@ -596,29 +669,28 @@ class Helper:
         self._clients.append(resource)
         return resource
 
-    def update_live_nodes(self) -> bool:
+    def refresh_nodes(self) -> bool:
         """Refresh the live-node list immediately."""
         return self._ensure_manager().refresh_nodes()
 
-    def next_node(self) -> str | None:
-        """Return the next live node selected for diagnostics."""
-        return self._ensure_manager().next_node()
-
-    def get_nodes(self) -> list[str]:
+    @property
+    def nodes(self) -> list[str]:
         """Return the current live-node hostnames."""
         if self._manager is None:
             return []
         return list(self._manager.nodes.nodes)
 
-    def get_active_nodes(self) -> list[str]:
+    @property
+    def active_nodes(self) -> list[str]:
         """Return active nodes; currently this is the live-node list."""
-        return self.get_nodes()
+        return self.nodes
 
-    def get_quarantined_nodes(self) -> list[str]:
+    @property
+    def quarantined_nodes(self) -> list[str]:
         """Return quarantined nodes; node quarantine is not implemented."""
         return []
 
-    def check_rack_and_datacenter_set_correctly(self) -> bool:
+    def validate_scope(self) -> bool:
         """Return whether the configured rack/datacenter scope is complete."""
         manager = self._manager
         if manager is not None:
@@ -630,7 +702,7 @@ class Helper:
         finally:
             manager.stop()
 
-    def check_rack_datacenter_feature_supported(self) -> bool:
+    def supports_topology_filters(self) -> bool:
         """Return whether this client supports rack/datacenter scoped discovery."""
         manager = self._manager
         if manager is not None:
@@ -642,7 +714,7 @@ class Helper:
         finally:
             manager.stop()
 
-    def get_partition_key_name(self, table_name: str) -> str | None:
+    def partition_key_for(self, table_name: str) -> str | None:
         """Return a known partition key name for diagnostics."""
         configured = self._config.key_affinity.table_pk_attributes.get(table_name)
         if configured is not None:

--- a/alternator/vector.py
+++ b/alternator/vector.py
@@ -21,7 +21,7 @@ DynamoDB Resource interface automatically converts :class:`Vector` instances
 to the ``FLOAT32VECTOR`` wire format and back.
 
 :func:`enable_vector_support` is called automatically by
-:func:`~alternator.create_client`, :func:`~alternator.create_resource`, and
+:func:`~alternator.client`, :func:`~alternator.resource`, and
 :func:`~alternator.async_client.create_async_client`, so users of the
 Alternator client library do not need to call it manually.
 
@@ -30,32 +30,33 @@ Usage::
     import alternator
 
     config = alternator.Config(seed_hosts=["192.168.1.1"], port=8000)
-    client = alternator.create_client(config)  # vector support enabled automatically
+    with alternator.client("dynamodb", cluster_config=config) as client:
+        # vector support enabled automatically
 
-    # Create a table with a vector index
-    client.create_table(
-        TableName="embeddings",
-        KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
-        AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
-        BillingMode="PAY_PER_REQUEST",
-        VectorIndexes=[{
-            "IndexName": "embedding_index",
-            "VectorAttribute": {"AttributeName": "embedding", "Dimensions": 4},
-            "SimilarityFunction": "COSINE",
-        }],
-    )
+        # Create a table with a vector index
+        client.create_table(
+            TableName="embeddings",
+            KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+            VectorIndexes=[{
+                "IndexName": "embedding_index",
+                "VectorAttribute": {"AttributeName": "embedding", "Dimensions": 4},
+                "SimilarityFunction": "COSINE",
+            }],
+        )
 
-    # Store a vector using the low-level client interface
-    client.put_item(
-        TableName="embeddings",
-        Item={"id": {"S": "item1"}, "embedding": {"FLOAT32VECTOR": [0.1, 0.2, 0.3, 0.4]}},
-    )
+        # Store a vector using the low-level client interface
+        client.put_item(
+            TableName="embeddings",
+            Item={"id": {"S": "item1"}, "embedding": {"FLOAT32VECTOR": [0.1, 0.2, 0.3, 0.4]}},
+        )
 
-    # Query by vector similarity
-    result = client.query(
-        TableName="embeddings",
-        VectorSearch={"QueryVector": {"FLOAT32VECTOR": [0.1, 0.2, 0.3, 0.4]}},
-    )
+        # Query by vector similarity
+        result = client.query(
+            TableName="embeddings",
+            VectorSearch={"QueryVector": {"FLOAT32VECTOR": [0.1, 0.2, 0.3, 0.4]}},
+        )
 
 With the high-level Resource interface, use :class:`Vector` directly::
 
@@ -63,14 +64,15 @@ With the high-level Resource interface, use :class:`Vector` directly::
     from alternator.vector import Vector
 
     config = alternator.Config(seed_hosts=["192.168.1.1"], port=8000)
-    resource = alternator.create_resource(config)  # vector support enabled automatically
+    resource_ctx = alternator.resource("dynamodb", cluster_config=config)
 
-    table = resource.Table("embeddings")
-    table.put_item(Item={"id": "item1", "embedding": Vector([0.1, 0.2, 0.3, 0.4])})
-    response = table.query(
-        VectorSearch={"QueryVector": Vector([0.1, 0.2, 0.3, 0.4])},
-    )
-    # response["Items"][0]["embedding"] will be a Vector instance
+    with resource_ctx as resource:  # vector support enabled automatically
+        table = resource.Table("embeddings")
+        table.put_item(Item={"id": "item1", "embedding": Vector([0.1, 0.2, 0.3, 0.4])})
+        response = table.query(
+            VectorSearch={"QueryVector": Vector([0.1, 0.2, 0.3, 0.4])},
+        )
+        # response["Items"][0]["embedding"] will be a Vector instance
 """
 
 from __future__ import annotations
@@ -231,9 +233,9 @@ def enable_vector_support(client_or_resource: Any) -> None:  # noqa: ANN401 -- a
 
     Args:
         client_or_resource: A boto3 DynamoDB *client* (e.g. returned by
-            :func:`~alternator.create_client` or ``boto3.client("dynamodb")``)
+            :func:`~alternator.client` or ``boto3.client("dynamodb")``)
             or a DynamoDB *resource* (e.g. returned by
-            :func:`~alternator.create_resource` or
+            :func:`~alternator.resource` or
             ``boto3.resource("dynamodb")``).
     """
     # Resolve to the underlying boto3 low-level client

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -5,9 +5,9 @@ and intentionally deferred behavior.
 
 | Capability | Status | Tracking | Notes |
 | --- | --- | --- | --- |
-| Sync DynamoDB client | Supported | Existing API | `create_client`, `AlternatorClient`, and `alternator.client(...)` return standard boto3 clients. |
-| DynamoDB resource | Supported | Existing API | `create_resource` and `AlternatorResource` wrap boto3 resource usage. |
-| Async DynamoDB client | Supported | Existing API | `create_async_client` and `AsyncAlternatorClient` use aioboto3. |
+| Sync DynamoDB client | Supported | Existing API | `alternator.client("dynamodb", ...)` and `Session.client("dynamodb")` return standard boto3 clients. |
+| DynamoDB resource | Supported | Existing API | `alternator.resource("dynamodb", ...)` and `Session.resource("dynamodb")` wrap boto3 resource usage. |
+| Async DynamoDB client | Supported | Existing API | `AsyncSession.client("dynamodb")` uses aioboto3. |
 | Host-only seeds with one shared port | Supported | Existing API | Seeds must not include ports; one port applies to all nodes. |
 | Node discovery | Supported | Existing API | `/localnodes` refresh updates the live node list. `ClusterScope` combines results from all configured seeds, so multi-DC routing requires at least one reachable seed from each datacenter. |
 | Routing scopes | Supported | [#35](https://github.com/scylladb/alternator-client-python/issues/35) | Cluster, datacenter, and rack scopes support explicit fallback chains and scoped validation helpers. |
@@ -22,7 +22,7 @@ and intentionally deferred behavior.
 | TLS key log file | Supported | [#38](https://github.com/scylladb/alternator-client-python/issues/38) | Debug-only key log file paths are applied to SSL contexts when supported by the runtime. |
 | Transport and SDK config knobs | Supported | [#34](https://github.com/scylladb/alternator-client-python/issues/34), [#89](https://github.com/scylladb/alternator-client-python/issues/89) | Retry, pool, connect/read timeout, region, TLS client certificates, and User-Agent settings have typed Alternator config fields. The client does not expose raw SDK config mutation. |
 | Key route affinity | Supported | [#23](https://github.com/scylladb/alternator-client-python/issues/23) | RMW detection, single-write affinity, and BatchWriteItem preferred-node voting are implemented with fallback on missing or ambiguous routing data. |
-| Helper lifecycle facade | Supported | [#33](https://github.com/scylladb/alternator-client-python/issues/33) | `Helper` and `AsyncHelper` expose lifecycle, node inspection, topology checks, and partition-key diagnostics. |
+| Session lifecycle facade | Supported | [#33](https://github.com/scylladb/alternator-client-python/issues/33) | `Session` and `AsyncSession` expose lifecycle, node inspection, topology checks, and partition-key diagnostics. |
 | Compatibility and release decisions | Supported | [#39](https://github.com/scylladb/alternator-client-python/issues/39) | Decision record lives in [docs/COMPATIBILITY_AND_RELEASE.md](COMPATIBILITY_AND_RELEASE.md). |
 | Node health tracking | Deferred | [#32](https://github.com/scylladb/alternator-client-python/issues/32) | Planning-only. No node health code, tests, config objects, or behavior changes are authorized by this roadmap. |
 | Vector search extension | Supported | Existing API | Python client enables ScyllaDB Alternator vector extensions. |

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -9,7 +9,7 @@ authority for compatibility decisions.
 
 ### Additive APIs
 
-- Added `Helper` and `AsyncHelper` lifecycle facades for callers that need one
+- Added `Session` and `AsyncSession` lifecycle facades for callers that need one
   owner for clients/resources plus topology diagnostics.
 - Added explicit routing fallback controls with `fallback=...` and
   `without_fallback(...)`.

--- a/examples/async_demo.py
+++ b/examples/async_demo.py
@@ -17,7 +17,7 @@ from typing import Any, cast
 from botocore.exceptions import ClientError
 
 from alternator import Config, NoNodesAvailableError
-from alternator.async_client import AsyncAlternatorClient
+from alternator.async_client import AsyncSession
 
 # Enable logging to see load balancing in action
 logging.basicConfig(
@@ -37,7 +37,9 @@ async def main() -> None:
 
     try:
         # Use the async context manager for automatic cleanup
-        async with AsyncAlternatorClient(config) as client:
+        async with AsyncSession(config) as session:
+            client = await session.client("dynamodb")
+
             # List existing tables
             print("Listing tables...")
             list_response = await client.list_tables()

--- a/examples/capability_configuration.py
+++ b/examples/capability_configuration.py
@@ -19,28 +19,27 @@ from alternator import (
     Config,
     DatacenterScope,
     HeaderWhitelistContext,
-    Helper,
     KeyRouteAffinityMode,
     RackScope,
     RetryMode,
+    Session,
     TimeoutConfig,
 )
 
 
 def helper_lifecycle_example() -> None:
-    """Use Helper when one object should own clients and topology diagnostics."""
+    """Use Session when one object should own clients and topology diagnostics."""
     config = Config(
         seed_hosts=["node1.example.com", "node2.example.com"],
         port=8000,
     )
 
-    with Helper(config, auth=Auth.disabled()) as helper:
-        client = helper.client()
-        resource = helper.resource()
+    with Session(config, auth=Auth.disabled()) as helper:
+        client = helper.client("dynamodb")
+        resource = helper.resource("dynamodb")
 
-        helper.update_live_nodes()
-        print("nodes:", helper.get_nodes())
-        print("next node:", helper.next_node())
+        helper.refresh_nodes()
+        print("nodes:", helper.nodes)
 
         client.list_tables()
         resource.Table("orders").scan(Limit=1)

--- a/examples/compare_aws_sdk.py
+++ b/examples/compare_aws_sdk.py
@@ -97,6 +97,7 @@ def main() -> None:
         auth = Auth.static_credentials(args.alternator_key_id, args.alternator_secret)
 
     with alternator.client(
+        "dynamodb",
         seeds=args.seed,
         port=args.port,
         auth=auth,

--- a/examples/sync_demo.py
+++ b/examples/sync_demo.py
@@ -15,7 +15,8 @@ from typing import Any, cast
 
 from botocore.exceptions import ClientError
 
-from alternator import AlternatorClient, Config, NoNodesAvailableError
+import alternator
+from alternator import Config, NoNodesAvailableError
 
 # Enable logging to see load balancing in action
 logging.basicConfig(
@@ -35,7 +36,7 @@ def main() -> None:
 
     try:
         # Use the context manager for automatic cleanup
-        with AlternatorClient(config) as client:
+        with alternator.client("dynamodb", cluster_config=config) as client:
             # List existing tables
             print("Listing tables...")
             list_response = client.list_tables()

--- a/tests/integration/test_live_nodes.py
+++ b/tests/integration/test_live_nodes.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import pytest
 
-from alternator import AlternatorConfigBuilder, Auth, Helper, KeyRouteAffinityMode
-from alternator.async_client import AsyncHelper
+from alternator import AlternatorConfigBuilder, Auth, KeyRouteAffinityMode, Session
+from alternator.async_client import AsyncSession
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
 
 pytestmark = [
@@ -31,22 +31,19 @@ class TestLiveNodeHelperDiagnostics:
     """Verify sync helper diagnostics and shared-client lifecycle."""
 
     def test_helper_exposes_nodes_clients_and_partition_keys(self) -> None:
-        with Helper(_affinity_config(), auth=Auth.disabled()) as helper:
-            assert helper.update_live_nodes()
-            nodes = helper.get_nodes()
+        with Session(_affinity_config(), auth=Auth.disabled()) as helper:
+            assert helper.refresh_nodes()
+            nodes = helper.nodes
             assert nodes
-            assert helper.get_active_nodes() == nodes
-            assert helper.get_quarantined_nodes() == []
-            assert helper.check_rack_datacenter_feature_supported()
-            assert helper.get_partition_key_name("preconfigured_table") == "pk"
+            assert helper.active_nodes == nodes
+            assert helper.quarantined_nodes == []
+            assert helper.supports_topology_filters()
+            assert helper.partition_key_for("preconfigured_table") == "pk"
 
-            visited = {helper.next_node() for _ in range(len(nodes) * 2)}
-            assert set(nodes).issubset({node for node in visited if node is not None})
-
-            client = helper.client()
+            client = helper.client("dynamodb")
             assert "TableNames" in client.list_tables()
 
-            resource = helper.resource()
+            resource = helper.resource("dynamodb")
             assert "TableNames" in resource.meta.client.list_tables()
 
 
@@ -55,21 +52,14 @@ class TestAsyncLiveNodeHelperDiagnostics:
 
     @pytest.mark.asyncio
     async def test_helper_exposes_nodes_clients_and_partition_keys(self) -> None:
-        async with AsyncHelper(_affinity_config(), auth=Auth.disabled()) as helper:
-            assert await helper.update_live_nodes()
-            nodes = helper.get_nodes()
+        async with AsyncSession(_affinity_config(), auth=Auth.disabled()) as helper:
+            assert await helper.refresh_nodes()
+            nodes = helper.nodes
             assert nodes
-            assert helper.get_active_nodes() == nodes
-            assert helper.get_quarantined_nodes() == []
-            assert await helper.check_rack_datacenter_feature_supported()
-            assert await helper.get_partition_key_name("preconfigured_table") == "pk"
+            assert helper.active_nodes == nodes
+            assert helper.quarantined_nodes == []
+            assert await helper.supports_topology_filters()
+            assert await helper.partition_key_for("preconfigured_table") == "pk"
 
-            visited: set[str] = set()
-            for _ in range(len(nodes) * 2):
-                node = await helper.next_node()
-                assert node is not None
-                visited.add(node)
-            assert set(nodes).issubset(visited)
-
-            client = await helper.client()
+            client = await helper.client("dynamodb")
             assert "TableNames" in await client.list_tables()

--- a/tests/integration/test_wrong_dc_rack.py
+++ b/tests/integration/test_wrong_dc_rack.py
@@ -15,9 +15,9 @@ from alternator import (
     ClusterScope,
     Config,
     DatacenterScope,
-    Helper,
     NoNodesAvailableError,
     RackScope,
+    Session,
 )
 from alternator.exceptions import ConfigurationError
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
@@ -189,17 +189,17 @@ class TestRackDatacenterFeatureSupport:
             assert "TableNames" in response
 
     def test_helper_validates_correct_datacenter(self) -> None:
-        """Helper validation succeeds for a known datacenter."""
+        """Session validation succeeds for a known datacenter."""
         config = Config(
             seed_hosts=[SCYLLA_HOST],
             port=SCYLLA_PORT,
             routing_scope=DatacenterScope("datacenter1", fallback=None),
         )
 
-        assert Helper(config).check_rack_and_datacenter_set_correctly()
+        assert Session(config).validate_scope()
 
     def test_helper_validation_rejects_wrong_datacenter(self) -> None:
-        """Helper validation raises a clear error for an absent datacenter."""
+        """Session validation raises a clear error for an absent datacenter."""
         config = Config(
             seed_hosts=[SCYLLA_HOST],
             port=SCYLLA_PORT,
@@ -207,4 +207,4 @@ class TestRackDatacenterFeatureSupport:
         )
 
         with pytest.raises(ConfigurationError, match="No nodes found"):
-            Helper(config).check_rack_and_datacenter_set_correctly()
+            Session(config).validate_scope()

--- a/tests/unit/test_client_alias.py
+++ b/tests/unit/test_client_alias.py
@@ -3,8 +3,8 @@
 import pytest
 
 import alternator
-from alternator import AlternatorClient, Auth, Config
-from alternator.client import DEFAULT_PORT, client
+from alternator import AlternatorClient, AlternatorResource, Auth, Config
+from alternator.client import DEFAULT_PORT, client, resource
 from alternator.exceptions import ConfigurationError
 
 
@@ -13,16 +13,16 @@ class TestClientAlias:
 
     def test_builds_context_manager_from_seed_keywords(self) -> None:
         """The alias builds an AlternatorClient from host-only seeds."""
-        ctx = client(seeds=["node1", "node2"])
+        ctx = client("dynamodb", seeds=["node1", "node2"])
 
         assert isinstance(ctx, AlternatorClient)
         assert ctx._config.seed_hosts == ("node1", "node2")
         assert ctx._config.port == DEFAULT_PORT
         assert ctx._config.scheme == "http"
 
-    def test_accepts_positional_seeds(self) -> None:
-        """The alias also accepts seeds as the first argument."""
-        ctx = client(["node1"], port=8042, scheme="https")
+    def test_accepts_service_name_and_connection_options(self) -> None:
+        """The alias mirrors boto3's service-name-first shape."""
+        ctx = client("dynamodb", seeds=["node1"], port=8042, scheme="https")
 
         assert ctx._config.seed_hosts == ("node1",)
         assert ctx._config.port == 8042
@@ -32,7 +32,12 @@ class TestClientAlias:
         """The alias can wrap an existing Config."""
         config = Config(seed_hosts=["node1"], port=9000)
 
-        ctx = client(config, auth=Auth.disabled(), region_name="us-east-1")
+        ctx = client(
+            "dynamodb",
+            cluster_config=config,
+            auth=Auth.disabled(),
+            region_name="us-east-1",
+        )
 
         assert ctx._config is config
         assert ctx._auth == Auth.disabled()
@@ -41,25 +46,38 @@ class TestClientAlias:
     def test_rejects_missing_seeds(self) -> None:
         """Seeds are required unless a Config object is passed."""
         with pytest.raises(ConfigurationError, match="seeds is required"):
-            client()
+            client("dynamodb")
+
+    def test_rejects_unsupported_service_name(self) -> None:
+        """Only the DynamoDB service is supported."""
+        with pytest.raises(ConfigurationError, match="'dynamodb'"):
+            client("s3", seeds=["node1"])
 
     def test_rejects_host_port_seed(self) -> None:
         """Seeds must not include ports."""
         with pytest.raises(ConfigurationError, match="without ports"):
-            client(seeds=["node1:8000"])
+            client("dynamodb", seeds=["node1:8000"])
 
     def test_rejects_url_seed(self) -> None:
         """Seeds must not include URL schemes."""
         with pytest.raises(ConfigurationError, match="without ports"):
-            client(seeds=["http://node1"])
+            client("dynamodb", seeds=["http://node1"])
 
     def test_rejects_config_with_port_override(self) -> None:
         """A Config object cannot be mixed with direct port settings."""
         config = Config(seed_hosts=["node1"], port=9000)
 
-        with pytest.raises(ConfigurationError, match="Config object"):
-            client(config, port=8001)
+        with pytest.raises(ConfigurationError, match="cluster_config"):
+            client("dynamodb", cluster_config=config, port=8001)
+
+    def test_resource_alias_builds_resource_context(self) -> None:
+        """The resource alias mirrors boto3.resource."""
+        ctx = resource("dynamodb", seeds=["node1"])
+
+        assert isinstance(ctx, AlternatorResource)
+        assert ctx._config.seed_hosts == ("node1",)
 
     def test_top_level_export(self) -> None:
         """Top-level alternator.client is the convenience alias."""
         assert alternator.client is client
+        assert alternator.resource is resource

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -1,4 +1,4 @@
-"""Tests for public Helper facades."""
+"""Tests for public Session facades."""
 
 from __future__ import annotations
 
@@ -9,9 +9,9 @@ from urllib.parse import urlsplit
 import pytest
 
 import alternator
-from alternator import Auth, Config, Helper, close_client, create_client
+from alternator import Auth, Config, Session, close_client, create_client
 from alternator._constants import MANAGER_ATTR, MANAGER_OWNS_ATTR
-from alternator.async_client import AsyncHelper
+from alternator.async_client import AsyncSession
 from alternator.config import KeyRouteAffinityConfig
 from alternator.core.routing_scope import (
     ClusterScope,
@@ -42,31 +42,38 @@ def _config_for_server(
 
 
 def test_helper_is_exported() -> None:
-    """Helper is available from the top-level package."""
-    assert alternator.Helper is Helper
-    assert alternator.AsyncHelper is AsyncHelper
+    """Session is available from the top-level package."""
+    assert alternator.Session is Session
+    assert alternator.AsyncSession is AsyncSession
+
+
+def test_session_accepts_seed_keywords() -> None:
+    """Session can be configured directly without a prebuilt Config."""
+    session = Session(seeds=["node1", "node2"], port=8042, scheme="https")
+
+    assert session.config.seed_hosts == ("node1", "node2")
+    assert session.config.port == 8042
+    assert session.config.scheme == "https"
 
 
 def test_helper_lifecycle_and_node_diagnostics(
     fake_alternator_server: FakeAlternatorServer,
 ) -> None:
-    """Helper exposes explicit lifecycle and live-node inspection."""
+    """Session exposes explicit lifecycle and live-node inspection."""
     fake_alternator_server.set_localnodes(["node2", "node1"])
-    helper = Helper(_config_for_server(fake_alternator_server))
+    helper = Session(_config_for_server(fake_alternator_server))
 
-    assert helper.get_nodes() == []
-    assert helper.update_live_nodes() is True
-    assert helper.get_nodes() == ["node1", "node2"]
-    assert helper.get_active_nodes() == ["node1", "node2"]
-    assert helper.get_quarantined_nodes() == []
-    assert helper.next_node() == "node1"
-    assert helper.next_node() == "node2"
+    assert helper.nodes == []
+    assert helper.refresh_nodes() is True
+    assert helper.nodes == ["node1", "node2"]
+    assert helper.active_nodes == ["node1", "node2"]
+    assert helper.quarantined_nodes == []
 
     helper.start()
     helper.start()
     helper.stop()
     helper.stop()
-    assert helper.get_nodes() == []
+    assert helper.nodes == []
 
 
 def test_helper_created_clients_borrow_helper_manager(
@@ -75,9 +82,9 @@ def test_helper_created_clients_borrow_helper_manager(
     """Closing a helper-created client does not stop the helper manager."""
     fake_alternator_server.set_localnodes(["node1"])
 
-    with Helper(_config_for_server(fake_alternator_server)) as helper:
-        client = helper.client()
-        resource = helper.resource()
+    with Session(_config_for_server(fake_alternator_server)) as helper:
+        client = helper.client("dynamodb")
+        resource = helper.resource("dynamodb")
 
         assert getattr(client, MANAGER_ATTR) is helper._manager
         assert getattr(resource, MANAGER_ATTR) is helper._manager
@@ -85,7 +92,7 @@ def test_helper_created_clients_borrow_helper_manager(
         assert getattr(resource, MANAGER_OWNS_ATTR) is False
 
         close_client(client)
-        assert helper.update_live_nodes() is True
+        assert helper.refresh_nodes() is True
 
 
 def test_helper_update_returns_new_helper(
@@ -93,7 +100,7 @@ def test_helper_update_returns_new_helper(
 ) -> None:
     """update returns a fresh helper with merged settings."""
     config = _config_for_server(fake_alternator_server)
-    helper = Helper(config, auth=Auth.disabled(), region_name="us-west-2")
+    helper = Session(config, auth=Auth.disabled(), region_name="us-west-2")
     updated = helper.update(region_name="us-east-1")
 
     assert updated is not helper
@@ -103,51 +110,51 @@ def test_helper_update_returns_new_helper(
 
 
 def test_helper_topology_checks(fake_alternator_server: FakeAlternatorServer) -> None:
-    """Helper exposes lightweight topology configuration checks."""
+    """Session exposes lightweight topology configuration checks."""
     fake_alternator_server.set_localnodes(["node1"], query="dc=dc1")
     fake_alternator_server.set_localnodes(["node1"], query="dc=dc1&rack=rack1")
 
-    assert Helper(
+    assert Session(
         _config_for_server(fake_alternator_server, routing_scope=ClusterScope())
-    ).check_rack_and_datacenter_set_correctly()
-    assert Helper(
+    ).validate_scope()
+    assert Session(
         _config_for_server(
             fake_alternator_server,
             routing_scope=DatacenterScope(datacenter="dc1"),
         )
-    ).check_rack_and_datacenter_set_correctly()
+    ).validate_scope()
 
-    invalid_helper = Helper(
+    invalid_helper = Session(
         _config_for_server(
             fake_alternator_server,
             routing_scope=RackScope(datacenter="dc1", rack=""),
         )
     )
-    assert not invalid_helper.check_rack_datacenter_feature_supported()
+    assert not invalid_helper.supports_topology_filters()
     with pytest.raises(ConfigurationError, match="non-empty"):
-        invalid_helper.check_rack_and_datacenter_set_correctly()
+        invalid_helper.validate_scope()
 
-    assert Helper(
+    assert Session(
         _config_for_server(
             fake_alternator_server,
             routing_scope=RackScope(datacenter="dc1", rack="rack1"),
         )
-    ).check_rack_datacenter_feature_supported()
+    ).supports_topology_filters()
 
 
 def test_helper_partition_key_diagnostics_from_config(
     fake_alternator_server: FakeAlternatorServer,
 ) -> None:
     """Configured partition-key mappings are exposed without private access."""
-    helper = Helper(
+    helper = Session(
         _config_for_server(
             fake_alternator_server,
             key_affinity=KeyRouteAffinityConfig(table_pk_attributes={"tbl": "pk"}),
         )
     )
 
-    assert helper.get_partition_key_name("tbl") == "pk"
-    assert helper.get_partition_key_name("missing") is None
+    assert helper.partition_key_for("tbl") == "pk"
+    assert helper.partition_key_for("missing") is None
 
 
 def test_no_fallback_scope_does_not_use_seed_hosts(
@@ -213,19 +220,18 @@ def test_close_resource_closes_underlying_boto_client() -> None:
 async def test_async_helper_lifecycle_and_node_diagnostics(
     fake_alternator_server: FakeAlternatorServer,
 ) -> None:
-    """AsyncHelper exposes async lifecycle and live-node inspection."""
+    """AsyncSession exposes async lifecycle and live-node inspection."""
     fake_alternator_server.set_localnodes(["node2", "node1"])
-    helper = AsyncHelper(_config_for_server(fake_alternator_server))
+    helper = AsyncSession(_config_for_server(fake_alternator_server))
 
-    assert helper.get_nodes() == []
-    assert await helper.update_live_nodes() is True
-    assert helper.get_nodes() == ["node1", "node2"]
-    assert helper.get_active_nodes() == ["node1", "node2"]
-    assert helper.get_quarantined_nodes() == []
-    assert await helper.next_node() == "node1"
+    assert helper.nodes == []
+    assert await helper.refresh_nodes() is True
+    assert helper.nodes == ["node1", "node2"]
+    assert helper.active_nodes == ["node1", "node2"]
+    assert helper.quarantined_nodes == []
 
     await helper.start()
     await helper.start()
     await helper.stop()
     await helper.stop()
-    assert helper.get_nodes() == []
+    assert helper.nodes == []


### PR DESCRIPTION
## Summary
- add boto3-style `alternator.client("dynamodb", ...)` and `alternator.resource("dynamodb", ...)` factory signatures
- replace `Helper` / `AsyncHelper` with `Session` / `AsyncSession` and require `session.client("dynamodb")` / `session.resource("dynamodb")`
- rename session diagnostics to `refresh_nodes`, `nodes`, `active_nodes`, `quarantined_nodes`, `validate_scope`, `supports_topology_filters`, and `partition_key_for`; remove session-level `next_node`
- update README, examples, capability docs, and tests for the new public surface

## Tests
- `pytest tests/unit -q`
- `make lint`
- `pytest tests/unit/test_client_alias.py tests/unit/test_helper.py -q`