### PR TITLE
Drop legacy client lifecycle API

### DIFF
--- a/alternator/__init__.py
+++ b/alternator/__init__.py
@@ -80,14 +80,8 @@ Notes
 
 from alternator._version import __version__
 from alternator.client import (
-    AlternatorClient,
-    AlternatorResource,
     Session,
     client,
-    close_client,
-    close_resource,
-    create_client,
-    create_resource,
     resource,
 )
 from alternator.config import (
@@ -130,19 +124,11 @@ __all__ = [
     # Version
     "__version__",
     # Sync Client
-    "AlternatorClient",
-    "AlternatorResource",
     "Session",
     "client",
-    "close_client",
-    "close_resource",
-    "create_client",
-    "create_resource",
     "resource",
     # Async Client (requires [async] extra)
     "AsyncSession",
-    "close_async_client",
-    "create_async_client",
     # Config
     "Auth",
     "Config",
@@ -181,11 +167,7 @@ __all__ = [
 
 def __getattr__(name: str) -> object:
     """Lazy import async client components to avoid requiring async dependencies."""
-    if name in (
-        "AsyncSession",
-        "close_async_client",
-        "create_async_client",
-    ):
+    if name in ("AsyncSession",):
         from alternator import async_client
 
         return getattr(async_client, name)

--- a/alternator/async_client.py
+++ b/alternator/async_client.py
@@ -397,66 +397,8 @@ async def _create_async_client_with_manager(
     return cast("AsyncDynamoDBClient", client)
 
 
-async def create_async_client(
-    config: Config,
-    *,
-    auth: Auth | None = None,
-    **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
-) -> AsyncDynamoDBClient:
-    """
-    Create a load-balanced async DynamoDB client for Alternator.
-
-    The returned client is an aioboto3 DynamoDB client that
-    transparently distributes requests across cluster nodes.
-
-    Note:
-        Authentication is disabled by default. Alternator authentication
-        currently supports only static credentials; pass
-        ``auth=Auth.static_credentials(...)`` to enable request signing.
-
-    Args:
-        config: Alternator configuration
-        auth: Explicit Alternator auth settings. Defaults to disabled auth.
-        **boto_kwargs: Additional arguments passed to aioboto3.client()
-
-    Returns:
-        An async DynamoDB client with load balancing enabled
-
-    Example:
-        from alternator import Config
-        from alternator.async_client import create_async_client
-
-        config = Config(
-            seed_hosts=["node1.example.com"],
-            port=8000,
-        )
-        client = await create_async_client(config)
-
-        # Use like a normal aioboto3 client
-        response = await client.list_tables()
-    """
-    manager = await _create_async_manager(config)
-    await manager.start()
-    try:
-        return await _create_async_client_with_manager(
-            config,
-            manager,
-            auth=auth,
-            owns_manager=True,
-            **boto_kwargs,
-        )
-    except Exception:
-        await _close_async_manager(manager)
-        raise
-
-
-async def close_async_client(client: AsyncDynamoDBClient) -> None:
-    """
-    Close an async Alternator client and stop its background refresh task.
-
-    Args:
-        client: Client created by create_async_client
-    """
+async def _close_async_client(client: AsyncDynamoDBClient) -> None:
+    """Close an async Alternator client and stop its owned refresh task."""
     try:
         manager = getattr(client, MANAGER_ATTR, None)
         if manager is not None:
@@ -545,7 +487,7 @@ class AsyncSession:
         """Stop background node discovery and close session-created clients."""
         for created_client in list(self._clients):
             with contextlib.suppress(Exception):
-                await close_async_client(created_client)
+                await _close_async_client(created_client)
         self._clients.clear()
 
         if self._manager is not None:

--- a/alternator/client.py
+++ b/alternator/client.py
@@ -263,44 +263,13 @@ def _create_client_with_manager(
     return client
 
 
-def create_client(
+def _create_client(
     config: Config,
     *,
     auth: Auth | None = None,
     **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
 ) -> DynamoDBClient:
-    """
-    Create a load-balanced DynamoDB client for Alternator.
-
-    The returned client is a standard boto3 DynamoDB client that
-    transparently distributes requests across cluster nodes.
-
-    Note:
-        Authentication is disabled by default. Alternator authentication
-        currently supports only static credentials; pass
-        ``auth=Auth.static_credentials(...)`` to enable request signing.
-
-    Args:
-        config: Alternator configuration
-        auth: Explicit Alternator auth settings. Defaults to disabled auth.
-        **boto_kwargs: Additional arguments passed to boto3.client()
-            (excluding ``config`` — BotoConfig is managed internally)
-
-    Returns:
-        A DynamoDB client with load balancing enabled
-
-    Example:
-        from alternator import Config, create_client
-
-        config = Config(
-            seed_hosts=["node1.example.com"],
-            port=8000,
-        )
-        client = create_client(config)
-
-        # Use like a normal boto3 client
-        response = client.list_tables()
-    """
+    """Create a load-balanced DynamoDB client for Alternator."""
     manager = _create_and_start_manager(config)
     try:
         return _create_client_with_manager(
@@ -380,7 +349,7 @@ def client(
     scheme: Literal["http", "https"] = "http",
     auth: Auth | None = None,
     **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
-) -> AlternatorClient:
+) -> _ClientContext:
     """
     Create a context-manager friendly Alternator client.
 
@@ -395,7 +364,7 @@ def client(
         port=port,
         scheme=scheme,
     )
-    return AlternatorClient(config, auth=auth, **boto_kwargs)
+    return _ClientContext(config, auth=auth, **boto_kwargs)
 
 
 def resource(
@@ -407,7 +376,7 @@ def resource(
     scheme: Literal["http", "https"] = "http",
     auth: Auth | None = None,
     **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
-) -> AlternatorResource:
+) -> _ResourceContext:
     """
     Create a context-manager friendly Alternator resource.
 
@@ -421,28 +390,16 @@ def resource(
         port=port,
         scheme=scheme,
     )
-    return AlternatorResource(config, auth=auth, **boto_kwargs)
+    return _ResourceContext(config, auth=auth, **boto_kwargs)
 
 
-def create_resource(
+def _create_resource(
     config: Config,
     *,
     auth: Auth | None = None,
     **boto_kwargs: Any,  # noqa: ANN401 -- boto3 kwargs are untyped
 ) -> DynamoDBServiceResource:
-    """
-    Create a load-balanced DynamoDB resource for Alternator.
-
-    Note:
-        Authentication is disabled by default. Alternator authentication
-        currently supports only static credentials; pass
-        ``auth=Auth.static_credentials(...)`` to enable request signing.
-
-    Example:
-        resource = create_resource(config)
-        table = resource.Table("my_table")
-        table.put_item(Item={"pk": "123", "data": "hello"})
-    """
+    """Create a load-balanced DynamoDB resource for Alternator."""
     manager = _create_and_start_manager(config)
     try:
         return _create_resource_with_manager(
@@ -510,16 +467,8 @@ def _create_resource_with_manager(
     return resource
 
 
-def close_client(client: DynamoDBClient | DynamoDBServiceResource) -> None:
-    """
-    Close an Alternator client or resource and stop its background refresh thread.
-
-    Works for both clients created by ``create_client`` and resources created
-    by ``create_resource``. See also ``close_resource`` alias.
-
-    Args:
-        client: Client or resource created by create_client or create_resource
-    """
+def _close_client(client: DynamoDBClient | DynamoDBServiceResource) -> None:
+    """Close an Alternator client/resource and stop its owned refresh thread."""
     manager = getattr(client, MANAGER_ATTR, None)
     if manager is not None:
         owns_manager = bool(getattr(client, MANAGER_OWNS_ATTR, True))
@@ -619,7 +568,7 @@ class Session:
         """Stop background node discovery and detach session-created clients."""
         for created_client in list(self._clients):
             with contextlib.suppress(Exception):
-                close_client(created_client)
+                _close_client(created_client)
         self._clients.clear()
 
         if self._manager is not None:
@@ -754,16 +703,8 @@ class Session:
         return cast(object | None, getattr(service_client, PK_CACHE_ATTR, None))
 
 
-class AlternatorClient:
-    """
-    Context manager for load-balanced Alternator connections.
-
-    Handles proper cleanup of background refresh threads.
-
-    Example:
-        with AlternatorClient(config) as client:
-            client.put_item(...)
-    """
+class _ClientContext:
+    """Context manager for load-balanced Alternator clients."""
 
     def __init__(
         self,
@@ -778,7 +719,9 @@ class AlternatorClient:
         self._client: DynamoDBClient | None = None
 
     def __enter__(self) -> DynamoDBClient:
-        self._client = create_client(self._config, auth=self._auth, **self._boto_kwargs)
+        self._client = _create_client(
+            self._config, auth=self._auth, **self._boto_kwargs
+        )
         return self._client
 
     def __exit__(
@@ -799,21 +742,12 @@ class AlternatorClient:
     def close(self) -> None:
         """Stop background threads and release resources."""
         if self._client is not None:
-            close_client(self._client)
+            _close_client(self._client)
             self._client = None
 
 
-class AlternatorResource:
-    """
-    Context manager for load-balanced Alternator resource connections.
-
-    Handles proper cleanup of background refresh threads.
-
-    Example:
-        with AlternatorResource(config) as resource:
-            table = resource.Table("my_table")
-            table.put_item(Item={"pk": "123", "data": "hello"})
-    """
+class _ResourceContext:
+    """Context manager for load-balanced Alternator resources."""
 
     def __init__(
         self,
@@ -828,7 +762,7 @@ class AlternatorResource:
         self._resource: DynamoDBServiceResource | None = None
 
     def __enter__(self) -> DynamoDBServiceResource:
-        self._resource = create_resource(
+        self._resource = _create_resource(
             self._config, auth=self._auth, **self._boto_kwargs
         )
         return self._resource
@@ -851,9 +785,5 @@ class AlternatorResource:
     def close(self) -> None:
         """Stop background threads and release resources."""
         if self._resource is not None:
-            close_client(self._resource)
+            _close_client(self._resource)
             self._resource = None
-
-
-# Alias for close_client that makes intent clearer when closing resources
-close_resource = close_client

--- a/alternator/vector.py
+++ b/alternator/vector.py
@@ -22,7 +22,7 @@ to the ``FLOAT32VECTOR`` wire format and back.
 
 :func:`enable_vector_support` is called automatically by
 :func:`~alternator.client`, :func:`~alternator.resource`, and
-:func:`~alternator.async_client.create_async_client`, so users of the
+:class:`~alternator.async_client.AsyncSession`, so users of the
 Alternator client library do not need to call it manually.
 
 Usage::

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,7 +208,8 @@ def scylla_version() -> ScyllaVersion | None:
         return None
 
     try:
-        from alternator import Config, close_client, create_client
+        from alternator import Config
+        from alternator import client as alternator_client
         from tests.integration.scylla_version import detect_version_from_cluster
 
         config = Config(
@@ -216,12 +217,9 @@ def scylla_version() -> ScyllaVersion | None:
             port=SCYLLA_PORT,
             scheme="http",
         )
-        client = create_client(config)
-        try:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             version = detect_version_from_cluster(client)
             return version
-        finally:
-            close_client(client)
     except Exception:
         return None
 

--- a/tests/integration/test_batch_transactions.py
+++ b/tests/integration/test_batch_transactions.py
@@ -9,7 +9,8 @@ import uuid
 
 import pytest
 
-from alternator import AlternatorClient, Config
+from alternator import Config
+from alternator import client as alternator_client
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
 
 pytestmark = [
@@ -39,7 +40,7 @@ class TestBatchWriteItem:
 
     def test_batch_write_multiple_items(self, config: Config, table_name: str) -> None:
         """Test writing multiple items in a single batch."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             client.create_table(
                 TableName=table_name,
                 KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
@@ -76,7 +77,7 @@ class TestBatchWriteItem:
 
     def test_batch_write_with_deletes(self, config: Config, table_name: str) -> None:
         """Test batch write mixing puts and deletes."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             client.create_table(
                 TableName=table_name,
                 KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
@@ -132,7 +133,7 @@ class TestBatchGetItem:
 
     def test_batch_get_multiple_items(self, config: Config, table_name: str) -> None:
         """Test getting multiple items in a single batch."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             client.create_table(
                 TableName=table_name,
                 KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
@@ -171,7 +172,7 @@ class TestBatchGetItem:
 
     def test_batch_get_nonexistent_keys(self, config: Config, table_name: str) -> None:
         """Test batch get with keys that don't exist."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             client.create_table(
                 TableName=table_name,
                 KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],

--- a/tests/integration/test_composite_keys.py
+++ b/tests/integration/test_composite_keys.py
@@ -6,14 +6,17 @@ Start a local cluster with: make scylla-start
 """
 
 import uuid
+from typing import Any
 
 import pytest
 
 from alternator import (
-    AlternatorClient,
     AlternatorConfigBuilder,
     Config,
     KeyRouteAffinityMode,
+)
+from alternator import (
+    client as alternator_client,
 )
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
 
@@ -39,7 +42,7 @@ def table_name() -> str:
     return f"test_composite_{uuid.uuid4().hex[:8]}"
 
 
-def _create_composite_table(client: AlternatorClient, table_name: str) -> None:
+def _create_composite_table(client: Any, table_name: str) -> None:  # noqa: ANN401 -- generated boto3 client type is unavailable in integration tests
     """Helper to create a table with HASH + RANGE key."""
     client.create_table(
         TableName=table_name,
@@ -62,7 +65,7 @@ class TestCompositeKeyBasicOperations:
 
     def test_put_and_get_item(self, config: Config, table_name: str) -> None:
         """Test put and get with composite key."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_composite_table(client, table_name)
             try:
                 client.put_item(
@@ -93,7 +96,7 @@ class TestCompositeKeyBasicOperations:
         self, config: Config, table_name: str
     ) -> None:
         """Test multiple items with same HASH key but different RANGE keys."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_composite_table(client, table_name)
             try:
                 for i in range(5):
@@ -121,7 +124,7 @@ class TestCompositeKeyBasicOperations:
 
     def test_update_item_composite_key(self, config: Config, table_name: str) -> None:
         """Test updating an item with composite key."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_composite_table(client, table_name)
             try:
                 client.put_item(
@@ -157,7 +160,7 @@ class TestCompositeKeyBasicOperations:
 
     def test_delete_item_composite_key(self, config: Config, table_name: str) -> None:
         """Test deleting an item with composite key."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_composite_table(client, table_name)
             try:
                 client.put_item(
@@ -194,7 +197,7 @@ class TestCompositeKeyQuery:
 
     def test_query_by_partition_key(self, config: Config, table_name: str) -> None:
         """Test querying all range keys for a given partition key."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_composite_table(client, table_name)
             try:
                 # Insert items for two different partition keys
@@ -226,7 +229,7 @@ class TestCompositeKeyQuery:
         self, config: Config, table_name: str
     ) -> None:
         """Test querying with both partition and range key conditions."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_composite_table(client, table_name)
             try:
                 for i in range(5):
@@ -276,7 +279,7 @@ class TestCompositeKeyAffinity:
             .build()
         )
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_composite_table(client, table_name)
             try:
                 # Write multiple items with same HASH key, different RANGE keys
@@ -313,7 +316,7 @@ class TestCompositeKeyAffinity:
             .build()
         )
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_composite_table(client, table_name)
             try:
                 # Should auto-discover that "pk" is the HASH key

--- a/tests/integration/test_connection_reuse.py
+++ b/tests/integration/test_connection_reuse.py
@@ -16,9 +16,11 @@ import pytest
 
 from alternator import (
     TLS,
-    AlternatorClient,
     AlternatorConfigBuilder,
     Config,
+)
+from alternator import (
+    client as alternator_client,
 )
 from tests.integration import (
     SCYLLA_HOST,
@@ -72,7 +74,7 @@ class TestHttpConnectionReuseSerial:
 
     def test_serial_requests_succeed(self, http_config: Config) -> None:
         """Test that multiple serial requests over HTTP succeed without errors."""
-        with AlternatorClient(http_config) as client:
+        with alternator_client("dynamodb", cluster_config=http_config) as client:
             for _ in range(20):
                 response = client.list_tables()
                 assert "TableNames" in response
@@ -80,7 +82,7 @@ class TestHttpConnectionReuseSerial:
     def test_serial_crud_operations(self, http_config: Config) -> None:
         """Test serial CRUD operations reuse connections."""
         table_name = f"test_conn_{uuid.uuid4().hex[:8]}"
-        with AlternatorClient(http_config) as client:
+        with alternator_client("dynamodb", cluster_config=http_config) as client:
             client.create_table(
                 TableName=table_name,
                 KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
@@ -111,7 +113,9 @@ class TestHttpsConnectionReuseSerial:
 
     def test_serial_requests_succeed(self, https_config: Config, ca_path: Path) -> None:
         """Test that multiple serial HTTPS requests succeed."""
-        with AlternatorClient(https_config, verify=str(ca_path)) as client:
+        with alternator_client(
+            "dynamodb", cluster_config=https_config, verify=str(ca_path)
+        ) as client:
             for _ in range(20):
                 response = client.list_tables()
                 assert "TableNames" in response
@@ -119,7 +123,9 @@ class TestHttpsConnectionReuseSerial:
     def test_serial_crud_over_https(self, https_config: Config, ca_path: Path) -> None:
         """Test serial CRUD over HTTPS reuses connections."""
         table_name = f"test_https_{uuid.uuid4().hex[:8]}"
-        with AlternatorClient(https_config, verify=str(ca_path)) as client:
+        with alternator_client(
+            "dynamodb", cluster_config=https_config, verify=str(ca_path)
+        ) as client:
             client.create_table(
                 TableName=table_name,
                 KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
@@ -149,7 +155,7 @@ class TestHttpConnectionReuseParallel:
 
     def test_parallel_list_tables(self, http_config: Config) -> None:
         """Test parallel requests over HTTP all succeed."""
-        with AlternatorClient(http_config) as client:
+        with alternator_client("dynamodb", cluster_config=http_config) as client:
             errors: list[Exception] = []
             results: list[dict] = []
             lock = threading.Lock()
@@ -175,7 +181,7 @@ class TestHttpConnectionReuseParallel:
     def test_parallel_writes(self, http_config: Config) -> None:
         """Test parallel write operations over HTTP."""
         table_name = f"test_par_{uuid.uuid4().hex[:8]}"
-        with AlternatorClient(http_config) as client:
+        with alternator_client("dynamodb", cluster_config=http_config) as client:
             client.create_table(
                 TableName=table_name,
                 KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
@@ -227,7 +233,9 @@ class TestHttpsConnectionReuseParallel:
         self, https_config: Config, ca_path: Path
     ) -> None:
         """Test parallel HTTPS requests all succeed."""
-        with AlternatorClient(https_config, verify=str(ca_path)) as client:
+        with alternator_client(
+            "dynamodb", cluster_config=https_config, verify=str(ca_path)
+        ) as client:
             errors: list[Exception] = []
             results: list[dict] = []
             lock = threading.Lock()
@@ -252,7 +260,9 @@ class TestHttpsConnectionReuseParallel:
     def test_parallel_writes_https(self, https_config: Config, ca_path: Path) -> None:
         """Test parallel write operations over HTTPS."""
         table_name = f"test_https_par_{uuid.uuid4().hex[:8]}"
-        with AlternatorClient(https_config, verify=str(ca_path)) as client:
+        with alternator_client(
+            "dynamodb", cluster_config=https_config, verify=str(ca_path)
+        ) as client:
             client.create_table(
                 TableName=table_name,
                 KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
@@ -296,7 +306,7 @@ class TestConnectionPoolingValidation:
         self, http_config: Config
     ) -> None:
         """Test that many serial requests don't exhaust file descriptors or connections."""
-        with AlternatorClient(http_config) as client:
+        with alternator_client("dynamodb", cluster_config=http_config) as client:
             # A large number of serial requests should work fine with connection reuse
             for _ in range(100):
                 response = client.list_tables()
@@ -304,7 +314,7 @@ class TestConnectionPoolingValidation:
 
     def test_high_concurrency_doesnt_exhaust_pool(self, http_config: Config) -> None:
         """Test high concurrency doesn't exhaust the connection pool."""
-        with AlternatorClient(http_config) as client:
+        with alternator_client("dynamodb", cluster_config=http_config) as client:
             errors: list[Exception] = []
             lock = threading.Lock()
 
@@ -330,7 +340,7 @@ class TestConnectionPoolingValidation:
         If connections were not being reused, we'd see degraded performance
         or errors with many sequential requests.
         """
-        with AlternatorClient(http_config) as client:
+        with alternator_client("dynamodb", cluster_config=http_config) as client:
             # Warm up
             client.list_tables()
 

--- a/tests/integration/test_header_optimization.py
+++ b/tests/integration/test_header_optimization.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import pytest
 
-from alternator import AlternatorConfigBuilder, Auth, close_client, create_client
-from alternator.async_client import close_async_client, create_async_client
+from alternator import AlternatorConfigBuilder, Auth
+from alternator import client as alternator_client
+from alternator.async_client import AsyncSession
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
 from tests.integration.wire_capture import (
     capture_prepared_requests,
@@ -33,14 +34,14 @@ class TestHeaderOptimization:
     """Verify sync header filtering on prepared requests."""
 
     def test_disabled_keeps_user_agent_on_wire(self) -> None:
-        client = create_client(_user_agent_config("alternator-unfiltered"))
-        try:
+        with alternator_client(
+            "dynamodb",
+            cluster_config=_user_agent_config("alternator-unfiltered"),
+        ) as client:
             captured = capture_prepared_requests(client)
             client.list_tables()
             request = latest_request(captured)
             assert request.header("user-agent") == "alternator-unfiltered"
-        finally:
-            close_client(client)
 
     def test_filters_wire_headers_and_preserves_auth(self) -> None:
         config = (
@@ -51,11 +52,11 @@ class TestHeaderOptimization:
             .with_user_agent("alternator-filtered")
             .build()
         )
-        client = create_client(
-            config,
+        with alternator_client(
+            "dynamodb",
+            cluster_config=config,
             auth=Auth.static_credentials("alternator", "secret"),
-        )
-        try:
+        ) as client:
             inject_custom_headers(client)
             captured = capture_prepared_requests(client)
             client.list_tables()
@@ -66,8 +67,6 @@ class TestHeaderOptimization:
             assert request.header("authorization") is not None
             assert request.header("x-amz-date") is not None
             assert request.header("user-agent") == "alternator-filtered"
-        finally:
-            close_client(client)
 
 
 class TestAsyncHeaderOptimization:
@@ -82,11 +81,11 @@ class TestAsyncHeaderOptimization:
             .with_header_optimization(whitelist={"X-Keep-Me"})
             .build()
         )
-        client = await create_async_client(
+        async with AsyncSession(
             config,
             auth=Auth.static_credentials("alternator", "secret"),
-        )
-        try:
+        ) as session:
+            client = await session.client("dynamodb")
             inject_custom_headers(client)
             captured = capture_prepared_requests(client)
             await client.list_tables()
@@ -96,5 +95,3 @@ class TestAsyncHeaderOptimization:
             assert request.header("x-drop-me") is None
             assert request.header("authorization") is not None
             assert request.header("x-amz-date") is not None
-        finally:
-            await close_async_client(client)

--- a/tests/integration/test_key_affinity_operations.py
+++ b/tests/integration/test_key_affinity_operations.py
@@ -8,14 +8,17 @@ Start a local cluster with: make scylla-start
 """
 
 import uuid
+from typing import Any
 
 import pytest
 
 from alternator import (
-    AlternatorClient,
     AlternatorConfigBuilder,
     Config,
     KeyRouteAffinityMode,
+)
+from alternator import (
+    client as alternator_client,
 )
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
 
@@ -31,7 +34,7 @@ def table_name() -> str:
     return f"test_affinity_{uuid.uuid4().hex[:8]}"
 
 
-def _create_table(client: AlternatorClient, table_name: str) -> None:
+def _create_table(client: Any, table_name: str) -> None:  # noqa: ANN401 -- generated boto3 client type is unavailable in integration tests
     """Helper to create a simple HASH-key table."""
     client.create_table(
         TableName=table_name,
@@ -81,7 +84,7 @@ class TestGetOperationAffinity:
         in ANY_WRITE mode it also does NOT use affinity. It should still work.
         """
         config = _make_rmw_config(table_name)
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_table(client, table_name)
             try:
                 client.put_item(
@@ -102,7 +105,7 @@ class TestGetOperationAffinity:
     def test_get_item_with_any_write_mode(self, table_name: str) -> None:
         """GET operations with ANY_WRITE mode should use round-robin (no affinity)."""
         config = _make_any_write_config(table_name)
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_table(client, table_name)
             try:
                 client.put_item(
@@ -126,7 +129,7 @@ class TestUpdateOperationAffinity:
     def test_update_with_rmw_condition(self, table_name: str) -> None:
         """UpdateItem with ConditionExpression is RMW — should use affinity."""
         config = _make_rmw_config(table_name)
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_table(client, table_name)
             try:
                 client.put_item(
@@ -155,7 +158,7 @@ class TestUpdateOperationAffinity:
     def test_update_with_any_write(self, table_name: str) -> None:
         """UpdateItem with ANY_WRITE mode routes all updates via affinity."""
         config = _make_any_write_config(table_name)
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_table(client, table_name)
             try:
                 client.put_item(
@@ -184,7 +187,7 @@ class TestUpdateOperationAffinity:
     def test_update_with_return_values_rmw(self, table_name: str) -> None:
         """UpdateItem with ReturnValues (non-NONE) is RMW — uses affinity in RMW mode."""
         config = _make_rmw_config(table_name)
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_table(client, table_name)
             try:
                 client.put_item(
@@ -212,7 +215,7 @@ class TestDeleteOperationAffinity:
     def test_delete_with_rmw_condition(self, table_name: str) -> None:
         """DeleteItem with ConditionExpression is RMW — should use affinity."""
         config = _make_rmw_config(table_name)
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_table(client, table_name)
             try:
                 client.put_item(
@@ -238,7 +241,7 @@ class TestDeleteOperationAffinity:
     def test_delete_with_any_write(self, table_name: str) -> None:
         """DeleteItem with ANY_WRITE routes all deletes via affinity."""
         config = _make_any_write_config(table_name)
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_table(client, table_name)
             try:
                 for i in range(5):
@@ -271,7 +274,7 @@ class TestInsertPutItemAffinity:
     def test_put_with_rmw_condition(self, table_name: str) -> None:
         """PutItem with ConditionExpression is RMW — should use affinity."""
         config = _make_rmw_config(table_name)
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_table(client, table_name)
             try:
                 # Conditional put (insert if not exists) — this is RMW
@@ -300,7 +303,7 @@ class TestInsertPutItemAffinity:
     def test_put_with_any_write(self, table_name: str) -> None:
         """PutItem with ANY_WRITE routes all puts via affinity."""
         config = _make_any_write_config(table_name)
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_table(client, table_name)
             try:
                 # Multiple puts with different keys — each routed via affinity
@@ -326,7 +329,7 @@ class TestBatchGetAffinity:
     def test_batch_get_works_with_affinity(self, table_name: str) -> None:
         """BatchGetItem should work correctly with affinity enabled."""
         config = _make_any_write_config(table_name)
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_table(client, table_name)
             try:
                 # Write items
@@ -353,7 +356,7 @@ class TestBatchGetAffinity:
     def test_batch_get_with_rmw_mode(self, table_name: str) -> None:
         """BatchGetItem with RMW mode (reads don't trigger affinity)."""
         config = _make_rmw_config(table_name)
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_table(client, table_name)
             try:
                 for i in range(3):
@@ -379,7 +382,7 @@ class TestBatchWriteAffinity:
     def test_batch_write_with_any_write(self, table_name: str) -> None:
         """BatchWriteItem with ANY_WRITE mode routes via affinity."""
         config = _make_any_write_config(table_name)
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_table(client, table_name)
             try:
                 items = [
@@ -408,7 +411,7 @@ class TestBatchWriteAffinity:
     def test_batch_write_with_rmw_mode(self, table_name: str) -> None:
         """BatchWriteItem with RMW mode (batch writes are not RMW)."""
         config = _make_rmw_config(table_name)
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_table(client, table_name)
             try:
                 items = [
@@ -436,7 +439,7 @@ class TestBatchWriteAffinity:
     def test_batch_write_mixed_operations(self, table_name: str) -> None:
         """BatchWriteItem with mixed puts and deletes using affinity."""
         config = _make_any_write_config(table_name)
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             _create_table(client, table_name)
             try:
                 # Pre-populate items to delete

--- a/tests/integration/test_node_health.py
+++ b/tests/integration/test_node_health.py
@@ -13,9 +13,11 @@ import time
 import pytest
 
 from alternator import (
-    AlternatorClient,
     AlternatorConfigBuilder,
     Config,
+)
+from alternator import (
+    client as alternator_client,
 )
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
 
@@ -40,7 +42,7 @@ class TestNodeDiscovery:
 
     def test_discovers_multiple_nodes(self, config: Config) -> None:
         """Test that the client discovers nodes via /localnodes endpoint."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             # Perform a request to trigger node discovery
             client.list_tables()
 
@@ -58,7 +60,7 @@ class TestNodeDiscovery:
             scheme="http",
         )
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             # The very first request should succeed using the seed host
             response = client.list_tables()
             assert "TableNames" in response
@@ -73,7 +75,7 @@ class TestNodeRecoveryDetection:
         This simulates the background refresh cycle by making requests
         over a period longer than the active refresh interval.
         """
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             # Make requests over time to trigger background refreshes
             for _ in range(30):
                 response = client.list_tables()
@@ -91,7 +93,7 @@ class TestActiveVsQuarantinedNodeTracking:
 
     def test_all_nodes_active_after_startup(self, config: Config) -> None:
         """Test that all discovered nodes are active after client startup."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             # Multiple requests should succeed, indicating active nodes
             success_count = 0
             for _ in range(50):
@@ -107,7 +109,7 @@ class TestActiveVsQuarantinedNodeTracking:
 
     def test_node_list_refreshed_periodically(self, config: Config) -> None:
         """Test that the node list is refreshed by the background thread."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             # Initial request
             response = client.list_tables()
             assert "TableNames" in response
@@ -142,7 +144,7 @@ class TestQuarantineAndRelease:
             .build()
         )
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             for _ in range(20):
                 response = client.list_tables()
                 assert "TableNames" in response
@@ -159,7 +161,7 @@ class TestQuarantineAndRelease:
             scheme="http",
         )
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             response = client.list_tables()
             assert "TableNames" in response
 
@@ -175,7 +177,7 @@ class TestQuarantineReleaseConcurrency:
         """Test that concurrent requests work during node list refresh."""
         import threading
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             errors: list[Exception] = []
             lock = threading.Lock()
 

--- a/tests/integration/test_request_compression.py
+++ b/tests/integration/test_request_compression.py
@@ -13,10 +13,11 @@ from alternator import (
     AlternatorConfigBuilder,
     Auth,
     CompressionAlgorithm,
-    close_client,
-    create_client,
 )
-from alternator.async_client import close_async_client, create_async_client
+from alternator import (
+    client as alternator_client,
+)
+from alternator.async_client import AsyncSession
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
 from tests.integration.wire_capture import (
     capture_prepared_requests,
@@ -48,14 +49,14 @@ class TestRequestCompression:
     """Verify sync request compression behavior on the wire."""
 
     def test_small_payload_is_not_gzipped_on_wire(self) -> None:
-        client = create_client(_gzip_config(min_size=10_000))
-        try:
+        with alternator_client(
+            "dynamodb",
+            cluster_config=_gzip_config(min_size=10_000),
+        ) as client:
             captured = capture_prepared_requests(client)
             client.list_tables()
             request = latest_request(captured)
             assert request.header("content-encoding") is None
-        finally:
-            close_client(client)
 
     def test_large_payload_is_gzipped_on_wire(
         self,
@@ -67,8 +68,7 @@ class TestRequestCompression:
             ScyllaVersion(2026, 1, 0), "gzip request compression"
         )
 
-        client = create_client(_gzip_config())
-        try:
+        with alternator_client("dynamodb", cluster_config=_gzip_config()) as client:
             captured = capture_prepared_requests(client)
             with pytest.raises(ClientError):
                 client.put_item(
@@ -82,8 +82,6 @@ class TestRequestCompression:
             request = latest_request(captured)
             assert request.header("content-encoding") == "gzip"
             assert b"wire-compression-payload" in gzip.decompress(request.body)
-        finally:
-            close_client(client)
 
     def test_headers_and_compression_share_wire_whitelist(
         self,
@@ -103,11 +101,11 @@ class TestRequestCompression:
             .with_header_optimization(whitelist={"X-Keep-Me"})
             .build()
         )
-        client = create_client(
-            config,
+        with alternator_client(
+            "dynamodb",
+            cluster_config=config,
             auth=Auth.static_credentials("alternator", "secret"),
-        )
-        try:
+        ) as client:
             inject_custom_headers(client)
             captured = capture_prepared_requests(client)
             with pytest.raises(ClientError):
@@ -125,8 +123,6 @@ class TestRequestCompression:
             assert request.header("x-keep-me") == "keep"
             assert request.header("x-drop-me") is None
             assert request.header("authorization") is not None
-        finally:
-            close_client(client)
 
 
 class TestAsyncRequestCompression:
@@ -143,8 +139,8 @@ class TestAsyncRequestCompression:
             ScyllaVersion(2026, 1, 0), "gzip request compression"
         )
 
-        client = await create_async_client(_gzip_config())
-        try:
+        async with AsyncSession(_gzip_config()) as session:
+            client = await session.client("dynamodb")
             captured = capture_prepared_requests(client)
             with pytest.raises(ClientError):
                 await client.put_item(
@@ -158,5 +154,3 @@ class TestAsyncRequestCompression:
             request = latest_request(captured)
             assert request.header("content-encoding") == "gzip"
             assert b"wire-compression-payload" in gzip.decompress(request.body)
-        finally:
-            await close_async_client(client)

--- a/tests/integration/test_response_compression.py
+++ b/tests/integration/test_response_compression.py
@@ -11,8 +11,9 @@ from alternator import (
     AlternatorConfigBuilder,
     Config,
     ResponseCompression,
-    close_client,
-    create_client,
+)
+from alternator import (
+    client as alternator_client,
 )
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
 from tests.integration.wire_capture import (
@@ -69,8 +70,10 @@ class TestResponseCompression:
         encoding: ResponseCompression,
     ) -> None:
         table_name = f"response_compression_{encoding.value}_{uuid.uuid4().hex}"
-        client = create_client(_response_compression_config(encoding))
-        try:
+        with alternator_client(
+            "dynamodb",
+            cluster_config=_response_compression_config(encoding),
+        ) as client:
             captured_requests = capture_prepared_requests(client)
             captured_responses = capture_raw_responses(client, "GetItem")
 
@@ -103,5 +106,3 @@ class TestResponseCompression:
                 assert response["Item"]["data"]["S"] == _large_response_payload()
             finally:
                 _delete_table(client, table_name)
-        finally:
-            close_client(client)

--- a/tests/integration/test_sdk_config.py
+++ b/tests/integration/test_sdk_config.py
@@ -9,10 +9,11 @@ from alternator import (
     RetryConfig,
     RetryMode,
     TimeoutConfig,
-    close_client,
-    create_client,
 )
-from alternator.async_client import close_async_client, create_async_client
+from alternator import (
+    client as alternator_client,
+)
+from alternator.async_client import AsyncSession
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
 
 pytestmark = [
@@ -43,8 +44,7 @@ class TestSdkConfigPropagation:
 
     def test_client_applies_sdk_config_and_still_operates(self) -> None:
         config = _transport_config("alternator-sdk-config-sync")
-        client = create_client(config)
-        try:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             sdk_config = client.meta.config
             assert client.meta.region_name == "us-west-2"
             assert sdk_config.max_pool_connections == 37
@@ -53,8 +53,6 @@ class TestSdkConfigPropagation:
             assert sdk_config.retries["mode"] == RetryMode.STANDARD.value
             assert sdk_config.user_agent.startswith("alternator-sdk-config-sync")
             assert "TableNames" in client.list_tables()
-        finally:
-            close_client(client)
 
 
 class TestAsyncSdkConfigPropagation:
@@ -63,8 +61,8 @@ class TestAsyncSdkConfigPropagation:
     @pytest.mark.asyncio
     async def test_client_applies_sdk_config_and_still_operates(self) -> None:
         config = _transport_config("alternator-sdk-config-async")
-        client = await create_async_client(config)
-        try:
+        async with AsyncSession(config) as session:
+            client = await session.client("dynamodb")
             sdk_config = client.meta.config
             assert client.meta.region_name == "us-west-2"
             assert sdk_config.max_pool_connections == 37
@@ -73,5 +71,3 @@ class TestAsyncSdkConfigPropagation:
             assert sdk_config.retries["mode"] == RetryMode.STANDARD.value
             assert sdk_config.user_agent.startswith("alternator-sdk-config-async")
             assert "TableNames" in await client.list_tables()
-        finally:
-            await close_async_client(client)

--- a/tests/integration/test_sync_client.py
+++ b/tests/integration/test_sync_client.py
@@ -11,14 +11,14 @@ from collections.abc import Callable
 import pytest
 
 from alternator import (
-    AlternatorClient,
     AlternatorConfigBuilder,
     Auth,
     CompressionAlgorithm,
     Config,
     KeyRouteAffinityMode,
-    close_client,
-    create_client,
+)
+from alternator import (
+    client as alternator_client,
 )
 from tests.integration import (
     SCYLLA_HOST,
@@ -54,14 +54,14 @@ class TestBasicOperations:
 
     def test_list_tables(self, config: Config) -> None:
         """Test listing tables."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             response = client.list_tables()
             assert "TableNames" in response
             assert isinstance(response["TableNames"], list)
 
     def test_create_and_delete_table(self, config: Config, table_name: str) -> None:
         """Test creating and deleting a table."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             # Create table
             client.create_table(
                 TableName=table_name,
@@ -87,7 +87,7 @@ class TestBasicOperations:
 
     def test_put_and_get_item(self, config: Config, table_name: str) -> None:
         """Test putting and getting an item."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             # Create table
             client.create_table(
                 TableName=table_name,
@@ -127,7 +127,7 @@ class TestLoadBalancing:
 
     def test_requests_distributed(self, config: Config) -> None:
         """Test that requests are distributed across nodes."""
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             # Make multiple requests
             for _ in range(10):
                 client.list_tables()
@@ -159,7 +159,7 @@ class TestCompression:
             .build()
         )
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             # Create table
             client.create_table(
                 TableName=table_name,
@@ -206,7 +206,7 @@ class TestKeyAffinity:
             .build()
         )
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             # Create table
             client.create_table(
                 TableName=table_name,
@@ -244,23 +244,21 @@ class TestKeyAffinity:
                 client.delete_table(TableName=table_name)
 
 
-class TestManualResourceManagement:
-    """Test manual client lifecycle management."""
+class TestClientContextManagement:
+    """Test client context-manager lifecycle management."""
 
-    def test_create_and_close(self, config: Config) -> None:
-        """Test manual create/close without context manager."""
-        client = create_client(config)
-        try:
+    def test_context_manager_opens_and_closes(self, config: Config) -> None:
+        """Test creating a client through the public context manager."""
+        with alternator_client("dynamodb", cluster_config=config) as client:
             response = client.list_tables()
             assert "TableNames" in response
-        finally:
-            close_client(client)
 
-    def test_double_close_safe(self, config: Config) -> None:
-        """Test that closing twice is safe."""
-        client = create_client(config)
-        close_client(client)
-        close_client(client)  # Should not raise
+    def test_context_close_is_idempotent(self, config: Config) -> None:
+        """Test that closing a client context twice is safe."""
+        ctx = alternator_client("dynamodb", cluster_config=config)
+        with ctx as client:
+            assert "TableNames" in client.list_tables()
+        ctx.close()
 
 
 class TestErrorHandling:
@@ -269,7 +267,7 @@ class TestErrorHandling:
     def test_invalid_table_raises(self, config: Config) -> None:
         """Test that accessing invalid table raises appropriate error."""
         with (
-            AlternatorClient(config) as client,
+            alternator_client("dynamodb", cluster_config=config) as client,
             pytest.raises(client.exceptions.ResourceNotFoundException),
         ):
             client.describe_table(TableName="nonexistent_table_12345")
@@ -296,7 +294,7 @@ class TestKeyAffinityDistribution:
             .build()
         )
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             # Create table
             client.create_table(
                 TableName=table_name,
@@ -345,7 +343,7 @@ class TestPartitionKeyAutoDiscovery:
             .build()
         )
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             # Create table with custom PK name
             client.create_table(
                 TableName=table_name,
@@ -406,7 +404,7 @@ class TestHeaderOptimization:
             .build()
         )
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             # Create table
             client.create_table(
                 TableName=table_name,
@@ -459,7 +457,7 @@ class TestHeaderOptimization:
             .build()
         )
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             # Basic operation should work
             response = client.list_tables()
             assert "TableNames" in response
@@ -474,8 +472,9 @@ class TestHeaderOptimization:
             .build()
         )
 
-        with AlternatorClient(
-            config,
+        with alternator_client(
+            "dynamodb",
+            cluster_config=config,
             auth=Auth.static_credentials("alternator", "secret"),
             region_name="us-east-1",
         ) as client:
@@ -504,7 +503,7 @@ class TestRoutingScopes:
         # Verify the config has the correct scope
         assert isinstance(config.routing_scope, DatacenterScope)
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             response = client.list_tables()
             assert "TableNames" in response
 
@@ -529,7 +528,7 @@ class TestRoutingScopes:
         # Verify the config has the correct scope
         assert isinstance(config.routing_scope, RackScope)
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             response = client.list_tables()
             assert "TableNames" in response
 
@@ -564,7 +563,9 @@ class TestTLSConfiguration:
             .build()
         )
 
-        with AlternatorClient(config, verify=str(ca_path)) as client:
+        with alternator_client(
+            "dynamodb", cluster_config=config, verify=str(ca_path)
+        ) as client:
             response = client.list_tables()
             assert "TableNames" in response
 
@@ -585,7 +586,9 @@ class TestTLSConfiguration:
             .build()
         )
 
-        with AlternatorClient(config, verify=False) as client:
+        with alternator_client(
+            "dynamodb", cluster_config=config, verify=False
+        ) as client:
             response = client.list_tables()
             assert "TableNames" in response
 
@@ -608,6 +611,6 @@ class TestTLSConfiguration:
 
         with (
             pytest.raises((ConnectionError, SSLError, Exception)),
-            AlternatorClient(config) as client,
+            alternator_client("dynamodb", cluster_config=config) as client,
         ):
             client.list_tables()

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -17,8 +17,10 @@ import pytest
 
 from alternator import (
     TLS,
-    AlternatorClient,
     AlternatorConfigBuilder,
+)
+from alternator import (
+    client as alternator_client,
 )
 from alternator.config import TlsSessionCacheConfig
 from tests.integration import SCYLLA_HOST, SCYLLA_HTTPS_PORT, SKIP_INTEGRATION
@@ -62,7 +64,9 @@ class TestTlsSessionCacheAln:
             .build()
         )
 
-        with AlternatorClient(config, verify=str(ca_path)) as client:
+        with alternator_client(
+            "dynamodb", cluster_config=config, verify=str(ca_path)
+        ) as client:
             # Multiple requests should benefit from session caching
             for _ in range(10):
                 response = client.list_tables()
@@ -83,7 +87,9 @@ class TestTlsSessionCacheAln:
             .build()
         )
 
-        with AlternatorClient(config, verify=str(ca_path)) as client:
+        with alternator_client(
+            "dynamodb", cluster_config=config, verify=str(ca_path)
+        ) as client:
             for _ in range(10):
                 response = client.list_tables()
                 assert "TableNames" in response
@@ -109,7 +115,9 @@ class TestTlsSessionCacheDynamoDbApi:
             .build()
         )
 
-        with AlternatorClient(config, verify=str(ca_path)) as client:
+        with alternator_client(
+            "dynamodb", cluster_config=config, verify=str(ca_path)
+        ) as client:
             client.create_table(
                 TableName=table_name,
                 KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
@@ -153,7 +161,9 @@ class TestTlsSessionCacheDynamoDbApi:
             .build()
         )
 
-        with AlternatorClient(config, verify=str(ca_path)) as client:
+        with alternator_client(
+            "dynamodb", cluster_config=config, verify=str(ca_path)
+        ) as client:
             client.create_table(
                 TableName=table_name,
                 KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
@@ -208,7 +218,9 @@ class TestSslKeyLogFile:
                     .build()
                 )
 
-                with AlternatorClient(config, verify=str(ca_path)) as client:
+                with alternator_client(
+                    "dynamodb", cluster_config=config, verify=str(ca_path)
+                ) as client:
                     response = client.list_tables()
                     assert "TableNames" in response
             finally:
@@ -247,7 +259,9 @@ class TestSslKeyLogFile:
                     .build()
                 )
 
-                with AlternatorClient(config, verify=str(ca_path)) as client:
+                with alternator_client(
+                    "dynamodb", cluster_config=config, verify=str(ca_path)
+                ) as client:
                     # Multiple API calls over HTTPS
                     for _ in range(5):
                         client.list_tables()

--- a/tests/integration/test_vector.py
+++ b/tests/integration/test_vector.py
@@ -14,9 +14,13 @@ from decimal import Decimal
 import pytest
 
 from alternator import (
-    AlternatorClient,
-    AlternatorResource,
     Config,
+)
+from alternator import (
+    client as alternator_client,
+)
+from alternator import (
+    resource as alternator_resource,
 )
 from alternator.vector import Vector
 from tests.integration import (
@@ -48,7 +52,7 @@ def test_create_table_with_vector_index(
     skip_if_scylla_version_below(ScyllaVersion(2026, 2, 0), "vector search")
 
     name = table_name()
-    with AlternatorClient(config) as client:
+    with alternator_client("dynamodb", cluster_config=config) as client:
         client.create_table(
             TableName=name,
             KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
@@ -85,7 +89,7 @@ def test_create_table_with_vector_index_via_resource(
     skip_if_scylla_version_below(ScyllaVersion(2026, 2, 0), "vector search")
 
     name = table_name()
-    with AlternatorResource(config) as resource:
+    with alternator_resource("dynamodb", cluster_config=config) as resource:
         resource.create_table(
             TableName=name,
             KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
@@ -120,7 +124,7 @@ def test_vector_roundtrip_via_resource(
     skip_if_scylla_version_below(ScyllaVersion(2026, 2, 0), "vector search")
 
     name = table_name()
-    with AlternatorResource(config) as resource:
+    with alternator_resource("dynamodb", cluster_config=config) as resource:
         resource.create_table(
             TableName=name,
             KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
@@ -164,7 +168,7 @@ def test_vector_differs_from_decimal_list(
     skip_if_scylla_version_below(ScyllaVersion(2026, 2, 0), "vector search")
 
     name = table_name()
-    with AlternatorResource(config) as resource:
+    with alternator_resource("dynamodb", cluster_config=config) as resource:
         resource.create_table(
             TableName=name,
             KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],

--- a/tests/integration/test_wrong_dc_rack.py
+++ b/tests/integration/test_wrong_dc_rack.py
@@ -10,7 +10,6 @@ Start a local cluster with: make scylla-start
 import pytest
 
 from alternator import (
-    AlternatorClient,
     AlternatorConfigBuilder,
     ClusterScope,
     Config,
@@ -18,6 +17,9 @@ from alternator import (
     NoNodesAvailableError,
     RackScope,
     Session,
+)
+from alternator import (
+    client as alternator_client,
 )
 from alternator.exceptions import ConfigurationError
 from tests.integration import SCYLLA_HOST, SCYLLA_PORT, SKIP_INTEGRATION
@@ -48,7 +50,7 @@ class TestWrongDatacenter:
         assert isinstance(config.routing_scope, DatacenterScope)
 
         # Should still work because fallback to cluster scope is explicit.
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             response = client.list_tables()
             assert "TableNames" in response
 
@@ -60,7 +62,7 @@ class TestWrongDatacenter:
             routing_scope=DatacenterScope("bad_dc", fallback=ClusterScope()),
         )
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             # Multiple operations should all succeed after fallback
             for _ in range(5):
                 response = client.list_tables()
@@ -74,7 +76,10 @@ class TestWrongDatacenter:
             routing_scope=DatacenterScope("bad_dc"),
         )
 
-        with pytest.raises(NoNodesAvailableError), AlternatorClient(config):
+        with (
+            pytest.raises(NoNodesAvailableError),
+            alternator_client("dynamodb", cluster_config=config),
+        ):
             pass
 
 
@@ -99,7 +104,7 @@ class TestWrongRack:
         assert isinstance(config.routing_scope, RackScope)
 
         # Should still work because fallback through datacenter to cluster is explicit.
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             response = client.list_tables()
             assert "TableNames" in response
 
@@ -117,7 +122,7 @@ class TestWrongRack:
 
         assert isinstance(config.routing_scope, RackScope)
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             response = client.list_tables()
             assert "TableNames" in response
 
@@ -133,7 +138,7 @@ class TestWrongRack:
             ),
         )
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             for _ in range(5):
                 response = client.list_tables()
                 assert "TableNames" in response
@@ -167,7 +172,7 @@ class TestRackDatacenterFeatureSupport:
             .build()
         )
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             response = client.list_tables()
             assert "TableNames" in response
 
@@ -184,7 +189,7 @@ class TestRackDatacenterFeatureSupport:
             .build()
         )
 
-        with AlternatorClient(config) as client:
+        with alternator_client("dynamodb", cluster_config=config) as client:
             response = client.list_tables()
             assert "TableNames" in response
 

--- a/tests/unit/test_client_alias.py
+++ b/tests/unit/test_client_alias.py
@@ -3,7 +3,7 @@
 import pytest
 
 import alternator
-from alternator import AlternatorClient, AlternatorResource, Auth, Config
+from alternator import Auth, Config
 from alternator.client import DEFAULT_PORT, client, resource
 from alternator.exceptions import ConfigurationError
 
@@ -12,10 +12,9 @@ class TestClientAlias:
     """Tests for alternator.client convenience API."""
 
     def test_builds_context_manager_from_seed_keywords(self) -> None:
-        """The alias builds an AlternatorClient from host-only seeds."""
+        """The alias builds a client context from host-only seeds."""
         ctx = client("dynamodb", seeds=["node1", "node2"])
 
-        assert isinstance(ctx, AlternatorClient)
         assert ctx._config.seed_hosts == ("node1", "node2")
         assert ctx._config.port == DEFAULT_PORT
         assert ctx._config.scheme == "http"
@@ -74,7 +73,6 @@ class TestClientAlias:
         """The resource alias mirrors boto3.resource."""
         ctx = resource("dynamodb", seeds=["node1"])
 
-        assert isinstance(ctx, AlternatorResource)
         assert ctx._config.seed_hosts == ("node1",)
 
     def test_top_level_export(self) -> None:

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -9,9 +9,10 @@ from urllib.parse import urlsplit
 import pytest
 
 import alternator
-from alternator import Auth, Config, Session, close_client, create_client
+from alternator import Auth, Config, Session
 from alternator._constants import MANAGER_ATTR, MANAGER_OWNS_ATTR
 from alternator.async_client import AsyncSession
+from alternator.client import _close_client
 from alternator.config import KeyRouteAffinityConfig
 from alternator.core.routing_scope import (
     ClusterScope,
@@ -91,7 +92,7 @@ def test_helper_created_clients_borrow_helper_manager(
         assert getattr(client, MANAGER_OWNS_ATTR) is False
         assert getattr(resource, MANAGER_OWNS_ATTR) is False
 
-        close_client(client)
+        _close_client(client)
         assert helper.refresh_nodes() is True
 
 
@@ -166,8 +167,11 @@ def test_no_fallback_scope_does_not_use_seed_hosts(
         routing_scope=DatacenterScope("missing", fallback=None),
     )
 
-    with pytest.raises(NoNodesAvailableError):
-        create_client(config)
+    with (
+        pytest.raises(NoNodesAvailableError),
+        alternator.client("dynamodb", cluster_config=config),
+    ):
+        pass
 
 
 def test_create_client_uses_configured_aws_region(
@@ -181,36 +185,33 @@ def test_create_client_uses_configured_aws_region(
         port=base_config.port,
         aws_region="us-west-2",
     )
-    client = create_client(config)
-    try:
+    with alternator.client("dynamodb", cluster_config=config) as client:
         assert client.meta.region_name == "us-west-2"
-    finally:
-        close_client(client)
 
 
 def test_close_client_closes_underlying_boto_client() -> None:
-    """close_client releases the botocore HTTP session for clients."""
+    """The internal close helper releases the botocore HTTP session."""
     manager = SimpleNamespace(stop=Mock())
     client = SimpleNamespace(close=Mock())
     setattr(client, MANAGER_ATTR, manager)
     setattr(client, MANAGER_OWNS_ATTR, True)
 
-    close_client(client)  # type: ignore[arg-type] # lightweight boto client stub
-    close_client(client)  # type: ignore[arg-type] # idempotency check
+    _close_client(client)  # type: ignore[arg-type] # lightweight boto client stub
+    _close_client(client)  # type: ignore[arg-type] # idempotency check
 
     assert manager.stop.call_count == 1
     assert client.close.call_count == 2
 
 
 def test_close_resource_closes_underlying_boto_client() -> None:
-    """close_client releases the botocore HTTP session for resources."""
+    """The internal close helper releases the resource's botocore client."""
     manager = SimpleNamespace(stop=Mock())
     service_client = SimpleNamespace(close=Mock())
     resource = SimpleNamespace(meta=SimpleNamespace(client=service_client))
     setattr(resource, MANAGER_ATTR, manager)
     setattr(resource, MANAGER_OWNS_ATTR, True)
 
-    close_client(resource)  # type: ignore[arg-type] # lightweight resource stub
+    _close_client(resource)  # type: ignore[arg-type] # lightweight resource stub
 
     manager.stop.assert_called_once_with()
     service_client.close.assert_called_once_with()


### PR DESCRIPTION
## Summary
- remove public legacy lifecycle names: `AlternatorClient`, `AlternatorResource`, `create_client`, `create_resource`, `close_client`, `close_resource`, `create_async_client`, and `close_async_client`
- keep the implementation behind `alternator.client("dynamodb", ...)`, `alternator.resource("dynamodb", ...)`, `Session`, and `AsyncSession`
- migrate tests and fixtures to the boto3-style context factories and sessions

## Tests
- `pytest tests/unit -q`
- `make lint`
- `pytest tests/unit/test_client_alias.py tests/unit/test_helper.py -q`